### PR TITLE
Travis: run tests in GAP branch fix-semi-iso

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,12 @@ env:
     - GENSS=genss-1.6.3
     - GRAPE=grape4r7
   matrix:
-    - GAP_BRANCH=master
-    - GAP_BRANCH=stable-4.8
-    - GAP_BRANCH=master GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
-    - GAP_BRANCH=stable-4.8 GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
+    - GAP_BRANCH=master GAP_FORK=gap-system
+    - GAP_BRANCH=stable-4.8 GAP_FORK=gap-system
+    - GAP_BRANCH=fix-semi-iso GAP_FORK=james-d-mitchell
+    - GAP_BRANCH=master GAP_FORK=gap-system GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
+    - GAP_BRANCH=stable-4.8 GAP_FORK=gap-system GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
+    - GAP_BRANCH=fix-semi-iso GAP_FORK=james-d-mitchell GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
 addons:
   apt:
     sources:

--- a/doc/attributes.xml
+++ b/doc/attributes.xml
@@ -476,7 +476,7 @@ true
 gap> IsomorphismPermGroup(S); 
 MappingByFunction( <transformation group of degree 8 with 2 generators
  >, Group([ (5,6,8), (2,3,8,
-4) ]), <Attribute "PermutationOfImage">, function( x ) ... end )
+4) ]), function( f ) ... end, function( x ) ... end )
 gap> StructureDescription(Range(IsomorphismPermGroup(S)));
 "S6"
 gap> S := Range(IsomorphismPartialPermSemigroup(SymmetricGroup(4)));

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -18,7 +18,7 @@ fi
 cd ..
 
 # Download and compile GAP
-git clone -b $GAP_BRANCH --depth=1 https://github.com/gap-system/gap.git
+git clone -b $GAP_BRANCH --depth=1 https://github.com/$GAP_FORK/gap.git
 cd gap
 ./configure --with-gmp=system $GAP_FLAGS
 make

--- a/tst/standard/grpperm.tst
+++ b/tst/standard/grpperm.tst
@@ -387,12 +387,15 @@ true
 true
 
 #T# SEMIGROUPS_UnbindVariables
+gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);
 gap> Unbind(F);
 gap> Unbind(G);
 gap> Unbind(R);
 gap> Unbind(S);
 gap> Unbind(iso);
+gap> Unbind(x);
+gap> Unbind(y);
 
 #E#
 gap> STOP_TEST("Semigroups package: standard/grpperm.tst");

--- a/tst/standard/semibipart.tst
+++ b/tst/standard/semibipart.tst
@@ -42,5 +42,12 @@ gap> S := ReesMatrixSemigroup(Group([(1,2)]), [[()]]);
 gap> S := AsSemigroup(IsBlockBijectionSemigroup, S);
 <block bijection group of degree 3 with 1 generator>
 
+#T# SEMIGROUPS_UnbindVariables
+gap> Unbind(BruteForceInverseCheck);
+gap> Unbind(BruteForceIsoCheck);
+gap> Unbind(S);
+gap> Unbind(x);
+gap> Unbind(y);
+
 #E# 
 gap> STOP_TEST("Semigroups package: standard/semibipart.tst");

--- a/tst/standard/semiboolmat.tst
+++ b/tst/standard/semiboolmat.tst
@@ -1430,5 +1430,17 @@ true
 gap> BruteForceInverseCheck(map);
 true
 
+#T# SEMIGROUPS_UnbindVariables
+gap> Unbind(BruteForceInverseCheck);
+gap> Unbind(BruteForceIsoCheck);
+gap> Unbind(F);
+gap> Unbind(R);
+gap> Unbind(S);
+gap> Unbind(T);
+gap> Unbind(map);
+gap> Unbind(rels);
+gap> Unbind(x);
+gap> Unbind(y);
+
 #E# 
 gap> STOP_TEST("Semigroups package: standard/semiboolmat.tst");

--- a/tst/standard/semifp.tst
+++ b/tst/standard/semifp.tst
@@ -1498,7 +1498,17 @@ gap> BruteForceInverseCheck(map);
 true
 
 #T# SEMIGROUPS_UnbindVariables
+gap> Unbind(BruteForceInverseCheck);
+gap> Unbind(BruteForceIsoCheck);
+gap> Unbind(F);
+gap> Unbind(R);
 gap> Unbind(S);
+gap> Unbind(T);
+gap> Unbind(inv);
+gap> Unbind(map);
+gap> Unbind(rels);
+gap> Unbind(x);
+gap> Unbind(y);
 
 #E#
 gap> STOP_TEST("Semigroups package: standard/semifp.tst");

--- a/tst/standard/semipbr.tst
+++ b/tst/standard/semipbr.tst
@@ -13,6 +13,28 @@ gap> LoadPackage("semigroups", false);;
 #
 gap> SEMIGROUPS.StartTest();
 
