### PR TITLE
Replace hash function for IsPlistMatrix/RowBasisOverFiniteFieldRep

### DIFF
--- a/gap/elements/ffmat.gi
+++ b/gap/elements/ffmat.gi
@@ -59,6 +59,12 @@ function(mat, pos)
 end);
 
 InstallMethod(MatrixNC, "for a matrix over finite field and mutable list",
+[IsMatrixOverFiniteField, IsList],
+function(sample, mat)
+  return MatrixNC(sample, ShallowCopy(mat));
+end);
+
+InstallMethod(MatrixNC, "for a matrix over finite field and mutable list",
 [IsMatrixOverFiniteField, IsList and IsMutable],
 function(sample, mat)
   local filter;

--- a/gap/greens/greens-generic.gi
+++ b/gap/greens/greens-generic.gi
@@ -231,6 +231,31 @@ function(H)
   return Idempotents(H)[1];
 end);
 
+InstallMethod(IsomorphismPermGroup, "for H-class of a semigroup",
+[IsGreensHClass],
+function(H)
+  local G, p, h;
+
+  if not IsGroupHClass(H) then
+    ErrorNoReturn("Semigroups: IsomorphismPermGroup: usage,\n",
+                  "the H-class is not a group,");
+  fi;
+
+  G := Group(());
+
+  for h in H do 
+    p := Permutation(h, AsSet(H), OnRight);
+    if not p in G then 
+      G := ClosureGroup(G, p);
+      if Size(G) = Size(H) then 
+        break;
+      fi;
+    fi;
+  od;
+  return MappingByFunction(H, G, h -> Permutation(h, AsSet(H), OnRight));
+end);
+  
+
 InstallMethod(StructureDescription, "for a Green's H-class",
 [IsGreensHClass],
 function(H)

--- a/gap/hash.gd
+++ b/gap/hash.gd
@@ -11,5 +11,3 @@
 
 DeclareGlobalFunction("SEMIGROUPS_HashFunctionForPlistMatricesOverFiniteField");
 DeclareGlobalFunction("SEMIGROUPS_HashFunctionForPlistRowBasisOverFiniteField");
-DeclareGlobalFunction("SEMIGROUPS_HashFunctionForPlistVectorOverFiniteFields");
-DeclareGlobalFunction("SEMIGROUPS_HashFunctionForFFECollColl");

--- a/gap/hash.gi
+++ b/gap/hash.gi
@@ -11,89 +11,57 @@
 
 InstallGlobalFunction(SEMIGROUPS_HashFunctionForPlistMatricesOverFiniteField,
 function(x, data)
-  local i, res;
+  local h;
+
   if DimensionOfMatrixOverSemiring(x) = 0 then
     return 1;
+  elif IsInt(data.data) then 
+    h := ChooseHashFunction(AsList(x), data.data);
+    data.func := h.func;
+    data.data := h.data;
   fi;
-  res := 0;
-  for i in [1 .. DimensionOfMatrixOverSemiring(x)] do
-    res := (res * 1001
-            + ORB_HashFunctionForPlainFlatList(AsPlist(x!.mat[i]), data))
-            mod data + 1;
-  od;
-  return res;
+
+  return data.func(AsList(x), data.data);
 end);
 
 InstallGlobalFunction(SEMIGROUPS_HashFunctionForPlistRowBasisOverFiniteField,
 function(x, data)
-  local i, res;
+  local h;
+
   if Rank(x) = 0 then
     return 1;
+  elif IsInt(data.data) then 
+    h := ChooseHashFunction(x!.rows, data.data);
+    data.func := h.func;
+    data.data := h.data;
   fi;
-  res := 0;
-  for i in [1 .. Rank(x)] do
-    res := (res * 1001
-            + ORB_HashFunctionForPlainFlatList(AsPlist(x!.rows[i]), data))
-            mod data + 1;
-  od;
-  return res;
+  return data.func(x!.rows, data.data);
 end);
-
-InstallGlobalFunction(SEMIGROUPS_HashFunctionForPlistVectorOverFiniteFields,
-function(x, data)
-  local i, res;
-  if Length(x) = 0 then
-    return 1;
-  fi;
-  res := 0;
-  for i in [1 .. Length(x)] do
-    res := (res * 1001
-            + ORB_HashFunctionForPlainFlatList(AsPlist(x[i]!.vec), data))
-            mod data + 1;
-  od;
-  return res;
-end);
-
-#InstallGlobalFunction(SEMIGROUPS_HashFunctionForFFECollColl,
-#function(x, data)
-#  local i, res;
-#  if Length(x) = 0 then
-#    return 1;
-#  fi;
-#  res := 0;
-#  for i in [1 .. Length(x)] do
-#    res := (res * 1001 + ORB_HashFunctionForPlainFlatList(AsPlist(x[i]), data))
-#           mod data + 1;
-#  od;
-#  return res;
-#end);
-
-InstallMethod(ChooseHashFunction,
-"for collections of plist vector over finite fields",
-[IsVectorOverFiniteFieldCollection, IsInt],
-function(m, hashlen)
-  return rec(func := SEMIGROUPS_HashFunctionForPlistVectorOverFiniteFields,
-             data := hashlen);
-end);
-
-#InstallMethod(ChooseHashFunction,
-#"for collections of ffeplist vector over finite fields",
-#[IsFFECollColl, IsInt],
-#function(m, hashlen)
-#  return rec(func := SEMIGROUPS_HashFunctionForFFECollColl,
-#             data := hashlen);
-#end);
 
 InstallMethod(ChooseHashFunction, "for plist matrices over finite fields",
 [IsPlistMatrixOverFiniteFieldRep, IsInt],
-function(m, hashlen)
+function(x, hashlen)
+  local data;
+
+  if DimensionOfMatrixOverSemiring(x) <> 0 then 
+    data := ChooseHashFunction(AsList(x), hashlen);
+  else 
+    data := hashlen;
+  fi;
   return rec(func := SEMIGROUPS_HashFunctionForPlistMatricesOverFiniteField,
-             data := hashlen);
+             data := ChooseHashFunction(AsList(x), hashlen));
 end);
 
 InstallMethod(ChooseHashFunction, "for plist rowbasis over finite fields",
 [IsPlistRowBasisOverFiniteFieldRep, IsInt],
-function(b, hashlen)
+function(x, hashlen)
+  local data;
+
+  if Rank(x) <> 0 then 
+    data := ChooseHashFunction(x!.rows, hashlen);
+  else 
+    data := hashlen;
+  fi;
   return rec(func := SEMIGROUPS_HashFunctionForPlistRowBasisOverFiniteField,
-             data := hashlen);
+             data := data);
 end);

