### PR TITLE
Fix issue #191

### DIFF
--- a/gap/congruences/congpairs.gi
+++ b/gap/congruences/congpairs.gi
@@ -761,7 +761,7 @@ function(_record)
     cong := EquivalenceClassRelation(class);
     S := Range(cong);
 
-    if not IsFinite(S) then
+    if not (HasIsFinite(S) and IsFinite(S)) then
       TryNextMethod();
     fi;
 
@@ -879,7 +879,7 @@ function(_record)
                 _record.info_string, "congruence class"),
   [IsMultiplicativeElement, _IsXCongruenceClass],
   function(elm, class)
-    if not IsFinite(Parent(class)) then
+    if not (HasIsFinite(Parent(class)) and IsFinite(Parent(class))) then
       TryNextMethod();
     fi;
     return [elm, Representative(class)] in EquivalenceClassRelation(class);
@@ -892,7 +892,7 @@ function(_record)
   [_IsXCongruenceClass],
   function(class)
     local p, tab;
-    if not IsFinite(Parent(class)) then
+    if not (HasIsFinite(Parent(class)) and IsFinite(Parent(class))) then
       TryNextMethod();
     fi;
     p := Position(GenericSemigroupData(Parent(class)), Representative(class));


### PR DESCRIPTION
This fixes Issue #191, [The GAP test file tst/testinstall/semicong.tst runs forever](https://github.com/gap-packages/Semigroups/issues/191), by checking whether a given semigroup is *known to be* finite.  This way, we don't get stuck on an infinite run trying to determine whether the `cong-pairs` algorithm is appropriate; we just go straight to the fallback method (which may well be replaced by our Todd-Coxeter algorithm in the future).