### PR TITLE
Travis: remove clang (stable-2.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 compiler:
   - gcc
-  - clang
 env:
   global:
     - SEMIGROUPSPLUSPLUS_BR=master
@@ -20,10 +19,8 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.6
     packages:
     - g++-5-multilib
-    - clang-3.6
 before_script:
   - echo "deb http://us.archive.ubuntu.com/ubuntu/ vivid main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
@@ -31,7 +28,6 @@ before_script:
   - sudo apt-get install libgmp-dev:i386
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
-  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.6" CC="clang-3.6"; fi
 script:
   - scripts/travis-build.sh
   - scripts/travis-test.sh


### PR DESCRIPTION
Travis is having some issues with some of its APT servers. The new and up-to-date versions of clang++ which we require have been taken down and are not currently available without some hacking.

This pull request removes clang tests - Travis will just use gcc for now.