--- a/gap/semigroups/semiffmat.gd
+++ b/gap/semigroups/semiffmat.gd
@@ -9,6 +9,7 @@
 #############################################################################
 ##
 
+
 DeclareOperation("RandomMatrixSemigroup", [IsRing, IsPosInt, IsPosInt]);
 DeclareOperation("RandomMatrixMonoid", [IsRing, IsPosInt, IsPosInt]);
 DeclareOperation("RandomMatrixSemigroup", [IsRing, IsPosInt, IsPosInt, IsList]);
@@ -20,7 +21,9 @@ DeclareSynonym("IsMatrixMonoid",
                IsMatrixOverFiniteFieldCollection and IsMonoid);
 DeclareAttribute("DegreeOfMatrixSemigroup", IsMatrixSemigroup);
 DeclareProperty("IsMatrixSemigroupGreensClass", IsGreensClass);
-InstallTrueMethod(CanComputeSize, IsMatrixSemigroup and IsFinite);
+
+InstallTrueMethod(CanComputeSize, IsMatrixSemigroup);
+InstallTrueMethod(IsFinite, IsMatrixSemigroup);
 
 # (mp) This is defined for groups, and already difficult there, so I
 # guess close to impossible to do in matrix semigroups

--- a/tst/standard/greens-generic.tst
+++ b/tst/standard/greens-generic.tst
@@ -1303,11 +1303,12 @@ gap> IsGroupHClass(H);
 true
 gap> IsomorphismPermGroup(H);
 MappingByFunction( <Green's H-class: IdentityTransformation>, Group([ (1,2)
-(3,5)(4,7)(6,10)(8,13)(9,14)(11,12)(15,19)(16,20)(17,22)(18,23)
-(21,24), (1,3,6,11)(2,4,8,14)(5,9,15,20)(7,12,17,23)(10,16,21,22)
-(13,18,24,19) ]), function( a ) ... end )
+(3,5)(4,6)(7,8)(9,11)(10,12)(13,19)(14,20)(15,21)(16,22)(17,23)
+(18,24), (1,19,17,10)(2,20,18,9)(3,21,14,12)(4,22,13,11)(5,23,16,7)
+(6,24,15,8) ]), function( h ) ... end )
 gap> IsomorphismPermGroup(HClass(S, S.1));
-Error, can only create isomorphisms of group H-classes
+Error, Semigroups: IsomorphismPermGroup: usage,
+the H-class is not a group,
 
 # greens-generic: PartialOrderOfDClasses, 1/2
 gap> S := AsSemigroup(IsTransformationSemigroup, FullBooleanMatMonoid(3));;

--- a/tst/standard/semiffmat.tst
+++ b/tst/standard/semiffmat.tst
@@ -35,12 +35,7 @@ true
 gap> H := GroupHClass(DClass(S, One(S)));
 <Green's H-class: Matrix(GF(3), [[Z(3)^0, 0*Z(3), 0*Z(3)], 
    [0*Z(3), Z(3)^0, 0*Z(3)], [0*Z(3), 0*Z(3), Z(3)^0]])>
