### PR TITLE
Fix IrredundantGeneratingSubset in stable-2.7 (Issue #160)

### DIFF
--- a/gap/attributes.gi
+++ b/gap/attributes.gi
@@ -420,6 +420,11 @@ function(coll)
 
   gens := Set(ShallowCopy(coll));
   nrgens := Length(gens);
+  
+  if nrgens = 1 then
+    return gens;
+  fi;
+
   deg := ActionDegree(coll);
   coll := Permuted(coll, Random(SymmetricGroup(Length(coll))));
   Sort(coll, function(x, y)

--- a/tst/attributes.tst
+++ b/tst/attributes.tst
@@ -368,6 +368,13 @@ gap> S := Semigroup([PartialPerm([]), PartialPerm([1])]);
 gap> UnderlyingSemigroupOfSemigroupWithAdjoinedZero(S);
 <trivial partial perm group of rank 1 with 1 generator>
 
+#T# attributes: IrredundantGeneratingSubset: for a set with a single repeated
+# element
+gap> S := Semigroup([Transformation([1, 1]), Transformation([1, 1])]);
+<transformation semigroup of degree 2 with 2 generators>
+gap> Size(IrredundantGeneratingSubset(S));
+1
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(s);
 gap> Unbind(t);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1285,6 +1285,13 @@ gap> inv := InverseGeneralMapping(iso);;
 gap> ForAll(S, x -> (x ^ iso) ^ inv = x);
 true
 
+#T# Issue 160: Bug in IrreundantGeneratingSubset for a semigroup with a single
+# repeated generator
+gap> S := Semigroup([Transformation([1, 1]), Transformation([1, 1])]);
+<transformation semigroup of degree 2 with 2 generators>
+gap> IrredundantGeneratingSubset(S);
+[ Transformation( [ 1, 1 ] ) ]
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(lookingfor);
 gap> Unbind(l);


### PR DESCRIPTION
IrreundantGeneratingSubset behaves incorrectly when given a
semigroup whose generating set consists of a single repeated
element.

Resolves: #160 