### PR TITLE
Added ham-examples (WIP)

### DIFF
--- a/doc/chap2.xml
+++ b/doc/chap2.xml
@@ -169,13 +169,16 @@ true</Log>
     used to creating semigroups belonging to several standard classes of
     example. See Chapter <Ref Chap="bipartition"/> for more information about
     semigroups of bipartitions. 
-    <#Include Label="EndomorphismsPartition"> 
-    <#Include Label="PartitionMonoid"> 
-    <#Include Label="BrauerMonoid"> 
-    <#Include Label="JonesMonoid"> 
-    <#Include Label="FactorisableDualSymmetricInverseSemigroup">
+    <#Include Label="EndomorphismsPartition">
+    <#Include Label="PartitionMonoid">
+    <#Include Label="PlanarPartitionMonoid">
+    <#Include Label="BrauerMonoid">
+    <#Include Label="JonesMonoid">
+    <#Include Label="PartialTransformationSemigroup">
     <#Include Label="DualSymmetricInverseSemigroup">
-    <#Include Label="PartialTransformationSemigroup"> 
+    <#Include Label="UniformBlockBijectionMonoid">
+    <#Include Label="ApsisMonoid">
+    <#Include Label="ModularPartitionMonoid">
     <#Include Label="GeneralLinearSemigroup">
     <#Include Label="SpecialLinearSemigroup">
     <#Include Label="MunnSemigroup">

--- a/doc/chap4.xml
+++ b/doc/chap4.xml
@@ -127,7 +127,41 @@
     <C>(x^*)^*=x, xx^*x=x, x^*xx^*=x^*, (xy)^*=y^*x^*.</C>
     <P/>
   </Alt>
-  In this way, the partition monoid is a <E>regular *-semigroup</E>.
+  In this way, the partition monoid is a <E>regular *-semigroup</E>. <P/>
+
+  A bipartition &x; of degree &n; is called <E>planar</E> if there does not exist
+  distinct blocks <M>A, B \in</M> &x;, along with <M>a, a' \in A</M> and
+  <M>b, b' \in B</M> such that <M>a &lt; a'</M>, <M>b &lt; b'</M> and
+  either:
+  <List>
+    <Item>
+      <M>a &lt; b &lt; a' &lt; b'</M>; or
+    </Item>
+    <Item>
+      <M>b &lt; a &lt; b' &lt; a'</M>.
+    </Item>
+  </List>
+  Or equivalently, &x; is planar if for each distinct blocks <M>A, B \in</M> &x;,
+  and each <M>a, a' \in A</M> and <M>b, b' \in B</M> such that <M>a &lt; a'</M>
+  and <M>b &lt; b'</M>, either:
+  <List>
+    <Item>
+      <M>a &lt; a' &lt; b &lt; b'</M>;
+    </Item>
+    <Item>
+      <M>a &lt; b &lt; b' &lt; a'</M>;
+    </Item>
+    <Item>
+      <M>b &lt; a &lt; a' &lt; b'</M>; or
+    </Item>
+    <Item>
+      <M>b &lt; b' &lt; a &lt; a'</M>.
+    </Item>
+  </List>
+  From a graphical perspective, as on Page 873 in 
+  <Cite Key="Halverson2005PartitionAlgebras"/>, a bipartition &x; of degree &n;
+  is planar if it can be represented as a graph without edges crossing inside of
+  the rectangle formed by its vertices &bfn;<M>\cup</M>-&bfn;.
 
   <Section><Heading>The family and categories of bipartitions</Heading>
     <#Include Label="IsBipartition">

--- a/doc/examples.xml
+++ b/doc/examples.xml
@@ -92,69 +92,6 @@ gap> SingularBrauerMonoid(8);
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="FactorisableDualSymmetricInverseSemigroup">
-   <ManSection>
-    <Oper Name="FactorisableDualSymmetricInverseSemigroup" Arg="n"/>
-    <Oper Name="SingularFactorisableDualSymmetricInverseSemigroup" Arg="n"/>
-    <Returns>An inverse bipartition monoid.</Returns>
-    <Description>
-      If <A>n</A> is a positive integer, then this operation returns the largest
-      factorisable inverse subsemigroup of the dual symmetric inverse monoid of
-      degree <A>n</A>. <P/>
-      
-      <C>SingularFactorisableDualSymmetricInverseSemigroup</C> returns the ideal
-      of the factorisable dual symmetric inverse semigroup consisting of the
-      non-invertible elements (i.e. those not in the group of units), when
-      <A>n</A> is at least 2.<P/>
-
-      See <Ref Prop="IsUniformBlockBijection"/>.
-      <Example><![CDATA[
-gap> S:=DualSymmetricInverseMonoid(4);
-<inverse bipartition monoid of degree 4 with 3 generators>
-gap> IsFactorisableSemigroup(S);
-false
-gap> S:=FactorisableDualSymmetricInverseSemigroup(4);
-<inverse bipartition monoid of degree 4 with 3 generators>
-gap> IsFactorisableSemigroup(S);
-true
-gap> S:=Range(IsomorphismBipartitionSemigroup(SymmetricInverseMonoid(5)));
-<inverse bipartition monoid of degree 5 with 3 generators>
-gap> IsFactorisableSemigroup(S);
-true
-]]></Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc>
-
-<#GAPDoc Label="DualSymmetricInverseSemigroup">
-   <ManSection>
-    <Oper Name="DualSymmetricInverseSemigroup" Arg="n"/>
-    <Oper Name="DualSymmetricInverseMonoid" Arg="n"/>
-    <Oper Name="SingularDualSymmetricInverseSemigroup" Arg="n"/>
-    <Returns>An inverse bipartition monoid.</Returns>
-    <Description>
-      If <A>n</A> is a positive integer, then these operations return the dual
-      symmetric inverse monoid of degree <A>n</A>, which is the subsemigroup of
-      the partition monoid consisting of the block bijections of degree <A>n</A>.<P/>
-
-      <C>SingularDualSymmetricInverseSemigroup</C> returns the ideal of the
-      dual symmetric inverse monoid consisting of the non-invertible elements
-      (i.e. those not in the group of units), when <A>n</A> is at least 2.<P/>
-      
-      See <Ref Prop="IsBlockBijection"/>.
-
-      <Example><![CDATA[
-gap> Number(PartitionMonoid(3), IsBlockBijection);
-25
-gap> S:=DualSymmetricInverseSemigroup(3);
-<inverse bipartition monoid of degree 3 with 3 generators>
-gap> Size(S);
-25
-]]></Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc>
-
 <#GAPDoc Label="PartitionMonoid">
    <ManSection>
     <Oper Name="PartitionMonoid" Arg="n"/>
