### PR TITLE
Add EquivalenceRelationPartition method for finite congruences by generating pairs rep

### DIFF
--- a/gap/congruences/congpairs.gi
+++ b/gap/congruences/congpairs.gi
@@ -52,6 +52,20 @@ function(cong)
   return out;
 end);
 
+InstallMethod(EquivalenceRelationPartition,
+"for a finite semigroup congruence by generating pairs rep",
+[IsFiniteCongruenceByGeneratingPairsRep],
+function(cong)
+  local part, data, out, class;
+  part := FiniteCongruenceByGeneratingPairsPartition(cong);
+  data := GenericSemigroupData(Range(cong));
+  out := [];
+  for class in part do
+    Add(out, List(class, i -> SEMIGROUP_ELEMENT_NUMBER(data, i)));
+  od;
+  return out;
+end);
+
 InstallMethod(FiniteCongruenceByGeneratingPairsPartition,
 "for a finite semigroup congruence by generating pairs rep",
 [IsFiniteCongruenceByGeneratingPairsRep], 

--- a/tst/standard/congpairs.tst
+++ b/tst/standard/congpairs.tst
@@ -502,6 +502,29 @@ gap> cong := SemigroupCongruence(S, [S.1, S.1 * S.2]);
 gap> [S.1, S.1] in cong;
 true
 
+#T# EquivalenceRelationPartition
+gap> S := PartialBrauerMonoid(2);;
+gap> pair := [[Bipartition([[1, 2], [-1], [-2]]),
+>              Bipartition([[1, -1], [2], [-2]])]];;
+gap> cong := SemigroupCongruence(S, pair);;
+gap> EquivalenceRelationPartition(cong);
+[ [ <block bijection: [ 1, -1 ], [ 2, -2 ]> ], 
+  [ <block bijection: [ 1, -2 ], [ 2, -1 ]> ], 
+  [ <bipartition: [ 1, 2 ], [ -1, -2 ]>, 
+      <bipartition: [ 1 ], [ 2 ], [ -1, -2 ]> ], 
+  [ <bipartition: [ 1, -1 ], [ 2 ], [ -2 ]>, 
+      <bipartition: [ 1 ], [ 2, -1 ], [ -2 ]>, 
+      <bipartition: [ 1, 2 ], [ -1 ], [ -2 ]>, 
+      <bipartition: [ 1, -2 ], [ 2 ], [ -1 ]>, 
+      <bipartition: [ 1 ], [ 2, -2 ], [ -1 ]>, 
+      <bipartition: [ 1 ], [ 2 ], [ -1 ], [ -2 ]> ] ]
+gap> cong := SemigroupCongruence(S, []);;
+gap> SortedList(EquivalenceRelationPartition(cong)) = List(Elements(S), x->[x]);
+true
+gap> cong := UniversalSemigroupCongruence(S);;
+gap> Length(EquivalenceRelationPartition(cong)) = 1;
+true
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(S);
 gap> Unbind(T);


### PR DESCRIPTION
Such a method didn't exist, and GAP was using a crazy method from the library to calculate the information.