+#T# helper functions
+gap> BruteForceIsoCheck := function(iso)
+>   local x, y;
+>   if not IsInjective(iso) or not IsSurjective(iso) then
+>     return false;
+>   fi;
+>   for x in Source(iso) do
+>     for y in Source(iso) do
+>       if x ^ iso * y ^ iso <> (x * y) ^ iso then
+>         return false;
+>       fi;
+>     od;
+>   od;
+>   return true;
+> end;;
+gap> BruteForceInverseCheck := function(map)
+> local inv;
+>   inv := InverseGeneralMapping(map);
+>   return ForAll(Source(map), x -> x = (x ^ map) ^ inv)
+>     and ForAll(Range(map), x -> x = (x ^ inv) ^ map);
+> end;;
+
 #T# AsSemigroup: 
 #   convert from IsPBRSemigroup to IsPBRSemigroup
 gap> S := Semigroup(PBR([[-2, 1, 2], [-2, -1, 1]], [[-2, -1, 1], [-2, -1, 1, 2]]),

--- a/tst/standard/semipbr.tst
+++ b/tst/standard/semipbr.tst
@@ -1100,5 +1100,16 @@ true
 gap> BruteForceInverseCheck(map);
 true
 
+#T# SEMIGROUPS_UnbindVariables
+gap> Unbind(BruteForceInverseCheck);
+gap> Unbind(BruteForceIsoCheck);
+gap> Unbind(F);
+gap> Unbind(S);
+gap> Unbind(T);
+gap> Unbind(map);
+gap> Unbind(rels);
+gap> Unbind(x);
+gap> Unbind(y);
+
 #E# 
 gap> STOP_TEST("Semigroups package: standard/semipbr.tst");

--- a/tst/standard/semirms.tst
+++ b/tst/standard/semirms.tst
@@ -1901,5 +1901,28 @@ gap> MatrixEntries(R);
   <bipartition: [ 1, -2, -4 ], [ 2, 3, 4, -3 ], [ -1 ]>, 
   <bipartition: [ 1, -1, -2 ], [ 2, 3, -3, -4 ], [ 4 ]> ]
 
+#T# SEMIGROUPS_UnbindVariables
+gap> Unbind(BruteForceInverseCheck);
+gap> Unbind(BruteForceIsoCheck);
+gap> Unbind(F);
+gap> Unbind(G);
+gap> Unbind(R);
+gap> Unbind(S);
+gap> Unbind(T);
+gap> Unbind(comps);
+gap> Unbind(i);
+gap> Unbind(id);
+gap> Unbind(idems);
+gap> Unbind(inv);
+gap> Unbind(iso);
+gap> Unbind(map);
+gap> Unbind(mat);
+gap> Unbind(occurrence);
+gap> Unbind(rels);
+gap> Unbind(x);
+gap> Unbind(y);
+gap> Unbind(z);
+gap> Unbind(zero);
+
 #E#
 gap> STOP_TEST("Semigroups package: standard/semirms.tst");

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -2051,11 +2051,18 @@ gap> Size(S);
 4
 
 #T# SEMIGROUPS_UnbindVariables
-gap> Unbind(S);
+gap> Unbind(BruteForceInverseCheck);
+gap> Unbind(BruteForceIsoCheck);
+gap> Unbind(F);
 gap> Unbind(R);
-gap> Unbind(x);
-gap> Unbind(n);
+gap> Unbind(S);
+gap> Unbind(T);
 gap> Unbind(gr);
+gap> Unbind(map);
+gap> Unbind(n);
+gap> Unbind(rels);
+gap> Unbind(x);
+gap> Unbind(y);
 
 #E#
 gap> STOP_TEST("Semigroups package: standard/semitrans.tst");


### PR DESCRIPTION
Currently, the Travis tests in the `unstable-3.0` branch all fail, due to us relying on GAP changes in James' `fix-semi-iso` branch which has not yet been merged into the official GAP repo.  In the long-term we should only test against official GAP versions, but for the moment it's difficult to tell whether new changes we make are causing new problems without any effective automated testing.

This pull request adds another configuration to Travis, which *additionally* runs the tests under `fix-semi-iso`.  Tests under the other branches still fail, but if you want to see whether new changes are alright, you can look at the Travis build page, and you're looking for **two green ticks** to indicate that Semigroups at least works with the altered GAP.

`semipbr.tst` was still failing due to a lack of helper functions at the top - it seems that it was passing only if executed after certain other test files which installed the functions.  I've added the functions to `semipbr.tst`, and made sure they're always unbound at the end of a file so that this problem doesn't go undetected again.

There was also an (I assume) harmless diff in `attributes.xml`, which I've fixed.

I expect this pull request to fail Travis tests (X), but pass 2 out of 12 on the actual build page.