### PR TITLE
Make RepresentativeOfMinimalIdeal check for high degree (Issue #192)

### DIFF
--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -607,17 +607,15 @@ function(S)
   local gens, nrgens, n, min_rank, rank, min_rank_index, graph, nrpairs, elts,
   marked, squashed, j, t, im, reduced, y, i, k, x;
 
-  gens := GeneratorsOfSemigroup(S);
-  nrgens := Length(gens);
   n := DegreeOfTransformationSemigroup(S); # Smallest n such that S <= T_n
                                            # We must have n >= 2.
-
+  gens := GeneratorsOfSemigroup(S);
+  nrgens := Length(gens);
   # Find the minimum rank of a generator
   min_rank := n;
   for i in [1 .. nrgens] do
     rank := RankOfTransformation(gens[i], n);
     if rank = 1 then
-      # SetIsSynchronizingSemigroup(S, true);
       return gens[i];
     elif rank < min_rank then
       min_rank := rank;
@@ -628,6 +626,11 @@ function(S)
   if min_rank = n then
     SetIsGroupAsSemigroup(S, true);
     return gens[1];
+  fi;
+
+  if (HasSize(S) and Size(S) < Binomial(n, 2))
+      or n > 10000 then
+    TryNextMethod();
   fi;
 
   graph := SEMIGROUPS.GraphOfRightActionOnPairs(gens, n, false);

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -2061,6 +2061,24 @@ true
 gap> LargestElementSemigroup(S);
 Transformation( [ 10, 8, 7, 8, 6, 10, 3, 2, 9, 1 ] )
 
+#T# RepresentativeOfMinimalIdeal: for a transformation semigroup on many points
+gap> x := ListWithIdenticalEntries(49999, 1);;
+gap> Add(x, 2);
+gap> x := Transformation(x);;
+gap> S := Semigroup(x);
+<commutative transformation semigroup of degree 50000 with 1 generator>
+gap> RepresentativeOfMinimalIdeal(S);
+<transformation on 50000 pts with rank 1>
+gap> x := ListWithIdenticalEntries(99, 1);;
+gap> Add(x, 2);
+gap> x := Transformation(x);;
+gap> S := Semigroup(x);
+<commutative transformation semigroup of degree 100 with 1 generator>
+gap> Size(S);
+2
+gap> RepresentativeOfMinimalIdeal(S);
+<transformation on 100 pts with rank 1>
+
 #T# RepresentativeOfMinimalIdeal: for a transformation group
 gap> S := Semigroup([
 > Transformation([1, 4, 1, 4, 1]),

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -2061,6 +2061,18 @@ true
 gap> LargestElementSemigroup(S);
 Transformation( [ 10, 8, 7, 8, 6, 10, 3, 2, 9, 1 ] )
 
+#T# RepresentativeOfMinimalIdeal: for a transformation group
+gap> S := Semigroup([
+> Transformation([1, 4, 1, 4, 1]),
+> Transformation([4, 1, 4, 1, 4])]);;
+gap> RepresentativeOfMinimalIdeal(S);
+Transformation( [ 1, 4, 1, 4, 1 ] )
+gap> S := Semigroup([
+> Transformation([2, 3, 4, 5, 1]),
+> Transformation([2, 1])]);;
+gap> RepresentativeOfMinimalIdeal(S);
+Transformation( [ 2, 3, 4, 5, 1 ] )
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);


### PR DESCRIPTION
This PR addresses Issue #192 by comparing the size of the semigroup (if known) to the degree of the transformation semigroup in `RepresentativeOfMinimalIdeal`, and doing `TryNextMethod` if appropriate.

I also check for the degree of the transformation semigroup (regardless of the size of the semigroup). If the degree is greater than some fixed number, we determine that the algorithm will take too long in any circumstance, and so we may as well try the next method. This requires a somewhat arbitrary decision for what that number should be - I went with degree  10,000 as the limit.