-gap> IsomorphismPermGroup(H); 
-MappingByFunction( <Green's H-class: Matrix(GF(3), [[Z(3)^0, 0*Z(3), 0*Z(3)], 
-   [0*Z(3), Z(3)^0, 0*Z(3)], [0*Z(3), 0*Z(3), Z(3)^0]])>, Group([ (), (10,19)
-(11,20)(12,21)(13,22)(14,23)(15,24)(16,25)(17,26)(18,27), (2,7,10,20,18,5,25,
-21,15,14,17,8,16)(3,4,19,12,23,9,13,11,26,27,24,6,
-22) ]), function( x ) ... end, function( x ) ... end )
+gap> IsomorphismPermGroup(H);;
 
 #E# 
 gap> STOP_TEST("Semigroups package: standard/semiffmat.tst");

--- a/tst/standard/semiffmat.tst
+++ b/tst/standard/semiffmat.tst
@@ -13,5 +13,35 @@ gap> LoadPackage("semigroups", false);;
 #
 gap> SEMIGROUPS.StartTest();
 
+# Issue 210
+gap> x := Matrix(GF(2^2),
+> [[Z(2^2), 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2)],
+>  [Z(2^2), 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2)],
+>  [0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2)],
+>  [0*Z(2), 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2)],
+>  [0*Z(2), 0*Z(2), 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2)],
+>  [0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2)]]);;
+gap> S := Monoid(x, rec(generic := true));
+<monoid of 6x6 matrices over GF(2^2) with 1 generator>
+gap> HasIsFinite(S);
+true
+gap> Size(S);
+7
+
+# Issue 211
+gap> S := FullMatrixSemigroup(3, 3);;
+gap> S := Semigroup(S, rec(generic := false));; #FIXME remove generic := false
+gap> One(S) in S;
+true
+gap> H := GroupHClass(DClass(S, One(S)));
+<Green's H-class: Matrix(GF(3), [[Z(3)^0, 0*Z(3), 0*Z(3)], 
+   [0*Z(3), Z(3)^0, 0*Z(3)], [0*Z(3), 0*Z(3), Z(3)^0]])>
+gap> IsomorphismPermGroup(H); 
+MappingByFunction( <Green's H-class: Matrix(GF(3), [[Z(3)^0, 0*Z(3), 0*Z(3)], 
+   [0*Z(3), Z(3)^0, 0*Z(3)], [0*Z(3), 0*Z(3), Z(3)^0]])>, Group([ (), (10,19)
+(11,20)(12,21)(13,22)(14,23)(15,24)(16,25)(17,26)(18,27), (2,7,10,20,18,5,25,
+21,15,14,17,8,16)(3,4,19,12,23,9,13,11,26,27,24,6,
+22) ]), function( x ) ... end, function( x ) ... end )
+
 #E# 
 gap> STOP_TEST("Semigroups package: standard/semiffmat.tst");

--- a/tst/standard/semiffmat.tst
+++ b/tst/standard/semiffmat.tst
@@ -30,7 +30,6 @@ gap> Size(S);
 
 # Issue 211
 gap> S := FullMatrixSemigroup(3, 3);;
-gap> S := Semigroup(S, rec(generic := false));; #FIXME remove generic := false
 gap> One(S) in S;
 true
 gap> H := GroupHClass(DClass(S, One(S)));

--- a/tst/standard/semirms.tst
+++ b/tst/standard/semirms.tst
@@ -1325,7 +1325,7 @@ true
 gap> S := DihedralGroup(IsPermGroup, 4);
 Group([ (1,2), (3,4) ])
 gap> T := AsSemigroup(IsReesMatrixSemigroup, S);
-<Rees matrix semigroup 1x1 over Group([ (1,3)(2,4), (1,4)(2,3) ])>
+<Rees matrix semigroup 1x1 over Group([ (1,3)(2,4), (1,2)(3,4) ])>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);
@@ -1347,7 +1347,7 @@ true
 gap> S := DihedralGroup(4);
 <pc group of size 4 with 2 generators>
 gap> T := AsSemigroup(IsReesMatrixSemigroup, S);
-<Rees matrix semigroup 1x1 over Group([ (1,3)(2,4), (1,4)(2,3) ])>
+<Rees matrix semigroup 1x1 over Group([ (1,2)(3,4), (1,3)(2,4) ])>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);


### PR DESCRIPTION
Remove unused hash functions, fix hash functions for matrices and row bases,
make sure that IsMatrixSemigroup implies IsFinite (since IsMatrixSemigroup =
IsMatrixOverFiniteFieldSemigroup), add some tests.

Resolves Issues #210 and #211.