### PR TITLE
Run Travis tests with more setups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,22 @@ language: cpp
 compiler:
   - gcc
   - clang
+env:
+  - GAP_CONFIGURE_FLAGS="" PKG_CONFIGURE_FLAGS=""
+  - GAP_CONFIGURE_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_CONFIGURE_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.6
     packages:
-    - gcc-5
-    - g++-5
+    - g++-5-multilib
     - clang-3.6
 before_script:
   - echo "deb http://us.archive.ubuntu.com/ubuntu/ vivid main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
   - sudo apt-get install libgmp-dev
+  - sudo apt-get install libgmp-dev:i386
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.6" CC="clang-3.6"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,19 @@ compiler:
   - gcc
   - clang
 env:
-  - GAP_BRANCH=master
-  - GAP_BRANCH=stable-4.8
-  - GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
+  global:
+    - SEMIGROUPSPLUSPLUS_BR=0.1
+    - DIGRAPHS_BR=0.5.1
+    - IO=io-4.4.5
+    - GAPDOC=GAPDoc-1.5.1
+    - ORB=orb-4.7.5
+    - GENSS=genss-1.6.3
+    - GRAPE=grape4r7
+  matrix:
+    - GAP_BRANCH=master
+    - GAP_BRANCH=stable-4.8
+    - GAP_BRANCH=master GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
+    - GAP_BRANCH=stable-4.8 GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ compiler:
   - gcc
   - clang
 env:
-  - GAP_CONFIGURE_FLAGS="" PKG_CONFIGURE_FLAGS=""
-  - GAP_CONFIGURE_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_CONFIGURE_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
+  - GAP_BRANCH=master
+  - GAP_BRANCH=stable-4.8
+  - GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
 addons:
   apt:
     sources:

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -20,7 +20,7 @@ cd ..
 # Download and compile GAP
 git clone -b master --depth=1 https://github.com/gap-system/gap.git
 cd gap
-./configure --with-gmp=system
+./configure --with-gmp=system $GAP_CONFIGURE_FLAGS
 make
 
 # Get the packages
@@ -33,14 +33,14 @@ curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/io-4.4.5.tar.gz
 tar xzf io-4.4.5.tar.gz
 rm io-4.4.5.tar.gz
 cd io-4.4.5
-./configure
+./configure $PKG_CONFIGURE_FLAGS
 make
 cd ..
 curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/orb-4.7.5.tar.gz
 tar xzf orb-4.7.5.tar.gz
 rm orb-4.7.5.tar.gz
 cd orb-4.7.5
-./configure
+./configure $PKG_CONFIGURE_FLAGS
 make
 cd ..
 curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/genss-1.6.3.tar.gz
@@ -50,13 +50,13 @@ curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/grape4r7.tar.gz
 tar xzf grape4r7.tar.gz
 rm grape4r7.tar.gz
 cd grape
-./configure
+./configure $PKG_CONFIGURE_FLAGS
 make
 cd ..
 hg clone https://james-d-mitchell@bitbucket.org/james-d-mitchell/digraphs -r 0.5.1
 cd digraphs
 ./autogen.sh
-./configure
+./configure $PKG_CONFIGURE_FLAGS
 make
 cd ../../..
 mv $SEMIDIR gap/pkg/semigroups
@@ -64,7 +64,7 @@ cd gap/pkg/semigroups
 if [ -d src ]
 then
     ./autogen.sh
-    ./configure
+    ./configure $PKG_CONFIGURE_FLAGS
     make
 fi
 cd ../..

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -18,9 +18,9 @@ fi
 cd ..
 
 # Download and compile GAP
-git clone -b master --depth=1 https://github.com/gap-system/gap.git
+git clone -b $GAP_BRANCH --depth=1 https://github.com/gap-system/gap.git
 cd gap
-./configure --with-gmp=system $GAP_CONFIGURE_FLAGS
+./configure --with-gmp=system $GAP_FLAGS
 make
 
 # Get the packages
@@ -33,14 +33,14 @@ curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/io-4.4.5.tar.gz
 tar xzf io-4.4.5.tar.gz
 rm io-4.4.5.tar.gz
 cd io-4.4.5
