### PR TITLE
Travis now uses system GMP 6.0 from APT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ addons:
     - gcc-5
     - g++-5
     - clang-3.6
+before_script:
+  - echo "deb http://us.archive.ubuntu.com/ubuntu/ vivid main" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -qq
+  - sudo apt-get install libgmp-dev
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.6" CC="clang-3.6"; fi

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -20,7 +20,7 @@ cd ..
 # Download and compile GAP
 git clone -b master --depth=1 https://github.com/gap-system/gap.git
 cd gap
-./configure #--with-gmp=system
+./configure --with-gmp=system
 make
 
 # Get the packages


### PR DESCRIPTION
This change cuts about 10 minutes off every Travis build by getting an updated system GMP from an external APT repo.  It should make Travis much more usable.

Note that Travis is still failing due to GAP changes which have not yet made it to the GAP `master` branch.