### PR TITLE
Travis: add log-folding (3.0)

### DIFF
--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -8,6 +8,7 @@ $CXX --version
 SEMIDIR=$(pwd)
 
 # Get semigroups++ if appropriate
+echo -en 'travis_fold:start:GetSemigroupsPP\r'
 if [ -d src ]
 then
     cd src
@@ -16,14 +17,18 @@ then
     cd ..
 fi
 cd ..
+echo -en 'travis_fold:end:GetSemigroupsPP\r'
 
 # Download and compile GAP
+echo -en 'travis_fold:start:InstallGAP\r'
 git clone -b $GAP_BRANCH --depth=1 https://github.com/$GAP_FORK/gap.git
 cd gap
 ./configure --with-gmp=system $GAP_FLAGS
 make
+echo -en 'travis_fold:end:InstallGAP\r'
 
 # Get the packages
+echo -en 'travis_fold:start:InstallPackages\r'
 mkdir pkg
 cd pkg
 curl -O http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$GAPDOC.tar.gz
@@ -59,6 +64,10 @@ cd digraphs
 ./configure $PKG_FLAGS
 make
 cd ../../..
+echo -en 'travis_fold:end:InstallPackages\r'
+
+# Compile the Semigroups package
+echo -en 'travis_fold:start:BuildSemigroups\r'
 mv $SEMIDIR gap/pkg/semigroups
 cd gap/pkg/semigroups
 if [ -d src ]
@@ -68,3 +77,4 @@ then
     make
 fi
 cd ../..
+echo -en 'travis_fold:end:BuildSemigroups\r'

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -1,6 +1,8 @@
 # If a command fails, exit this script with an error code
 set -e
 
+echo -en 'travis_fold:start:RunTests\r'
 cd ../..
 echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples(); quit; quit; quit;" | bin/gap.sh -A -r -m 1g -T 2>&1 | tee testlog.txt
+echo -en 'travis_fold:end:RunTests\r'
 ( ! grep -E "########> Diff|brk>|#E|Error|# WARNING|fail|Syntax warning" testlog.txt )


### PR DESCRIPTION
The full log produced by Travis CI is verbose and unwieldy.  If the build fails it can take a long time to figure out what's going wrong.

This pull request just adds some extra commands to the build and test scripts which "fold" the Travis output, i.e. collapse certain sections so that they can be expanded by a click.  A successful test should display on just one or two screens, and a failing test should be much easier to diagnose.

Have a look at the Travis output for this PR to see how it looks in action.