@@ -179,6 +116,31 @@ gap> Size(S);
   </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="PlanarPartitionMonoid">
+   <ManSection>
+    <Oper Name="PlanarPartitionMonoid" Arg="n"/>
+    <Oper Name="SingularPlanarPartitionMonoid" Arg="n"/>
+    <Returns>A bipartition monoid.</Returns>
+    <Description>
+      If <A>n</A> is a positive integer, then this operation returns the planar
+      partition monoid of degree <A>n</A> which is the monoid consisting of all
+      the planar bipartitions of degree <A>n</A> (planar bipartitions are defined
+      in Chapter <Ref Label="bipartition"/>). <P/>
+
+      <C>SingularPlanarPartitionMonoid</C> returns the ideal of the planar
+      partition monoid consisting of the non-invertible elements
+      (i.e. those not in the group of units). <P/>
+
+      <Example><![CDATA[
+gap> S := PlanarPartitionMonoid(5);
+<regular bipartition monoid of degree 5 with 9 generators>
+gap> Size(S);
+16796
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="PartialTransformationSemigroup">
    <ManSection>
     <Oper Name="PartialTransformationSemigroup" Arg="n"/>
@@ -194,6 +156,168 @@ gap> PartialTransformationSemigroup(8);
 <regular transformation monoid of degree 9 with 4 generators>
 gap> Size(last);
 43046721]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="UniformBlockBijectionMonoid">
+   <ManSection>
+    <Oper Name="UniformBlockBijectionMonoid" Arg="n"/>
+    <Oper Name="FactorisableDualSymmetricInverseSemigroup" Arg="n"/>
+    <Oper Name="SingularUniformBlockBijectionMonoid" Arg="n"/>
+    <Oper Name="SingularFactorisableDualSymmetricInverseSemigroup" Arg="n"/>
+    <Oper Name="PlanarUniformBlockBijectionMonoid" Arg="n"/>
+    <Oper Name="SingularPlanarUniformBlockBijectionMonoid" Arg="n"/>
+    <Returns>An inverse bipartition monoid.</Returns>
+    <Description>
+      If <A>n</A> is a positive integer, then this operation returns the uniform
+      block bijection monoid of degree <A>n</A>. The <E>uniform block bijection
+      monoid</E> is the submonoid of the partition monoid consisting of the
+      block bijections of degree &n; where the number of positive integers in a
+      block equals the number of negative integers in that block. 
+      The uniform block bijection monoid is also referred to as the 
+      <E>factorisable dual symmetric inverse semigroup</E>. <P/>
+
+      <C>SingularUniformBlockBijectionMonoid</C> returns the ideal of the
+      uniform block bijection monoid consisting of the non-invertible elements
+      (i.e. those not in the group of units), when <A>n</A> is at least 2. <P/>
+
+      <C>PlanarUniformBlockBijectionMonoid</C> returns the submonoid of the
+      uniform block bijection monoid consisting of the planar elements
+      (i.e. those in the planar partition monoid). <P/>
+
+      <C>SingularPlanarUniformBlockBijectionMonoid</C> returns the ideal of the
+      planar uniform block bijection monoid consisting of the non-invertible
+      elements (i.e. those not in the group of units), when <A>n</A> is
+      at least 2. <P/>
+      <!-- TODO reference -->
+
+      See <Ref Prop="IsUniformBlockBijection"/>.       
+      <Example><![CDATA[
+gap> S := UniformBlockBijectionMonoid(4);
+<inverse bipartition monoid of degree 4 with 3 generators>
+gap> Size(PlanarUniformBlockBijectionMonoid(8));
+128
+gap> S:=DualSymmetricInverseMonoid(4);
+<inverse bipartition monoid of degree 4 with 3 generators>
+gap> IsFactorisableSemigroup(S);
+false
+gap> S:=FactorisableDualSymmetricInverseSemigroup(4);
+<inverse bipartition monoid of degree 4 with 3 generators>
+gap> IsFactorisableSemigroup(S);
+true
+gap> S:=Range(IsomorphismBipartitionSemigroup(SymmetricInverseMonoid(5)));
+<inverse bipartition monoid of degree 5 with 3 generators>
+gap> IsFactorisableSemigroup(S);
+true]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DualSymmetricInverseSemigroup">
+   <ManSection>
+    <Oper Name="DualSymmetricInverseSemigroup" Arg="n"/>
+    <Oper Name="DualSymmetricInverseMonoid" Arg="n"/>
+    <Oper Name="SingularDualSymmetricInverseSemigroup" Arg="n"/>
+    <Returns>An inverse bipartition monoid.</Returns>
+    <Description>
+      If <A>n</A> is a positive integer, then these operations return the dual
+      symmetric inverse monoid of degree <A>n</A>, which is the subsemigroup of
+      the partition monoid consisting of the block bijections of degree <A>n</A>.<P/>
+
+      <C>SingularDualSymmetricInverseSemigroup</C> returns the ideal of the
+      dual symmetric inverse monoid consisting of the non-invertible elements
+      (i.e. those not in the group of units), when <A>n</A> is at least 2.<P/>
+      
+      See <Ref Prop="IsBlockBijection"/>.
+
+      <Example><![CDATA[
+gap> Number(PartitionMonoid(3), IsBlockBijection);
+25
+gap> S := DualSymmetricInverseSemigroup(3);
+<inverse bipartition monoid of degree 3 with 3 generators>
+gap> Size(S);
+25
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="ApsisMonoid">
+   <ManSection>
+    <Oper Name="ApsisMonoid" Arg="m, n"/>
+    <Oper Name="SingularApsisMonoid" Arg="m, n"/>
+    <Oper Name="CrossedApsisMonoid" Arg="m, n"/>
+    <Oper Name="SingularCrossedApsisMonoid" Arg="m, n"/>
+    <Returns>A bipartition monoid.</Returns>
+    <Description>
+      If <A>m</A> and <A>n</A> are positive integers, then this operation
+      returns the <A>m</A>-apsis monoid of degree <A>n</A>. The
+      <A>m</A><E>-apsis monoid</E> is the monoid of bipartitions generated when
+      the diapses in generators of the Jones monoid are replaced
+      with <A>m</A>-apses. Note that an <A>m</A><E>-apsis</E> is a block that 
+      contains precisely <A>m</A> consecutive integers. <P/>
+
+      <C>SingularApsisMonoid</C> returns the ideal of the
+      apsis monoid consisting of the non-invertible elements
+      (i.e. those not in the group of units), when <A>m &lt;= n</A>. <P/>
+
+      <C>CrossedApsisGeneratedMonoid</C> returns the semigroup generated by the
+      symmetric group of degree <A>n</A> and the <A>m</A>-apsis monoid of
+      degree <A>n</A>. <P/>
+
+      <C>SingularCrossedApsisMonoid</C> returns the ideal of the
+      crossed apsis monoid consisting of the non-invertible elements
+      (i.e. those not in the group of units), when <A>m &lt;= n</A>.
+      <!-- TODO reference and/or definition -->
+
+      <Example><![CDATA[
+gap> S := ApsisMonoid(3, 7);
+<regular bipartition monoid of degree 7 with 5 generators>
+gap> Size(S);
+320
+gap> Size(CrossedApsisMonoid(4, 9));
+24291981]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="ModularPartitionMonoid">
+   <ManSection>
+    <Oper Name="ModularPartitionMonoid" Arg="m, n"/>
+    <Oper Name="SingularModularPartitionMonoid" Arg="m, n"/>
+    <Oper Name="PlanarModularPartitionMonoid" Arg="m, n"/>
+    <Oper Name="SingularPlanarModularPartitionMonoid" Arg="m, n"/>
+    <Returns>A bipartition monoid.</Returns>
+    <Description>
+      If <A>m</A> and <A>n</A> are positive integers, then this operation
+      returns the modular-<A>m</A> partition monoid of degree <A>n</A>. The
+      <E>modular-</E><A>m</A> <E>partition monoid</E> is the submonoid of the
+      partition monoid such that the numbers of positive and negative
+      integers contained in each block are congruent mod <A>m</A>. <P/>
+
+      <C>SingularModularPartitionMonoid</C> returns the ideal of the
+      modular partition monoid consisting of the non-invertible elements
+      (i.e. those not in the group of units), when either
+      <A>m = n = 1</A> or <A>m, n &gt; 1</A>. <P/>
+
+      <C>PlanarModularPartitionMonoid</C> returns the submonoid of the
+      modular-<A>m</A> partition monoid consisting of the planar elements
+      (i.e. those in the planar partition monoid). <P/>
+
+      <C>SingularPlanarModularPartitionMonoid</C> returns the ideal of the
+      planar modular partition monoid consisting of the non-invertible elements
+      (i.e. those not in the group of units), when either
+      <A>m = n = 1</A> or <A>m, n &gt; 1</A>.
+      <!-- TODO reference -->
+
+      <Example><![CDATA[
+gap> S := ModularPartitionMonoid(3, 7);
+<regular bipartition monoid of degree 7 with 4 generators>
+gap> Size(S);
+826897
+gap> Size(PlanarModularPartitionMonoid(4, 9));
+1795]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/semigroups.bib
+++ b/doc/semigroups.bib
@@ -61,6 +61,16 @@
 	Volume = {4},
 	Year = {1968}}
 
+@article{Halverson2005PartitionAlgebras,
+	title={Partition algebras},
+	author={Halverson, Tom and Ram, Arun},
+	journal={European Journal of Combinatorics},
+	volume={26},
+	number={6},
+	pages={869--921},
+	year={2005},
+	publisher={Elsevier}}
+
 @article{Schein1992aa,
 	Author = {Schein, Boris M.},
 	Journal = {Trans. Amer. Math. Soc.},

--- a/gap/examples.gd
+++ b/gap/examples.gd
@@ -17,16 +17,12 @@ DeclareSynonym("TemperleyLiebMonoid", JonesMonoid);
 DeclareOperation("BrauerMonoid", [IsPosInt]);
 DeclareOperation("PartialBrauerMonoid", [IsPosInt]);
 DeclareOperation("SingularBrauerMonoid", [IsPosInt]);
-DeclareOperation("FactorisableDualSymmetricInverseSemigroup", [IsPosInt]);
-DeclareOperation("SingularFactorisableDualSymmetricInverseSemigroup",
-                 [IsPosInt]);
 DeclareOperation("DualSymmetricInverseSemigroup", [IsPosInt]);
 DeclareSynonym("DualSymmetricInverseMonoid", DualSymmetricInverseSemigroup);
 DeclareOperation("SingularDualSymmetricInverseSemigroup", [IsPosInt]);
 
 DeclareOperation("EndomorphismsPartition", [IsCyclotomicCollection]);
 
-DeclareOperation("TriapsisMonoid", [IsPosInt]);
 # DeclareProperty("IsFullMatrixSemigroup", IsSemigroup);
 # DeclareSynonymAttr("IsGeneralLinearSemigroup", IsFullMatrixSemigroup);
 DeclareOperation("MunnSemigroup", [IsSemigroup]);
@@ -41,6 +37,25 @@ DeclareOperation("RegularBinaryRelationSemigroup", [IsPosInt]);
 DeclareOperation("SingularTransformationSemigroup", [IsPosInt]);
 DeclareSynonym("SingularTransformationMonoid",
                SingularTransformationSemigroup);
+
+DeclareOperation("PlanarUniformBlockBijectionMonoid", [IsPosInt]);
+DeclareOperation("SingularPlanarUniformBlockBijectionMonoid", [IsPosInt]);
+DeclareOperation("UniformBlockBijectionMonoid", [IsPosInt]);
+DeclareSynonym("FactorisableDualSymmetricInverseSemigroup",
+               UniformBlockBijectionMonoid);
+DeclareOperation("SingularUniformBlockBijectionMonoid", [IsPosInt]);
+DeclareSynonym("SingularFactorisableDualSymmetricInverseSemigroup",
+               SingularUniformBlockBijectionMonoid);
+DeclareOperation("ApsisMonoid", [IsPosInt, IsPosInt]);
+DeclareOperation("SingularApsisMonoid", [IsPosInt, IsPosInt]);
+DeclareOperation("CrossedApsisMonoid", [IsPosInt, IsPosInt]);
+DeclareOperation("SingularCrossedApsisMonoid", [IsPosInt, IsPosInt]);
+DeclareOperation("PlanarModularPartitionMonoid", [IsPosInt, IsPosInt]);
+DeclareOperation("SingularPlanarModularPartitionMonoid", [IsPosInt, IsPosInt]);
+DeclareOperation("PlanarPartitionMonoid", [IsPosInt]);
+DeclareOperation("SingularPlanarPartitionMonoid", [IsPosInt]);
+DeclareOperation("ModularPartitionMonoid", [IsPosInt, IsPosInt]);
+DeclareOperation("SingularModularPartitionMonoid", [IsPosInt, IsPosInt]);
 
 DeclareConstructor("ZeroSemigroupCons", [IsSemigroup, IsPosInt]);
 DeclareConstructor("RectangularBandCons", [IsSemigroup, IsPosInt, IsPosInt]);

--- a/gap/examples.gi
+++ b/gap/examples.gi
@@ -778,22 +778,6 @@ end);
 
 #
 
-InstallMethod(FactorisableDualSymmetricInverseSemigroup,
-"for a positive integer", [IsPosInt],
-function(n)
-  local gens;
-  if n = 1 then
-    return DualSymmetricInverseSemigroup(1);
-  fi;
-
-  gens := List(GeneratorsOfGroup(SymmetricGroup(n)), x -> AsBipartition(x, n));
-  Add(gens, BipartitionNC(Concatenation([[1, 2, -1, -2]],
-                                        List([3 .. n], x -> [x, -x]))));
-  return InverseMonoid(gens);
-end);
-
-#
-
 InstallMethod(BrauerMonoid, "for a positive integer", [IsPosInt],
 function(n)
   local gens;
@@ -866,34 +850,6 @@ function(n)
 
 end);
 
-# TODO: document this!
-
-InstallMethod(TriapsisMonoid, "for a positive integer", [IsPosInt],
-function(n)
-  local gens, next, i, j;
-
-  gens := [];
-  for i in [1 .. n - 2] do
-    next := [];
-    for j in [1 .. i - 1] do
-      next[j] := j;
-      next[n + j] := j;
-    od;
-    next[i] := i;
-    next[i + 1] := i;
-    next[i + 2] := i;
-    next[i + n] := n - 1;
-    next[i + n + 1] := n - 1;
-    next[i + n + 2] := n - 1;
-    for j in [i + 3 .. n] do
-      next[j] := j - 2;
-      next[n + j] := j - 2;
-    od;
-    gens[i] := BipartitionByIntRep(next);
-  od;
-  return Semigroup(gens);
-end);
-
 #
 
 InstallMethod(POI, "for a positive integer",
@@ -952,6 +908,237 @@ function(g)
     s := ClosureSemigroup(s, f);
   od;
   return s;
+end);
+
+#
+
+InstallMethod(PlanarUniformBlockBijectionMonoid, "for a positive integer",
+[IsPosInt],
+function(n)
+  local gens, next, i, j;
+
+  if n = 1 then
+    return InverseMonoid(BipartitionNC([[1, -1]]));
+  fi;
+
+  gens := [];
+
+  #(2,2)-transapsis generators
+  for i in [1 .. n - 1] do
+    next := [];
+    for j in [1 .. i - 1] do
+      next[j] := j;
+      next[n + j] := j;
+    od;
+    next[i] := i;
+    next[i + 1] := i;
+    next[i + n] := i;
+    next[i + n + 1] := i;
+    for j in [i + 2 .. n] do
+      next[j] := j - 1;
+      next[n + j] := j - 1;
+    od;
+    gens[i] := BipartitionByIntRep(next);
+  od;
+
+  return InverseMonoid(gens);
+end);
+
+#
+
+InstallMethod(UniformBlockBijectionMonoid, "for a positive integer", [IsPosInt],
+function(n)
+  local gens;
+  if n = 1 then
+    return InverseMonoid(BipartitionNC([[1, -1]]));
+  fi;
+
+  gens := List(GeneratorsOfGroup(SymmetricGroup(n)), x -> AsBipartition(x, n));
+  Add(gens, BipartitionNC(Concatenation([[1, 2, -1, -2]],
+                                        List([3 .. n], x -> [x, -x]))));
+  return InverseMonoid(gens);
+end);
+
+#
+
+InstallMethod(ApsisMonoid,
+"for a positive integer and positive integer",
+[IsPosInt, IsPosInt],
+function(m, n)
+  local gens, next, b, i, j;
+
+  if n = 1 and m = 1 then
+    return InverseMonoid(BipartitionNC([[1], [-1]]));
+  fi;
+
+  gens := [];
+
+  if n < m then
+    next := [];
+
+    #degree k identity bipartition
+    for i in [1 .. n] do
+      next[i] := i;
+      next[n + i] := i;
+    od;
+    gens[1] := BipartitionByIntRep(next);
+
+    return InverseMonoid(gens, rec(regular := true));
+  fi;
+
+  #m-apsis generators
+  for i in [1 .. n - m + 1] do
+    next := [];
+    b := 1;
+
+    for j in [1 .. i - 1] do
+      next[j] := b;
+      next[n + j] := b;
+      b := b + 1;
+    od;
+
+    for j in [i .. i + m - 1] do
+      next[j] := b;
+    od;
+    b := b + 1;
+
+    for j in [i + m .. n] do
+      next[j] := b;
+      next[n + j] := b;
+      b := b + 1;
+    od;
+
+    for j in [i .. i + m - 1] do
+      next[n + j] := b;
+    od;
+
+    gens[i] := BipartitionByIntRep(next);
+  od;
+
+  return Monoid(gens, rec(regular := true));
+end);
+
+#
+
+InstallMethod(CrossedApsisMonoid,
+"for a positive integer and positive integer",
+[IsPosInt, IsPosInt],
+function(m, n)
+  local gens;
+
+  if n = 1 then
+    if m = 1 then
+      return InverseMonoid(BipartitionNC([[1], [-1]]));
+    else
+      return InverseMonoid(BipartitionNC([[1, -1]]));
+    fi;
+  fi;
+
+  gens := List(GeneratorsOfGroup(SymmetricGroup(n)), x -> AsBipartition(x, n));
+  if m <= n then
+    Add(gens, BipartitionNC(Concatenation([[1 .. m]],
+                                          List([m + 1 .. n],
+                                               x -> [x, -x]), [[-m .. -1]])));
+  fi;
+
+  return Monoid(gens, rec(regular := true));
+end);
+
+#
+
+InstallMethod(PlanarModularPartitionMonoid,
+"for a positive integer and positive integer",
+[IsPosInt, IsPosInt],
+function(m, n)
+  local gens, next, b, i, j;
+
+  if n < m then
+    return PlanarUniformBlockBijectionMonoid(n);
+  elif n = 1 then
+    return InverseMonoid(BipartitionNC([[1], [-1]]));
+  fi;
+
+  gens := [];
+
+  #(2,2)-transapsis generators
+  for i in [1 .. n - 1] do
+    next := [];
+    for j in [1 .. i - 1] do
+      next[j] := j;
+      next[n + j] := j;
+    od;
+    next[i] := i;
+    next[i + 1] := i;
+    next[i + n] := i;
+    next[i + n + 1] := i;
+    for j in [i + 2 .. n] do
+      next[j] := j - 1;
+      next[n + j] := j - 1;
+    od;
+    gens[i] := BipartitionByIntRep(next);
+  od;
+
+  #m-apsis generators
+  for i in [1 .. n - m + 1] do
+    next := [];
+    b := 1;
+
+    for j in [1 .. i - 1] do
+      next[j] := b;
+      next[n + j] := b;
+      b := b + 1;
+    od;
+
+    for j in [i .. i + m - 1] do
+      next[j] := b;
+    od;
+    b := b + 1;
+
+    for j in [i + m .. n] do
+      next[j] := b;
+      next[n + j] := b;
+      b := b + 1;
+    od;
+
+    for j in [i .. i + m - 1] do
+      next[n + j] := b;
+    od;
+
+    gens[n - 1 + i] := BipartitionByIntRep(next);
+  od;
+
+  return Monoid(gens, rec(regular := true));
+end);
+
+#
+
+InstallMethod(PlanarPartitionMonoid,
+"for a positive integer",
+[IsPosInt],
+function(n)
+  return PlanarModularPartitionMonoid(1, n);
+end);
+
+#
+
+InstallMethod(ModularPartitionMonoid,
+"for a positive integer and positive integer",
+[IsPosInt, IsPosInt],
+function(m, n)
+  local gens;
+  if n = 1 then
+    return InverseMonoid(BipartitionNC([[1], [-1]]));
+  fi;
+
+  gens := List(GeneratorsOfGroup(SymmetricGroup(n)), x -> AsBipartition(x, n));
+  Add(gens, BipartitionNC(Concatenation([[1, 2, -1, -2]],
+                                        List([3 .. n], x -> [x, -x]))));
+  if m <= n then
+    Add(gens, BipartitionNC(Concatenation([[1 .. m]],
+                                          List([m + 1 .. n],
+                                               x -> [x, -x]), [[-m .. -1]])));
+  fi;
+  return Monoid(gens, rec(regular := true));
 end);
 
 #
@@ -1070,13 +1257,13 @@ end);
 
 #
 
-InstallMethod(SingularFactorisableDualSymmetricInverseSemigroup,
+InstallMethod(SingularPlanarUniformBlockBijectionMonoid,
 "for a positive integer", [IsPosInt],
 function(n)
   local blocks, x, S, i;
   if n = 1 then
-    Error("Semigroups: SingularFactorisableDualSymmetricInverseSemigroup:",
-          " usage,\nthe argument must be greater than 1");
+    Error("Semigroups: SingularPlanarUniformBlockBijectionMonoid:",
+          " usage,\nthe argument must be greater than 1,");
     return;
   fi;
 
@@ -1086,7 +1273,155 @@ function(n)
   od;
 
   x := Bipartition(blocks);
-  S := FactorisableDualSymmetricInverseSemigroup(n);
+  S := PlanarUniformBlockBijectionMonoid(n);
+  return SemigroupIdeal(S, x);
+end);
+
+#
+
+InstallMethod(SingularUniformBlockBijectionMonoid,
+"for a positive integer", [IsPosInt],
+function(n)
+  local blocks, x, S, i;
+  if n = 1 then
+    Error("Semigroups: SingularUniformBlockBijectionMonoid:",
+          " usage,\nthe argument must be greater than 1,");
+    return;
+  fi;
+
+  blocks := [[1, 2, -1, -2]];
+  for i in [3 .. n] do
+    blocks[i - 1] := [i, -i];
+  od;
+
+  x := Bipartition(blocks);
+  S := UniformBlockBijectionMonoid(n);
+  return SemigroupIdeal(S, x);
+end);
+
+#
+
+InstallMethod(SingularApsisMonoid,
+"for a positive integer and positive integer",
+[IsPosInt, IsPosInt],
+function(m, n)
+  local blocks, x, S, i;
+  if m > n then
+    Error("Semigroups: SingularApsisMonoid:",
+          " usage,\nthe first argument must be less than or equal to the second",
+          " argument,");
+    return;
+  fi;
+
+  blocks := [[1 .. m], [-m .. -1]];
+  for i in [m + 1 .. n] do
+    blocks[i - m + 2] := [i, -i];
+  od;
+
+  x := Bipartition(blocks);
+  S := ApsisMonoid(m, n);
+  return SemigroupIdeal(S, x);
+end);
+
+#
+
+InstallMethod(SingularCrossedApsisMonoid,
+"for a positive integer and positive integer",
+[IsPosInt, IsPosInt],
+function(m, n)
+  local blocks, x, S, i;
+  if m > n then
+    Error("Semigroups: SingularCrossedApsisMonoid:",
+          " usage,\nthe first argument must be less than or equal to the second",
+          " argument,");
+    return;
+  fi;
+
+  blocks := [[1 .. m], [-m .. -1]];
+  for i in [m + 1 .. n] do
+    blocks[i - m + 2] := [i, -i];
+  od;
+
+  x := Bipartition(blocks);
+  S := CrossedApsisMonoid(m, n);
+  return SemigroupIdeal(S, x);
+end);
+
+#
+
+InstallMethod(SingularPlanarModularPartitionMonoid,
+"for a positive integer and positive integer",
+[IsPosInt, IsPosInt],
+function(m, n)
+  local blocks, x, S, i;
+  if n = 1 then
+    if m = 1 then
+      return SemigroupIdeal(PlanarModularPartitionMonoid(1, 1),
+                            Bipartition([[1], [-1]]));
+    else
+      Error("Semigroups: SingularPlanarModularPartitionMonoid:",
+            " usage,\nthe second argument must be greater than 1",
+            " when the first argument is also greater than 1,");
+      return;
+    fi;
+  fi;
+
+  blocks := [[1, 2, -1, -2]];
+  for i in [3 .. n] do
+    blocks[i - 1] := [i, -i];
+  od;
+
+  x := Bipartition(blocks);
+  S := PlanarModularPartitionMonoid(m, n);
+  return SemigroupIdeal(S, x);
+end);
+
+#
+
+InstallMethod(SingularPlanarPartitionMonoid, "for a positive integer",
+[IsPosInt],
+function(n)
+  local blocks, x, S, i;
+  if n = 1 then
+    return SemigroupIdeal(PlanarPartitionMonoid(1), Bipartition([[1], [-1]]));
+  fi;
+
+  blocks := [[1, 2, -1, -2]];
+  for i in [3 .. n] do
+    blocks[i - 1] := [i, -i];
+  od;
+
+  x := Bipartition(blocks);
+  S := PlanarPartitionMonoid(n);
+  return SemigroupIdeal(S, x);
+end);
+
+#
+
+InstallMethod(SingularModularPartitionMonoid,
+"for a positive integer and positive integer",
+[IsPosInt, IsPosInt],
+function(m, n)
+  local blocks, x, S, i;
+  if n = 1 then
+    if m = 1 then
+      return SemigroupIdeal(ModularPartitionMonoid(1, 1),
+                            Bipartition([[1], [-1]]));
+    else
+      Error("Semigroups: SingularModularPartitionMonoid:",
+            " usage,\nthe second argument must be greater than 1",
+            " when the first argument is also greater than 1,");
+      return;
+    fi;
+  fi;
+
+  blocks := [[1, 2, -1, -2]];
+  for i in [3 .. n] do
+    blocks[i - 1] := [i, -i];
+  od;
+
+  x := Bipartition(blocks);
+  S := ModularPartitionMonoid(m, n);
   return SemigroupIdeal(S, x);
 end);
 

--- a/tst/examples.tst
+++ b/tst/examples.tst
@@ -3368,6 +3368,1153 @@ gap> s := RightZeroSemigroup(1, 1, 1);
 Error, Semigroups: RightZeroSemigroup: usage,
 this function takes at most two arguments,
 
+#T# ExamplesTest37: ham-examples
+# planar uniform block bijection monoid
+gap> s := PlanarUniformBlockBijectionMonoid(1);
+<trivial bipartition group of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := PlanarUniformBlockBijectionMonoid(4);
+<inverse bipartition monoid of degree 4 with 3 generators>
+gap> Size(s);
+8
+gap> Size(Generators(s));
+3
+gap> NrHClasses(s);
+8
+gap> NrRClasses(s);
+8
+gap> NrDClasses(s);
+8
+gap> NrIdempotents(s);
+8
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# singular planar uniform block bijection monoid
+gap> s := SingularPlanarUniformBlockBijectionMonoid(4);
+<inverse bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+4
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+4
+gap> NrRClasses(s);
+4
+gap> NrDClasses(s);
+4
+gap> NrIdempotents(s);
+4
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# uniform block bijection monoid
+gap> s := UniformBlockBijectionMonoid(1);
+<trivial bipartition group of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := UniformBlockBijectionMonoid(4);
+<inverse bipartition monoid of degree 4 with 3 generators>
+gap> Size(s);
+131
+gap> Size(Generators(s));
+3
+gap> NrHClasses(s);
+63
+gap> NrRClasses(s);
+15
+gap> NrDClasses(s);
+5
+gap> NrIdempotents(s);
+15
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2", "S4" ]
+
+# singular uniform block bijection monoid
+gap> s := SingularUniformBlockBijectionMonoid(4);
+<inverse bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+107
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+62
+gap> NrRClasses(s);
+14
+gap> NrDClasses(s);
+4
+gap> NrIdempotents(s);
+14
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2" ]
+
+# apsis monoid
+gap> s := ApsisMonoid(1, 1);
+<commutative inverse bipartition monoid of degree 1 with 1 generator>
+gap> Size(s);
+2
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+2
+gap> NrRClasses(s);
+2
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+2
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := ApsisMonoid(2, 1);
+<trivial bipartition group of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := ApsisMonoid(3, 2);
+<trivial bipartition group of degree 2 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := ApsisMonoid(3, 4);
+<regular bipartition monoid of degree 4 with 2 generators>
+gap> Size(s);
+5
+gap> Size(Generators(s));
+2
+gap> NrHClasses(s);
+5
+gap> NrRClasses(s);
+3
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+5
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := ApsisMonoid(5, 4);
+<trivial bipartition group of degree 4 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# singular apsis monoid
+gap> s := SingularApsisMonoid(1, 1);
+<commutative inverse bipartition semigroup ideal of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := SingularApsisMonoid(2, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+13
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+13
+gap> NrRClasses(s);
+5
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+11
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := SingularApsisMonoid(3, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+4
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+4
+gap> NrRClasses(s);
+2
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+4
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# crossed apsis monoid
+gap> s := CrossedApsisMonoid(1, 1);
+<commutative inverse bipartition monoid of degree 1 with 1 generator>
+gap> Size(s);
+2
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+2
+gap> NrRClasses(s);
+2
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+2
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := CrossedApsisMonoid(2, 1);
+<trivial bipartition group of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := CrossedApsisMonoid(2, 4);
+<regular bipartition monoid of degree 4 with 3 generators>
+gap> Size(s);
+105
+gap> Size(Generators(s));
+3
+gap> NrHClasses(s);
+46
+gap> NrRClasses(s);
+10
+gap> NrDClasses(s);
+3
+gap> NrIdempotents(s);
+40
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2", "S4" ]
+gap> s := CrossedApsisMonoid(3, 4);
+<regular bipartition monoid of degree 4 with 3 generators>
+gap> Size(s);
+40
+gap> Size(Generators(s));
+3
+gap> NrHClasses(s);
+17
+gap> NrRClasses(s);
+5
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+17
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "S4" ]
+gap> s := CrossedApsisMonoid(5, 4);
+<regular bipartition monoid of degree 4 with 2 generators>
+gap> Size(s);
+24
+gap> Size(Generators(s));
+2
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "S4" ]
+
+# singular crossed apsis monoid
+gap> s := SingularCrossedApsisMonoid(1, 1);
+<commutative inverse bipartition semigroup ideal of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := SingularCrossedApsisMonoid(2, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+81
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+45
+gap> NrRClasses(s);
+9
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+39
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2" ]
+gap> s := SingularCrossedApsisMonoid(3, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+16
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+16
+gap> NrRClasses(s);
+4
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+16
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# planar modular partition monoid
+gap> s := PlanarModularPartitionMonoid(1, 1);
+<commutative inverse bipartition monoid of degree 1 with 1 generator>
+gap> Size(s);
+2
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+2
+gap> NrRClasses(s);
+2
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+2
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := PlanarModularPartitionMonoid(2, 1);
+<trivial bipartition group of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := PlanarModularPartitionMonoid(2, 4);
+<regular bipartition monoid of degree 4 with 6 generators>
+gap> Size(s);
+55
+gap> Size(Generators(s));
+6
+gap> NrHClasses(s);
+55
+gap> NrRClasses(s);
+17
+gap> NrDClasses(s);
+8
+gap> NrIdempotents(s);
+45
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := PlanarModularPartitionMonoid(3, 4);
+<regular bipartition monoid of degree 4 with 5 generators>
+gap> Size(s);
+16
+gap> Size(Generators(s));
+5
+gap> NrHClasses(s);
+16
+gap> NrRClasses(s);
+10
+gap> NrDClasses(s);
+8
+gap> NrIdempotents(s);
+16
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := PlanarModularPartitionMonoid(5, 4);
+<inverse bipartition monoid of degree 4 with 3 generators>
+gap> Size(s);
+8
+gap> Size(Generators(s));
+3
+gap> NrHClasses(s);
+8
+gap> NrRClasses(s);
+8
+gap> NrDClasses(s);
+8
+gap> NrIdempotents(s);
+8
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# singular planar modular partition monoid
+gap> s := SingularPlanarModularPartitionMonoid(1, 1);
+<commutative inverse bipartition semigroup ideal of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := SingularPlanarModularPartitionMonoid(2, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+52
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+52
+gap> NrRClasses(s);
+14
+gap> NrDClasses(s);
+5
+gap> NrIdempotents(s);
+42
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := SingularPlanarModularPartitionMonoid(3, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+12
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+12
+gap> NrRClasses(s);
+6
+gap> NrDClasses(s);
+4
+gap> NrIdempotents(s);
+12
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := SingularPlanarModularPartitionMonoid(5, 4);
+<inverse bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+4
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+4
+gap> NrRClasses(s);
+4
+gap> NrDClasses(s);
+4
+gap> NrIdempotents(s);
+4
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# planar partition monoid
+gap> s := PlanarPartitionMonoid(1);
+<commutative inverse bipartition monoid of degree 1 with 1 generator>
+gap> Size(s);
+2
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+2
+gap> NrRClasses(s);
+2
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+2
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := PlanarPartitionMonoid(4);
+<regular bipartition monoid of degree 4 with 7 generators>
+gap> Size(s);
+1430
+gap> Size(Generators(s));
+7
+gap> NrHClasses(s);
+1430
+gap> NrRClasses(s);
+70
+gap> NrDClasses(s);
+5
+gap> NrIdempotents(s);
+886
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# singular planar partition monoid
+gap> s := SingularPlanarPartitionMonoid(1);
+<commutative inverse bipartition semigroup ideal of degree 1 with 1 generator>
+gap> Size(s);
+1
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1
+gap> NrRClasses(s);
+1
+gap> NrDClasses(s);
+1
+gap> NrIdempotents(s);
+1
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+true
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := SingularPlanarPartitionMonoid(4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+1429
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+1429
+gap> NrRClasses(s);
+69
+gap> NrDClasses(s);
+4
+gap> NrIdempotents(s);
+885
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+
+# modular partition monoid
+gap> s := ModularPartitionMonoid(1, 1);
+<commutative inverse bipartition monoid of degree 1 with 1 generator>
+gap> Size(s);
+2
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+2
+gap> NrRClasses(s);
+2
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+2
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := ModularPartitionMonoid(2, 1);
+<commutative inverse bipartition monoid of degree 1 with 1 generator>
+gap> Size(s);
+2
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+2
+gap> NrRClasses(s);
+2
+gap> NrDClasses(s);
+2
+gap> NrIdempotents(s);
+2
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+true
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1" ]
+gap> s := ModularPartitionMonoid(2, 4);
+<regular bipartition monoid of degree 4 with 4 generators>
+gap> Size(s);
+379
+gap> Size(Generators(s));
+4
+gap> NrHClasses(s);
+211
+gap> NrRClasses(s);
+31
+gap> NrDClasses(s);
+6
+gap> NrIdempotents(s);
+127
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2", "S4" ]
+gap> s := ModularPartitionMonoid(3, 4);
+<regular bipartition monoid of degree 4 with 4 generators>
+gap> Size(s);
+155
+gap> Size(Generators(s));
+4
+gap> NrHClasses(s);
+87
+gap> NrRClasses(s);
+19
+gap> NrDClasses(s);
+5
+gap> NrIdempotents(s);
+39
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2", "S4" ]
+gap> s := ModularPartitionMonoid(5, 4);
+<regular bipartition monoid of degree 4 with 3 generators>
+gap> Size(s);
+131
+gap> Size(Generators(s));
+3
+gap> NrHClasses(s);
+63
+gap> NrRClasses(s);
+15
+gap> NrDClasses(s);
+5
+gap> NrIdempotents(s);
+15
+gap> IsBlockBijectionMonoid(s);
+true
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+true
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2", "S4" ]
+
+# singular modular partition monoid
+gap> s := SingularModularPartitionMonoid(2, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+355
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+210
+gap> NrRClasses(s);
+30
+gap> NrDClasses(s);
+5
+gap> NrIdempotents(s);
+126
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2" ]
+gap> s := SingularModularPartitionMonoid(3, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+131
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+86
+gap> NrRClasses(s);
+18
+gap> NrDClasses(s);
+4
+gap> NrIdempotents(s);
+38
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2" ]
+gap> s := SingularModularPartitionMonoid(5, 4);
+<regular bipartition semigroup ideal of degree 4 with 1 generator>
+gap> Size(s);
+107
+gap> Size(Generators(s));
+1
+gap> NrHClasses(s);
+62
+gap> NrRClasses(s);
+14
+gap> NrDClasses(s);
+4
+gap> NrIdempotents(s);
+14
+gap> IsBlockBijectionMonoid(s);
+false
+gap> IsHTrivial(s);
+false
+gap> IsInverseMonoid(s);
+false
+gap> IsRegularSemigroup(s);
+true
+gap> IsSimpleSemigroup(s);
+false
+gap> StructureDescriptionMaximalSubgroups(s);
+[ "1", "C2" ]
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(s);
 gap> Unbind(gens);


### PR DESCRIPTION
I've been unable to get the profiling package configured (despite installing and running autoconf), consequently I haven't tested the tests that I've added to Semigroups/tst/examples.tst using code-coverage-test.py. However they are hopefully straight forward, and I'm reasonably confident the rest is good to go.