### PR TITLE
Add a reasonable ViewObj method for quotient semigroups

### DIFF
--- a/gap/congruences/quotients.gi
+++ b/gap/congruences/quotients.gi
@@ -1,12 +1,20 @@
 #############################################################################
 ##
 #W  congruences/quotients.gi
-#Y  Copyright (C) 2014-15                                James D. Mitchell
+#Y  Copyright (C) 2014-16                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
 #############################################################################
 ##
+
+InstallMethod(ViewObj, "for a quotient semigroup",
+[IsQuotientSemigroup],
+function(S)
+  Print( "<quotient of ");
+  ViewObj(QuotientSemigroupCongruence(S));
+  Print(">");
+end);
 
 InstallMethod(OneImmutable, "for a quotient semigroup",
 [IsQuotientSemigroup],

--- a/tst/standard/quotients.tst
+++ b/tst/standard/quotients.tst
@@ -74,12 +74,31 @@ gap> T.1 * GreensRClasses(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 3rd choice method found for `*' on 2 arguments
 
+#T# quotients, ViewObj
+gap> S := Semigroup([Transformation([2, 3, 2]), Transformation([3, 1, 3])]);;
+gap> pair := [Transformation([3, 2, 3]), Transformation([1, 1, 1])];;
+gap> cong := SemigroupCongruence(S, [pair]);
+<semigroup congruence over <transformation semigroup of degree 3 with 2 
+ generators> with 1 generating pairs>
+gap> Q := S / cong;
+<quotient of <semigroup congruence over <transformation semigroup of degree 3 
+ with 2 generators> with 1 generating pairs>>
+gap> I := MinimalIdeal(S);
+<simple transformation semigroup ideal of degree 3 with 1 generator>
+gap> R := S / I;
+<quotient of <Rees congruence of <simple transformation semigroup ideal of 
+ degree 3 with 1 generator> over <transformation semigroup of degree 3 with 2 
+generators>>>
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(I);
 gap> Unbind(J);
+gap> Unbind(Q);
+gap> Unbind(R);
 gap> Unbind(S);
 gap> Unbind(T);
 gap> Unbind(cong);
+gap> Unbind(pair);
 
 #E#
 gap> STOP_TEST("Semigroups package: standard/quotients.tst");

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -705,22 +705,12 @@ gap> S := Monoid(
 >  Transformation([2, 2, 1, 3]), Transformation([1, 2, 2, 3]),
 >  Transformation([2, 4, 3, 2]), Transformation([2, 3, 3, 3]));;
 gap> I := SemigroupIdeal(S, S.3);;
+gap> IsRegularSemigroup(I);
+true
 gap> S / I;
-<quotient of Monoid( [ Transformation( [ 3, 3, 3, 3 ] ), 
-  Transformation( [ 2, 4, 2, 4 ] ), Transformation( [ 2, 3, 2, 3 ] ), 
-  Transformation( [ 4, 1, 4, 3 ] ), Transformation( [ 1, 4, 4, 1 ] ), 
-  Transformation( [ 2, 2, 3, 1 ] ), Transformation( [ 2, 4, 3, 4 ] ), 
-  Transformation( [ 2, 2, 1, 2 ] ), Transformation( [ 2, 2, 1, 3 ] ), 
-  Transformation( [ 1, 2, 2, 3 ] ), Transformation( [ 2, 4, 3, 2 ] ), 
-  Transformation( [ 2, 3, 3, 3 ] ) ] ) by ReesCongruenceOfSemigroupIdeal( 
-SemigroupIdeal( 
- Monoid( 
-  [ Transformation( [ 3, 3, 3, 3 ] ), Transformation( [ 2, 4, 2, 4 ] ), Transf\
-ormation( [ 2, 3, 2, 3 ] ), Transformation( [ 4, 1, 4, 3 ] ), Transformation( \
-[ 1, 4, 4, 1 ] ), Transformation( [ 2, 2, 3, 1 ] ), Transformation( [ 2, 4, 3,\
- 4 ] ), Transformation( [ 2, 2, 1, 2 ] ), Transformation( [ 2, 2, 1, 3 ] ), Tr\
-ansformation( [ 1, 2, 2, 3 ] ), Transformation( [ 2, 4, 3, 2 ] ), Transformati\
-on( [ 2, 3, 3, 3 ] ) ] ), [ Transformation( [ 2, 3, 2, 3 ] ) ] ) )>
+<quotient of <Rees congruence of <regular transformation semigroup ideal of 
+ degree 4 with 1 generator> over <transformation monoid of degree 4 with 12 
+generators>>>
 
 #T# TestInstall43: Issue 89
 gap> S := Semigroup(Transformation([2, 1, 3, 1, 4, 3]),


### PR DESCRIPTION
The current library method uses `Print` on the congruence and the semigroup, meaning that it regurgitates all the generating pairs and semigroup generators all over the screen, which creates an unreadable mess.

This method uses `ViewObj` on the congruence, giving something like
```
<quotient of <semigroup congruence over <transformation semigroup of degree 3 with 2 generators> with 1 generating pairs>>
```
which is much more readable.

Note that we also don't display the parent semigroup in the form "<quotient of `S` by `cong`>" but rather only "<quotient of `cong`>", since the `ViewObj` method for a congruence specifies what semigroup it's defined over anyway, and we don't want the semigroup printed twice.