### PR TITLE
Travis setup for stable-2.7 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.6
+    packages:
+    - gcc-5
+    - g++-5
+    - clang-3.6
+before_script:
+  - echo "deb http://us.archive.ubuntu.com/ubuntu/ vivid main" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -qq
+  - sudo apt-get install libgmp-dev
+install:
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
+  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.6" CC="clang-3.6"; fi
+script:
+  - scripts/travis-build.sh
+  - scripts/travis-test.sh

--- a/scripts/drone.sh
+++ b/scripts/drone.sh
@@ -1,1 +1,0 @@
-echo "LoadPackage(\"semigroups\"); SemigroupsTestInstall(); SemigroupsTestAll(); SemigroupsTestManualExamples(); quit;" | sh bin/gap.sh | tee testlog.txt | grep --colour=always -A 1 -E "########> Diff|$" ; ( ! grep -E "########> Diff|# WARNING" testlog.txt )

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -1,0 +1,70 @@
+# If a command fails, exit this script with an error code
+set -e
+
+# Display version of compiler
+$CXX --version
+
+# Store this directory
+SEMIDIR=$(pwd)
+
+# Get semigroups++ if appropriate
+if [ -d src ]
+then
+    cd src
+    git clone -b 0.1 --depth=1 https://github.com/james-d-mitchell/semigroupsplusplus.git
+    mv semigroupsplusplus semigroups++
+    cd ..
+fi
+cd ..
+
+# Download and compile GAP
+git clone -b master --depth=1 https://github.com/gap-system/gap.git
+cd gap
+./configure --with-gmp=system
+make
+
+# Get the packages
+mkdir pkg
+cd pkg
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/GAPDoc-1.5.1.tar.gz
+tar xzf GAPDoc-1.5.1.tar.gz
+rm GAPDoc-1.5.1.tar.gz
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/io-4.4.5.tar.gz
+tar xzf io-4.4.5.tar.gz
+rm io-4.4.5.tar.gz
+cd io-4.4.5
+./configure
+make
+cd ..
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/orb-4.7.5.tar.gz
+tar xzf orb-4.7.5.tar.gz
+rm orb-4.7.5.tar.gz
+cd orb-4.7.5
+./configure
+make
+cd ..
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/genss-1.6.3.tar.gz
+tar xzf genss-1.6.3.tar.gz
+rm genss-1.6.3.tar.gz
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/grape4r7.tar.gz
+tar xzf grape4r7.tar.gz
+rm grape4r7.tar.gz
+cd grape
+./configure
+make
+cd ..
+hg clone https://james-d-mitchell@bitbucket.org/james-d-mitchell/digraphs -r 0.5.1
+cd digraphs
+./autogen.sh
+./configure
+make
+cd ../../..
+mv $SEMIDIR gap/pkg/semigroups
+cd gap/pkg/semigroups
+if [ -d src ]
+then
+    ./autogen.sh
+    ./configure
+    make
+fi
+cd ../..

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -1,0 +1,6 @@
+# If a command fails, exit this script with an error code
+set -e
+
+cd ../..
+echo "LoadPackage(\"semigroups\"); SemigroupsTestInstall(); SemigroupsTestAll(); SemigroupsTestManualExamples(); quit; quit; quit;" | bin/gap.sh -A -r -m 1g -T 2>&1 | tee testlog.txt
+( ! grep -E "########> Diff|brk>|#E|Error|# WARNING|fail|Syntax warning" testlog.txt )


### PR DESCRIPTION
This should run all tests in `SemigroupsTestAll` and `SemigroupsTestManualExamples`.  Travis tests should be passing at the moment.  They currently work using the `master` branch of GAP, but we should add further checks for `stable-4.8`.