### PR TITLE
Make IsUniversalSemigroupCongruence a property

### DIFF
--- a/gap/congruences/congsimple.gi
+++ b/gap/congruences/congsimple.gi
@@ -47,14 +47,21 @@ function(S)
   fi;
   R := Range(iso);
   congs := ShallowCopy(CongruencesOfSemigroup(R));
-  for i in [1 .. Length(congs)] do
-    if IsUniversalSemigroupCongruence(congs[i]) then
-      congs[i] := UniversalSemigroupCongruence(S);
-    else
-      congs[i] := SEMIGROUPS.SimpleCongFromRMSCong(S, iso, congs[i]);
-    fi;
-  od;
-  return congs;
+  if IsReesMatrixSemigroup(R) then
+    # The universal congruence has a linked triple
+    return List(congs,
+                cong -> SEMIGROUPS.SimpleCongFromRMSCong(S, iso, cong));
+  else
+    # The universal congruence has no linked triple
+    for i in [1 .. Length(congs)] do
+      if IsRZMSCongruenceByLinkedTriple(congs[i]) then
+        congs[i] := SEMIGROUPS.SimpleCongFromRMSCong(S, iso, congs[i]);
+      else
+        congs[i] := UniversalSemigroupCongruence(S);
+      fi;
+    od;
+    return congs;
+  fi;
 end);
 
 #

--- a/gap/congruences/conguniv.gd
+++ b/gap/congruences/conguniv.gd
@@ -12,8 +12,8 @@
 ##
 
 # Universal Congruences
-DeclareCategory("IsUniversalSemigroupCongruence",
-                IsSemigroupCongruence and IsAttributeStoringRep and IsFinite);
+DeclareProperty("IsUniversalSemigroupCongruence",
+                IsSemigroupCongruence);
 DeclareCategory("IsUniversalSemigroupCongruenceClass",
                 IsCongruenceClass and IsAttributeStoringRep and
                 IsAssociativeElement);

--- a/tst/standard/conguniv.tst
+++ b/tst/standard/conguniv.tst
@@ -217,6 +217,48 @@ gap> uni := UniversalSemigroupCongruence(S);;
 gap> GeneratingPairsOfSemigroupCongruence(uni);
 [ [ Transformation( [ 4, 5, 3, 4, 5 ] ), Transformation( [ 5, 5, 3, 5, 5 ] ) 
      ] ]
+gap> S := Monoid([PartialPerm([1], [1]),
+>                 PartialPerm([1, 2], [1, 2]),
+>                 PartialPerm([1], [1])]);;
+gap> uni := UniversalSemigroupCongruence(S);;
+gap> GeneratingPairsOfSemigroupCongruence(uni);
+[ [ <identity partial perm on [ 1 ]>, <identity partial perm on [ 1, 2 ]> ] ]
+gap> S := Semigroup([Transformation([2, 1, 2]),
+>                    Transformation([1, 2, 2])]);;
+gap> uni := UniversalSemigroupCongruence(S);
+<universal semigroup congruence over <transformation semigroup of degree 3 
+ with 2 generators>>
+gap> GeneratingPairsOfSemigroupCongruence(uni);
+[ [ Transformation( [ 1, 2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ], 
+  [ Transformation( [ 2, 1, 2 ] ), Transformation( [ 1, 2, 1 ] ) ], 
+  [ Transformation( [ 1, 2, 1 ] ), Transformation( [ 1, 2, 2 ] ) ] ]
+
+#T# IsUniversalSemigroupCongruence for a cong by generating pairs
+gap> S := Semigroup([PartialPerm([1], [2]),
+>                    PartialPerm([1, 2, 3], [2, 3, 1])]);;
+gap> cong := SemigroupCongruence(S, [PartialPerm([1], [1]),
+>                                    PartialPerm([1, 2, 3], [3, 1, 2])]);;
+gap> IsUniversalSemigroupCongruence(cong);
+true
+gap> cong := SemigroupCongruence(S, [PartialPerm([1], [2]),
+>                                    PartialPerm([1], [3])]);;
+gap> IsUniversalSemigroupCongruence(cong);
+false
+
+#T# IsUniversalSemigroupCongruence for an RMS congruence
+gap> S := ReesMatrixSemigroup(SymmetricGroup(4),
+>                             [[(), (), (), ()],
+>                              [(2,4), (), (1,3), ()],
+>                              [(1,2,3,4), (), (1,3,2,4), ()]]);;
+gap> cong := RMSCongruenceByLinkedTriple(S,
+>                                        Group([(2,4,3),(1,4)(2,3),(1,3)(2,4)]),
+>                                        [[1], [2], [3], [4]], [[1],[2, 3]]);;
+gap> IsUniversalSemigroupCongruence(cong);
+false
+gap> cong := RMSCongruenceByLinkedTriple(S, SymmetricGroup(4),
+>                                        [[1, 2, 3, 4]], [[1, 2, 3]]);;
+gap> IsUniversalSemigroupCongruence(cong);
+true
 
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(S);


### PR DESCRIPTION
For technical reasons, ever since Rees 0-matrix semigroup congruences by linked triple were implemented, `IsUniversalSemigroupCongruence` has been a **category** which contains only objects created explicitly by the function `UniversalSemigroupCongruence(S)`.  Therefore we had the situation where a congruence (say by generating pairs or by linked triple in an RMS) might turn out to be universal, but would not satisfy this filter.

`IsUniversalSemigroupCongruence` has now been changed to a **property**, which can be tested, and will return `true` iff a congruence has precisely one congruence class.  Methods intended for universal congruences will then be selected if possible, reducing work done.