-./configure $PKG_CONFIGURE_FLAGS
+./configure $PKG_FLAGS
 make
 cd ..
 curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/orb-4.7.5.tar.gz
 tar xzf orb-4.7.5.tar.gz
 rm orb-4.7.5.tar.gz
 cd orb-4.7.5
-./configure $PKG_CONFIGURE_FLAGS
+./configure $PKG_FLAGS
 make
 cd ..
 curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/genss-1.6.3.tar.gz
@@ -50,13 +50,13 @@ curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/grape4r7.tar.gz
 tar xzf grape4r7.tar.gz
 rm grape4r7.tar.gz
 cd grape
-./configure $PKG_CONFIGURE_FLAGS
+./configure $PKG_FLAGS
 make
 cd ..
 hg clone https://james-d-mitchell@bitbucket.org/james-d-mitchell/digraphs -r 0.5.1
 cd digraphs
 ./autogen.sh
-./configure $PKG_CONFIGURE_FLAGS
+./configure $PKG_FLAGS
 make
 cd ../../..
 mv $SEMIDIR gap/pkg/semigroups
@@ -64,7 +64,7 @@ cd gap/pkg/semigroups
 if [ -d src ]
 then
     ./autogen.sh
-    ./configure $PKG_CONFIGURE_FLAGS
+    ./configure $PKG_FLAGS
     make
 fi
 cd ../..

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -11,7 +11,7 @@ SEMIDIR=$(pwd)
 if [ -d src ]
 then
     cd src
-    git clone -b 0.1 --depth=1 https://github.com/james-d-mitchell/semigroupsplusplus.git
+    git clone -b $SEMIGROUPSPLUSPLUS_BR --depth=1 https://github.com/james-d-mitchell/semigroupsplusplus.git
     mv semigroupsplusplus semigroups++
     cd ..
 fi
@@ -26,34 +26,34 @@ make
 # Get the packages
 mkdir pkg
 cd pkg
-curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/GAPDoc-1.5.1.tar.gz
-tar xzf GAPDoc-1.5.1.tar.gz
-rm GAPDoc-1.5.1.tar.gz
-curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/io-4.4.5.tar.gz
-tar xzf io-4.4.5.tar.gz
-rm io-4.4.5.tar.gz
-cd io-4.4.5
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$GAPDOC.tar.gz
+tar xzf $GAPDOC.tar.gz
+rm $GAPDOC.tar.gz
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$IO.tar.gz
+tar xzf $IO.tar.gz
+rm $IO.tar.gz
+cd $IO
 ./configure $PKG_FLAGS
 make
 cd ..
-curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/orb-4.7.5.tar.gz
-tar xzf orb-4.7.5.tar.gz
-rm orb-4.7.5.tar.gz
-cd orb-4.7.5
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$ORB.tar.gz
+tar xzf $ORB.tar.gz
+rm $ORB.tar.gz
+cd $ORB
 ./configure $PKG_FLAGS
 make
 cd ..
-curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/genss-1.6.3.tar.gz
-tar xzf genss-1.6.3.tar.gz
-rm genss-1.6.3.tar.gz
-curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/grape4r7.tar.gz
-tar xzf grape4r7.tar.gz
-rm grape4r7.tar.gz
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$GENSS.tar.gz
+tar xzf $GENSS.tar.gz
+rm $GENSS.tar.gz
+curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$GRAPE.tar.gz
+tar xzf $GRAPE.tar.gz
+rm $GRAPE.tar.gz
 cd grape
 ./configure $PKG_FLAGS
 make
 cd ..
-hg clone https://james-d-mitchell@bitbucket.org/james-d-mitchell/digraphs -r 0.5.1
+hg clone https://james-d-mitchell@bitbucket.org/james-d-mitchell/digraphs -r $DIGRAPHS_BR
 cd digraphs
 ./autogen.sh
 ./configure $PKG_FLAGS


### PR DESCRIPTION
Travis now runs the test suite 8 times, i.e. every combination of 3 variables:
 * 64-bit/32-bit compile
 * `master`/`stable-4.8` version of GAP
 * `gcc`/`clang` compiler

The version numbers of all required packages are set once each, in `.travis.yml`, for easy editing.