### PR TITLE
Fix IrredundantGeneratingSubset in unstable-3.0 (Issue #160)

### DIFF
--- a/gap/attributes/attributes.gi
+++ b/gap/attributes/attributes.gi
@@ -234,6 +234,10 @@ function(coll)
   gens := Set(coll);
   nrgens := Length(gens);
 
+  if nrgens = 1 then
+    return gens;
+  fi;
+
   if IsGeneratorsOfActingSemigroup(coll) then
     deg := ActionDegree(coll);
     Shuffle(coll);

--- a/tst/standard/attributes.tst
+++ b/tst/standard/attributes.tst
@@ -422,15 +422,22 @@ gap> T := Semigroup(IrredundantGeneratingSubset(S));;
 gap> S = T;
 true
 
-#T# attributes: IrredundantGeneratingSubset: for a set with one element
+#T# attributes: IrredundantGeneratingSubset: for a set with one element, 1
 gap> IrredundantGeneratingSubset([RandomTransformation(10)]);;
 
-#T# attributes: IrredundantGeneratingSubset: for a set with one element
+#T# attributes: IrredundantGeneratingSubset: for a set with one element, 2
 gap> S := Monoid([Transformation([1, 1]), Transformation([2, 1]),
 >  Transformation([2, 2])], rec(generic := false));
 <transformation monoid of degree 2 with 3 generators>
 gap> Size(IrredundantGeneratingSubset(S));
 2
+
+#T# attributes: IrredundantGeneratingSubset: for a set with a single repeated
+# element
+gap> S := Semigroup([Transformation([1, 1]), Transformation([1, 1])]);
+<transformation semigroup of degree 2 with 2 generators>
+gap> Size(IrredundantGeneratingSubset(S));
+1
 
 #T# attributes: IsomorphismReesMatrixSemigroup: for a simple semigroup
 gap> S := SemigroupIdeal(

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1327,6 +1327,13 @@ gap> inv := InverseGeneralMapping(iso);;
 gap> ForAll(S, x -> (x ^ iso) ^ inv = x);
 true
 
+#T# Issue 160: Bug in IrreundantGeneratingSubset for a semigroup with a single
+# repeated generator
+gap> S := Semigroup([Transformation([1, 1]), Transformation([1, 1])]);
+<transformation semigroup of degree 2 with 2 generators>
+gap> IrredundantGeneratingSubset(S);
+[ Transformation( [ 1, 1 ] ) ]
+
 #T# SEMIGROUPS_UnbindVariables
 # FIXME redo these!
 gap> Unbind(lookingfor);


### PR DESCRIPTION
IrreundantGeneratingSubset behaves incorrectly when given a
semigroup whose generating set consists of a single repeated
element.

Resolves: #160 