### PR TITLE
Delete redundant OneImmutable code for congruence classes

### DIFF
--- a/gap/congruences/congrees.gi
+++ b/gap/congruences/congrees.gi
@@ -311,21 +311,6 @@ function(cong)
   return GeneratingPairsOfSemigroupCongruence(cong);
 end);
 
-# Not sure if this is still required or not. TODO delete or reinstate
-
-#InstallMethod(OneImmutable,
-#"for a congruence class",
-#[IsCongruenceClass],
-#function(class)
-#  local cong, one;
-#  cong := EquivalenceClassRelation(class);
-#  one := One(Range(cong));
-#  if one <> fail then
-#    return EquivalenceClassOfElementNC(cong, one);
-#  fi;
-#  return fail;
-#end);
-
 InstallMethod(Enumerator,
 "for a Rees congruence class",
 [IsReesCongruenceClass],


### PR DESCRIPTION
This is no longer used anywhere, and it's not clear what `One` should mean for a congruence class anyway.