### PR TITLE
Correct DotString doc for the 'normal' option

### DIFF
--- a/doc/display.xml
+++ b/doc/display.xml
@@ -250,9 +250,9 @@ ent}"]]></Log>
 
         <Mark>normal</Mark>
         <Item>
-          if <C><A>options</A>.number</C> is <K>false</K>, then the &L;- and
+          if <C><A>options</A>.normal</C> is <K>false</K>, then the &L;- and
           &R;-classes within each &D;-class arranged to correspond to <Ref
-            Attr="PrincipalFactor"/>.  If <C><A>options</A>.number</C> is
+            Attr="PrincipalFactor"/>.  If <C><A>options</A>.normal</C> is
           <K>true</K>, they are instead arranged to correspond to <Ref
             Attr="NormalizedPrincipalFactor"/>. Setting this attribute to
           <K>false</K> may improve the performance of <C>DotString</C> as it


### PR DESCRIPTION
I noticed that the documentation for `DotString` twice included the text `opts.number` when it should have said `opts.normal`. I've fixed this.