### PR TITLE
UFData: add SaveWorkspace and LoadWorkspace support

### DIFF
--- a/src/ufdata.hh
+++ b/src/ufdata.hh
@@ -36,6 +36,12 @@ class UFData {
   }
   UFData& operator= (UFData const& copy) = delete;
 
+  // Constructor by table
+  UFData (const table_t& table) : _size(table.size()),
+                                  _table(new table_t(table)),
+                                  _blocks(nullptr),
+                                  _haschanged(true) { }
+
   // Constructor by size
   UFData (size_t size) : _size(size),
                          _table(new table_t()),


### PR DESCRIPTION
This should make it possible to save `UFData` objects and reload them with `SaveWorkspace` and `LoadWorkspace`.

I haven't been able to test it properly, since I get a segfault any time I try to use `SaveWorkspace` (even before these changes).