### PR TITLE
Resolve Issue #174

### DIFF
--- a/src/bipart.cc
+++ b/src/bipart.cc
@@ -1146,7 +1146,7 @@ class NrIdempotentsFinder {
           _scc.back().push_back(INT_INTOBJ(ELM_PLIST(comp, j)) - 2);
         }
         _ranks.push_back(_orbit[_scc.back()[0]]->rank());
-        total_load += std::pow(_scc.back().size(), 2);
+        total_load += _scc.back().size() * _scc.back().size();
       }
 
       total_load = total_load / _nr_threads;


### PR DESCRIPTION
Issue #174 is a problem with c++11.  `std::pow` is used, but in the latest version of GCC `pow` is no longer in `std`.  This is only used in one place in the whole of Semigroups, and it is easily replaced with a straight multiplication.

I've checked on my computer, and this compiles successfully in GCC 5.3.1