### PR TITLE
Re-order the types of a maximal subsemigroup

### DIFF
--- a/doc/z-chap15.xml
+++ b/doc/z-chap15.xml
@@ -148,8 +148,8 @@
     <Enum>
       <Item><C>{0};</C></Item>
       <Item>formed by removing <C>0</C>;</Item>
-      <Item>formed by removing a row (a non-zero &R;-class);</Item>
       <Item>formed by removing a column (a non-zero &L;-class);</Item>
+      <Item>formed by removing a row (a non-zero &R;-class);</Item>
       <Item>formed by removing a set of both rows and columns;</Item>
       <Item>isomorphic to a Rees (0-)matrix semigroup of the same dimensions over
         a maximal subgroup of <C>G</C> (in particular, the maximal subsemigroup

--- a/gap/attributes/maximal.gi
+++ b/gap/attributes/maximal.gi
@@ -215,9 +215,47 @@ function(R, opts)
   out := [];
   tot := 0;
 
+  # Maximal subsemigroups equal to I x G x L', where L' = L \ {l} for some l
+  # These are the maximal subsemigroups of R of type (iv)
+  if type[3] then
+    Info(InfoSemigroups, 2, "Type 4: looking for maximal subsemigroups ",
+                            "formed by discarding a column...");
+    if L > 1 then
+      lookup_cols := EmptyPlist(Maximum(cols));
+      for i in [1 .. L] do
+        lookup_cols[cols[i]] := i;
+      od;
+      remove := BlistList(Columns(R), Columns(R));
+      i := 0;
+      while i < Length(contain) and SizeBlist(remove) > 0 do
+        i := i + 1;
+        x := contain[i];
+        remove[lookup_cols[x![3]]] := false;
+      od;
+      n := SizeBlist(remove);
+    fi;
+    if L > 1 and n > 0 then
+      Info(InfoSemigroups, 2, "...found ", n, " result(s).");
+      tot := tot + n;
+      if not opts.number then
+        Info(InfoSemigroups, 2, "...creating these maximal subsemigroups.");
+        for l in ListBlist(cols, remove) do
+          x := Difference(cols, [l]);
+          x := ReesMatrixSubsemigroupNC(R, rows, G, x);
+          if opts.gens then
+            x := GeneratorsOfSemigroup(x);
+          fi;
+          Add(out, x);
+        od;
+      fi;
+    else
+      Info(InfoSemigroups, 2, "...found none.");
+    fi;
+  fi;
+
   # Maximal subsemigroups equal to I' x G x L, where I' = I \ {i} for some i
   # These are the maximal subsemigroups of R of type (iii)
-  if type[3] then
+  if type[4] then
     Info(InfoSemigroups, 2, "Type 3: looking for maximal subsemigroups ",
                             "formed by discarding a row...");
     if I > 1 then
@@ -243,44 +281,6 @@ function(R, opts)
         for i in ListBlist(rows, remove) do
           x := Difference(rows, [i]);
           x := ReesMatrixSubsemigroupNC(R, x, G, cols);
-          if opts.gens then
-            x := GeneratorsOfSemigroup(x);
-          fi;
-          Add(out, x);
-        od;
-      fi;
-    else
-      Info(InfoSemigroups, 2, "...found none.");
-    fi;
-  fi;
-
-  # Maximal subsemigroups equal to I x G x L', where L' = L \ {l} for some l
-  # These are the maximal subsemigroups of R of type (iv)
-  if type[4] then
-    Info(InfoSemigroups, 2, "Type 4: looking for maximal subsemigroups ",
-                            "formed by discarding a column...");
-    if L > 1 then
-      lookup_cols := EmptyPlist(Maximum(cols));
-      for i in [1 .. L] do
-        lookup_cols[cols[i]] := i;
-      od;
-      remove := BlistList(Columns(R), Columns(R));
-      i := 0;
-      while i < Length(contain) and SizeBlist(remove) > 0 do
-        i := i + 1;
-        x := contain[i];
-        remove[lookup_cols[x![3]]] := false;
-      od;
-      n := SizeBlist(remove);
-    fi;
-    if L > 1 and n > 0 then
-      Info(InfoSemigroups, 2, "...found ", n, " result(s).");
-      tot := tot + n;
-      if not opts.number then
-        Info(InfoSemigroups, 2, "...creating these maximal subsemigroups.");
-        for l in ListBlist(cols, remove) do
-          x := Difference(cols, [l]);
-          x := ReesMatrixSubsemigroupNC(R, rows, G, x);
           if opts.gens then
             x := GeneratorsOfSemigroup(x);
           fi;

--- a/tst/extreme/maximal.tst
+++ b/tst/extreme/maximal.tst
@@ -54,11 +54,11 @@ gap> mat := [[(), (1, 2), (1, 2)(3, 4)], [(), (1, 2), ()]];;
 gap> R := ReesMatrixSemigroup(G, mat); # 3x2 RMS over C2 x C2
 <Rees matrix semigroup 3x2 over Group([ (1,2), (3,4) ])>
 gap> max := MaximalSubsemigroups(R);
-[ <Rees matrix semigroup 2x2 over Group([ (1,2), (3,4) ])>, 
+[ <Rees matrix semigroup 3x1 over Group([ (1,2), (3,4) ])>, 
+  <Rees matrix semigroup 3x1 over Group([ (1,2), (3,4) ])>, 
   <Rees matrix semigroup 2x2 over Group([ (1,2), (3,4) ])>, 
   <Rees matrix semigroup 2x2 over Group([ (1,2), (3,4) ])>, 
-  <Rees matrix semigroup 3x1 over Group([ (1,2), (3,4) ])>, 
-  <Rees matrix semigroup 3x1 over Group([ (1,2), (3,4) ])>, 
+  <Rees matrix semigroup 2x2 over Group([ (1,2), (3,4) ])>, 
   <subsemigroup of 3x2 Rees matrix semigroup with 3 generators> ]
 gap> NrMaximalSubsemigroups(R);
 6
@@ -68,21 +68,21 @@ gap> mat := [[(), (1, 2, 3)], [(), (1, 2, 3)]];;
 gap> R := ReesMatrixSemigroup(G, mat); # 2x2 RMS over C3
 <Rees matrix semigroup 2x2 over Group([ (1,2,3) ])>
 gap> max := MaximalSubsemigroups(R);
-[ <Rees matrix semigroup 1x2 over Group([ (1,2,3) ])>, 
+[ <Rees matrix semigroup 2x1 over Group([ (1,2,3) ])>, 
+  <Rees matrix semigroup 2x1 over Group([ (1,2,3) ])>, 
   <Rees matrix semigroup 1x2 over Group([ (1,2,3) ])>, 
-  <Rees matrix semigroup 2x1 over Group([ (1,2,3) ])>, 
-  <Rees matrix semigroup 2x1 over Group([ (1,2,3) ])>, 
+  <Rees matrix semigroup 1x2 over Group([ (1,2,3) ])>, 
   <subsemigroup of 2x2 Rees matrix semigroup with 2 generators> ]
 gap> G := Group([(1, 2, 3), (1, 2)]);;
 gap> mat := [[(), (1, 3, 2)], [(1, 3), (2, 3)], [(1, 2, 3), ()]];;
 gap> R := ReesMatrixSemigroup(G, mat); # 2x3 RMS over Sym(3)
 <Rees matrix semigroup 2x3 over Group([ (1,2,3), (1,2) ])>
 gap> max := MaximalSubsemigroups(R);
-[ <Rees matrix semigroup 1x3 over Group([ (1,2,3), (1,2) ])>, 
+[ <Rees matrix semigroup 2x2 over Group([ (1,2,3), (1,2) ])>, 
+  <Rees matrix semigroup 2x2 over Group([ (1,2,3), (1,2) ])>, 
+  <Rees matrix semigroup 2x2 over Group([ (1,2,3), (1,2) ])>, 
   <Rees matrix semigroup 1x3 over Group([ (1,2,3), (1,2) ])>, 
-  <Rees matrix semigroup 2x2 over Group([ (1,2,3), (1,2) ])>, 
-  <Rees matrix semigroup 2x2 over Group([ (1,2,3), (1,2) ])>, 
-  <Rees matrix semigroup 2x2 over Group([ (1,2,3), (1,2) ])>, 
+  <Rees matrix semigroup 1x3 over Group([ (1,2,3), (1,2) ])>, 
   <subsemigroup of 2x3 Rees matrix semigroup with 3 generators> ]
 gap> S := max[6]; # a non-RMS subsemigroup of an RMS
 <subsemigroup of 2x3 Rees matrix semigroup with 3 generators>

--- a/tst/standard/maximal.tst
+++ b/tst/standard/maximal.tst
@@ -176,10 +176,10 @@ gap> MaximalSubsemigroups(R);
 gap> R := ReesMatrixSemigroup(SymmetricGroup(3), [[(), ()], [(), ()]]);
 <Rees matrix semigroup 2x2 over Sym( [ 1 .. 3 ] )>
 gap> MaximalSubsemigroups(R);
-[ <Rees matrix semigroup 1x2 over Sym( [ 1 .. 3 ] )>, 
+[ <Rees matrix semigroup 2x1 over Sym( [ 1 .. 3 ] )>, 
+  <Rees matrix semigroup 2x1 over Sym( [ 1 .. 3 ] )>, 
   <Rees matrix semigroup 1x2 over Sym( [ 1 .. 3 ] )>, 
-  <Rees matrix semigroup 2x1 over Sym( [ 1 .. 3 ] )>, 
-  <Rees matrix semigroup 2x1 over Sym( [ 1 .. 3 ] )>, 
+  <Rees matrix semigroup 1x2 over Sym( [ 1 .. 3 ] )>, 
   <subsemigroup of 2x2 Rees matrix semigroup with 2 generators>, 
   <subsemigroup of 2x2 Rees matrix semigroup with 2 generators>, 
   <subsemigroup of 2x2 Rees matrix semigroup with 2 generators>, 
@@ -231,10 +231,10 @@ gap> MaximalSubsemigroups(R, rec(types := [6]));
 gap> R := ReesMatrixSemigroup(SymmetricGroup(2), [[(), (1, 2)], [(), (1, 2)]]);
 <Rees matrix semigroup 2x2 over Sym( [ 1 .. 2 ] )>
 gap> MaximalSubsemigroups(R, rec(D := DClasses(R)[1])); # <opts.D> is specified
-[ <Rees matrix semigroup 1x2 over Sym( [ 1 .. 2 ] )>, 
+[ <Rees matrix semigroup 2x1 over Sym( [ 1 .. 2 ] )>, 
+  <Rees matrix semigroup 2x1 over Sym( [ 1 .. 2 ] )>, 
   <Rees matrix semigroup 1x2 over Sym( [ 1 .. 2 ] )>, 
-  <Rees matrix semigroup 2x1 over Sym( [ 1 .. 2 ] )>, 
-  <Rees matrix semigroup 2x1 over Sym( [ 1 .. 2 ] )>, 
+  <Rees matrix semigroup 1x2 over Sym( [ 1 .. 2 ] )>, 
   <subsemigroup of 2x2 Rees matrix semigroup with 2 generators> ]
 gap> MaximalSubsemigroups(R, rec(types := [6])); # <opts.types> is specified
 [ <subsemigroup of 2x2 Rees matrix semigroup with 2 generators> ]
@@ -242,8 +242,8 @@ gap> x := [RMSElement(R, 1, (), 1),
 >          RMSElement(R, 1, (1, 2), 1)];
 [ (1,(),1), (1,(1,2),1) ]
 gap> MaximalSubsemigroups(R, rec(contain := x)); # <opts.contain> is specified
-[ <Rees matrix semigroup 1x2 over Sym( [ 1 .. 2 ] )>, 
-  <Rees matrix semigroup 2x1 over Sym( [ 1 .. 2 ] )> ]
+[ <Rees matrix semigroup 2x1 over Sym( [ 1 .. 2 ] )>, 
+  <Rees matrix semigroup 1x2 over Sym( [ 1 .. 2 ] )> ]
 gap> Add(x, RMSElement(R, 1, (), 2));
 gap> MaximalSubsemigroups(R, rec(contain := x));
 [ <Rees matrix semigroup 1x2 over Sym( [ 1 .. 2 ] )> ]
@@ -261,13 +261,13 @@ gap> NrMaximalSubsemigroups(R);
 gap> Length(MaximalSubsemigroupsNC(R, rec()));
 7
 gap> MaximalSubsemigroups(R, rec(contain := [RMSElement(R, 1, (1, 2), 1)]));
-[ <Rees matrix semigroup 1x2 over Group([ (1,2), (3,4) ])>, 
-  <Rees matrix semigroup 2x1 over Group([ (1,2), (3,4) ])>, 
+[ <Rees matrix semigroup 2x1 over Group([ (1,2), (3,4) ])>, 
+  <Rees matrix semigroup 1x2 over Group([ (1,2), (3,4) ])>, 
   <subsemigroup of 2x2 Rees matrix semigroup with 2 generators> ]
 gap> MaximalSubsemigroups(R, rec(contain := [RMSElement(R, 1, (1, 2), 1)],
 >                                gens := true));
-[ [ (1,(1,2),1), (1,(3,4),1), (1,(),2) ], 
-  [ (1,(1,2),1), (1,(3,4),1), (2,(),1) ], [ (1,(1,2),1), (2,(),2) ] ]
+[ [ (1,(1,2),1), (1,(3,4),1), (2,(),1) ], 
+  [ (1,(1,2),1), (1,(3,4),1), (1,(),2) ], [ (1,(1,2),1), (2,(),2) ] ]
 
 #T# maximal: MaximalSubsemigroups, for a Rees matrix subsemigroup, 1
 
@@ -306,11 +306,11 @@ gap> R := ReesMatrixSemigroup(Group((1, 2)),
 gap> U := ReesMatrixSubsemigroup(R, [2, 3], Group((1, 2)), [2 .. 4]);
 <Rees matrix semigroup 2x3 over Group([ (1,2) ])>
 gap> MaximalSubsemigroups(U);
-[ <Rees matrix semigroup 1x3 over Group([ (1,2) ])>, 
+[ <Rees matrix semigroup 2x2 over Group([ (1,2) ])>, 
+  <Rees matrix semigroup 2x2 over Group([ (1,2) ])>, 
+  <Rees matrix semigroup 2x2 over Group([ (1,2) ])>, 
   <Rees matrix semigroup 1x3 over Group([ (1,2) ])>, 
-  <Rees matrix semigroup 2x2 over Group([ (1,2) ])>, 
-  <Rees matrix semigroup 2x2 over Group([ (1,2) ])>, 
-  <Rees matrix semigroup 2x2 over Group([ (1,2) ])>, 
+  <Rees matrix semigroup 1x3 over Group([ (1,2) ])>, 
   <subsemigroup of 3x4 Rees matrix semigroup with 3 generators> ]
 
 #T# maximal: MaximalSubsemigroups, for a Rees 0-matrix semigroup, 1


### PR DESCRIPTION
The maximal subsemigroups of a regular Rees 0-matrix semigroup
over a group are described as one of 6 possible types. I have updated
the ordering in the documentation, and consequently the code, so that
the ordering agrees with the ordering as they are described in the paper
by DMW (Donoven, Mitchell, Wilson).