### PR TITLE
Travis package versions updated (unstable-3.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,20 @@ compiler:
   - clang
 env:
   global:
-    - SEMIGROUPSPLUSPLUS_BR=0.1
+    - SEMIGROUPSPLUSPLUS_BR=master
     - DIGRAPHS_BR=0.5.1
-    - IO=io-4.4.5
+    - IO=io-4.4.6
     - GAPDOC=GAPDoc-1.5.1
-    - ORB=orb-4.7.5
-    - GENSS=genss-1.6.3
+    - ORB=orb-4.7.6
+    - GENSS=genss-1.6.4
     - GRAPE=grape4r7
   matrix:
-    - GAP_BRANCH=master GAP_FORK=gap-system
-    - GAP_BRANCH=stable-4.8 GAP_FORK=gap-system
     - GAP_BRANCH=fix-semi-iso GAP_FORK=james-d-mitchell
-    - GAP_BRANCH=master GAP_FORK=gap-system GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
-    - GAP_BRANCH=stable-4.8 GAP_FORK=gap-system GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
     - GAP_BRANCH=fix-semi-iso GAP_FORK=james-d-mitchell GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
+    - GAP_BRANCH=master GAP_FORK=gap-system
+    - GAP_BRANCH=master GAP_FORK=gap-system GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
+    - GAP_BRANCH=stable-4.8 GAP_FORK=gap-system
+    - GAP_BRANCH=stable-4.8 GAP_FORK=gap-system GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
 addons:
   apt:
     sources:


### PR DESCRIPTION
There are new versions of certain packages available, and Travis should use them.

Builds were also reordered for easier readability on the Travis page.

I was going to push this straight to the gap-packages repo as we discussed (it being a trivial change) but it seems that `unstable-3.0` is a protected branch - hence this pull request.