### PR TITLE
Travis: remove clang tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 compiler:
   - gcc
-  - clang
 env:
   global:
     - SEMIGROUPSPLUSPLUS_BR=master
@@ -22,10 +21,8 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.6
     packages:
     - g++-5-multilib
-    - clang-3.6
 before_script:
   - echo "deb http://us.archive.ubuntu.com/ubuntu/ vivid main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
@@ -33,7 +30,6 @@ before_script:
   - sudo apt-get install libgmp-dev:i386
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
-  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.6" CC="clang-3.6"; fi
 script:
   - scripts/travis-build.sh
   - scripts/travis-test.sh


### PR DESCRIPTION
Travis is having some issues with some of its APT servers.  The new and up-to-date versions of clang++ which we require have been taken down and are not currently available without some hacking.

This pull request removes clang tests - Travis will just use gcc for now.

See these links for more detail: [1](https://github.com/travis-ci/travis-ci/issues/6120#issuecomment-224072540) [2](http://lists.llvm.org/pipermail/llvm-foundation/2016-May/000020.html)