### PR TITLE
Fix MatrixEntires in stable-2.7 (Issue #164)

### DIFF
--- a/gap/reesmat.gi
+++ b/gap/reesmat.gi
@@ -78,7 +78,29 @@ function(R)
 end);
 
 InstallMethod(MatrixEntries, "for a Rees 0-matrix semigroup",
-[IsReesZeroMatrixSemigroup], x -> Union(Matrix(x){Columns(x)}{Rows(x)}));
+[IsReesZeroMatrixSemigroup],
+function(R)
+  local mat, elt, zero, i, j;
+
+  mat := Matrix(R);
+  elt := [];
+  zero := false;
+
+  for i in Rows(R) do
+    for j in Columns(R) do
+      if mat[j][i] = 0 then
+        zero := true;
+      else
+        AddSet(elt, mat[j][i]);
+      fi;
+    od;
+  od;
+
+  if zero then
+    return Concatenation([0], elt);
+  fi;
+  return elt;
+end);
 
 #
 

--- a/tst/reesmat.tst
+++ b/tst/reesmat.tst
@@ -1037,6 +1037,34 @@ true
 gap> UnderlyingSemigroup(T);
 <partial perm group of size 120, rank 5 with 73 generators>
 
+#T# MatrixEntries: Test for Issue #164
+gap> mat := [
+>  [Bipartition([[1, 2, 3, 4, -2, -3], [-1], [-4]]), 0, 0, 0],
+>  [0, Bipartition([[1, 3, -1], [2, 4, -2, -3], [-4]]), 0,
+>   Bipartition([[1, 4, -1], [2, 3], [-2], [-3, -4]])],
+>  [0, 0, Bipartition([[1, 2, 3, -3], [4, -1, -4], [-2]]), 0]];;
+gap> R := ReesZeroMatrixSemigroup(PartitionMonoid(4), mat);;
+gap> MatrixEntries(R);
+[ 0, <bipartition: [ 1, 2, 3, 4, -2, -3 ], [ -1 ], [ -4 ]>, 
+  <bipartition: [ 1, 2, 3, -3 ], [ 4, -1, -4 ], [ -2 ]>, 
+  <bipartition: [ 1, 3, -1 ], [ 2, 4, -2, -3 ], [ -4 ]>, 
+  <bipartition: [ 1, 4, -1 ], [ 2, 3 ], [ -2 ], [ -3, -4 ]> ]
+gap> mat := [
+>  [Bipartition([[1, 2, 4], [3, -1, -2], [-3], [-4]]),
+>   Bipartition([[1, -2, -4], [2, 3, 4, -3], [-1]])],
+>  [Bipartition([[1, 2, 4, -1, -4], [3], [-2, -3]]),
+>   Bipartition([[1, 3, -1], [2, 4, -2, -3], [-4]])],
+>  [Bipartition([[1, 2, -2, -3], [3, 4, -1], [-4]]),
+>   Bipartition([[1, -1, -2], [2, 3, -3, -4], [4]])]];;
+gap> R := ReesZeroMatrixSemigroup(PartitionMonoid(4), mat);;
+gap> MatrixEntries(R);
+[ <bipartition: [ 1, 2, 4, -1, -4 ], [ 3 ], [ -2, -3 ]>, 
+  <bipartition: [ 1, 2, 4 ], [ 3, -1, -2 ], [ -3 ], [ -4 ]>, 
+  <bipartition: [ 1, 2, -2, -3 ], [ 3, 4, -1 ], [ -4 ]>, 
+  <bipartition: [ 1, 3, -1 ], [ 2, 4, -2, -3 ], [ -4 ]>, 
+  <bipartition: [ 1, -2, -4 ], [ 2, 3, 4, -3 ], [ -1 ]>, 
+  <bipartition: [ 1, -1, -2 ], [ 2, 3, -3, -4 ], [ 4 ]> ]
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(f1);
 gap> Unbind(f2);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1292,6 +1292,13 @@ gap> S := Semigroup([Transformation([1, 1]), Transformation([1, 1])]);
 gap> IrredundantGeneratingSubset(S);
 [ Transformation( [ 1, 1 ] ) ]
 
+#T# Issue 164: Bug in MatrixEntries for a Rees 0-matrix semigroup
+gap> S := Semigroup(SymmetricInverseMonoid(2));;
+gap> id := Identity(S);;
+gap> R := ReesZeroMatrixSemigroup(S, [[id], [0]]);;
+gap> MatrixEntries(R);
+[ 0, <identity partial perm on [ 1, 2 ]> ]
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(lookingfor);
 gap> Unbind(l);


### PR DESCRIPTION
`MatrixEntries` fails for some Rees 0-matrix semigroups whose
matrices contain `0`, since MatrixEntries removes duplicates and
sorts using `Union`, however `0` is not comparable with all
semigroup elements.

This issue is resolved by using `Unique` to remove duplicates,
but not sorting the list of matrix entries.

Resolves: #164