### PR TITLE
SaveWorkspace: add tests to Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ src/pkgconfig.h
 src/semigroups++
 src/stamp-h1
 tags
+tst/workspaces/test-output.w

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -1,8 +1,18 @@
 # If a command fails, exit this script with an error code
 set -e
 
+# Run the standard tests and manual examples
 echo -en 'travis_fold:start:RunTests\r'
 cd ../..
 echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples(); quit; quit; quit;" | bin/gap.sh -A -r -m 1g -T 2>&1 | tee testlog.txt
 echo -en 'travis_fold:end:RunTests\r'
-( ! grep -E "########> Diff|brk>|#E|Error|# WARNING|fail|Syntax warning" testlog.txt )
+
+# Run the SaveWorkspace tests
+echo -en 'travis_fold:start:SaveWorkspaceTests\r'
+echo "LoadPackage(\"semigroups\", false); SemigroupsTestInstall(); Test(\"pkg/semigroups/tst/workspaces/save-workspace.tst\"); quit; quit; quit;" | bin/gap.sh -A -r -m 1g -T 2>&1 | tee -a testlog.txt
+echo "LoadPackage(\"semigroups\", false); Test(\"pkg/semigroups/tst/workspaces/load-workspace.tst\"); SemigroupsTestInstall(); quit; quit; quit;" | bin/gap.sh -L pkg/semigroups/tst/workspaces/test-output.w -A -r -m 1g -T 2>&1 | tee -a testlog.txt
+rm pkg/semigroups/tst/workspaces/test-output.w
+echo -en 'travis_fold:end:SaveWorkspaceTests\r'
+
+# Check the logs for invalid phrases
+( ! grep -E "########> Diff|brk>|#E|Error|# WARNING|fail|Syntax warning|Couldn't open saved workspace" testlog.txt )

--- a/tst/workspaces/load-workspace.tst
+++ b/tst/workspaces/load-workspace.tst
@@ -1,0 +1,49 @@
+#############################################################################
+##
+#W  workspaces/load-workspace.tst
+#Y  Copyright (C) 2016                                      Michael Torpey
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+##  This file, together with save-workspace.tst, tests the ability to save
+##  and load workspaces which include Semigroups objects.  Objects should be
+##  created and stored in save-workspace.tst, and then loaded and tested in
+##  load-workspace.tst to ensure that they work correctly after being saved.
+##
+#############################################################################
+
+# Set up testing environment
+gap> START_TEST("Semigroups package: workspaces/load-workspace.tst");
+gap> SEMIGROUPS.StartTest();
+
+#############################################################################
+##  Test objects that were created in save-workspace.tst, using the same
+##  variable names.  Give the test blocks the same headers as in the previous
+##  file.
+#############################################################################
+
+#T# Union-find structures
+gap> UF_TABLE(uftable1);
+[ 1, 2, 3, 2, 5, 6, 7, 8, 2, 10 ]
+gap> UF_TABLE(uftable2);
+[ 1 ]
+gap> UF_FIND(uftable3, 17);
+17
+gap> UF_FIND(uftable3, 20222);
+234
+gap> UF_FIND(uftable3, 234);
+234
+
+#############################################################################
+##  Tests end here
+#############################################################################
+
+# SEMIGROUPS_UnbindVariables
+gap> Unbind(uftable1);
+gap> Unbind(uftable2);
+gap> Unbind(uftable3);
+
+#E#
+gap> STOP_TEST("Semigroups package: workspaces/load-workspace.tst");

--- a/tst/workspaces/save-workspace.tst
+++ b/tst/workspaces/save-workspace.tst
@@ -1,0 +1,51 @@
+#############################################################################
+##
+#W  workspaces/save-workspace.tst
+#Y  Copyright (C) 2016                                      Michael Torpey
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+##  This file, together with load-workspace.tst, tests the ability to save
+##  and load workspaces which include Semigroups objects.  Objects should be
+##  created and stored in save-workspace.tst, and then loaded and tested in
+##  load-workspace.tst to ensure that they work correctly after being saved.
+##
+#############################################################################
+
+# Set up testing environment
+gap> START_TEST("Semigroups package: workspaces/save-workspace.tst");
+gap> SetInfoLevel(InfoDebug, 0);
+gap> LoadPackage("semigroups", false);;
+gap> SEMIGROUPS.StartTest();
+
+#############################################################################
+##  Create objects below here, and add tests to load-workspace.tst to ensure
+##  that they are saved to disk correctly.  Do not reuse variable names.
+#############################################################################
+
+#T# Union-find structures
+gap> uftable1 := UF_NEW(10);;
+gap> UF_UNION(uftable1, [4, 9]);;
+gap> UF_UNION(uftable1, [4, 2]);;
+gap> uftable2 := UF_NEW(1);;
+gap> uftable3 := UF_NEW(30000);;
+gap> UF_UNION(uftable3, [20222, 234]);;
+
+#############################################################################
+##  Tests end here
+#############################################################################
+
+# Save the workspace
+gap> SaveWorkspace(Concatenation(SEMIGROUPS.PackageDir,
+>                                "/tst/workspaces/test-output.w"));
+true
+
+# SEMIGROUPS_UnbindVariables
+gap> Unbind(uftable1);
+gap> Unbind(uftable2);
+gap> Unbind(uftable3);
+
+#E#
+gap> STOP_TEST("Semigroups package: workspaces/save-workspace.tst");


### PR DESCRIPTION
This pull request adds a new test system to the automatic Travis tests, to allow objects to be saved to a workspace which is then reloaded.  There is a new `tst/workspaces` directory with two new files, `save-workspace.tst` and `load-workspace.tst`, which create objects and then verify that the objects exist after loading.

`travis-test.sh` now has an extra section where it:
 * creates a new session
 * runs `save-workspace.tst`
 * saves the workspace to a file
 * ends the session
 * reloads the workspace from the file
 * runs `load-workspace.tst`
 * deletes the workspace file

I have included tests for the UFData object as an example.  New tests should be added for any other C/C++ objects we have created, and this can be done easily by adding new test blocks to those files.