### PR TITLE
Fix issue #227: congruence manual examples failing

### DIFF
--- a/doc/reesmat-cong.xml
+++ b/doc/reesmat-cong.xml
@@ -282,8 +282,8 @@ gap> Size(classes);
     <Example><![CDATA[
 gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3), 
 > [[(),(1,3,2)],[(1,2),0]]);;
-gap> congs := CongruencesOfSemigroup(S);;
-gap> MeetSemigroupCongruences(congs[2], congs[3]);
+gap> congs := Set(CongruencesOfSemigroup(S));;
+gap> MeetSemigroupCongruences(congs[1], congs[3]);
 <semigroup congruence over <Rees 0-matrix semigroup 2x2 over 
   Sym( [ 1 .. 3 ] )> with linked triple (1,2,2)>]]></Example>
   </Description>
@@ -303,8 +303,8 @@ gap> MeetSemigroupCongruences(congs[2], congs[3]);
     <Example><![CDATA[
 gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3), 
 > [[(),(1,3,2)],[(1,2),0]]);;
-gap> congs := CongruencesOfSemigroup(S);;
-gap> JoinSemigroupCongruences(congs[2], congs[3]);
+gap> congs := Set(CongruencesOfSemigroup(S));;
+gap> JoinSemigroupCongruences(congs[1], congs[3]);
 <semigroup congruence over <Rees 0-matrix semigroup 2x2 over 
   Sym( [ 1 .. 3 ] )> with linked triple (3,2,2)>]]></Example>
   </Description>

--- a/doc/simple-cong.xml
+++ b/doc/simple-cong.xml
@@ -52,15 +52,19 @@ gap> SemigroupCongruence(S, pair1, pair2);
       <Example><![CDATA[
 gap> s := ReesZeroMatrixSemigroup(SymmetricGroup(3), 
 > [[(),(1,3,2)],[(1,2),0]]);;
-gap> congs := CongruencesOfSemigroup(s);
-[ <universal semigroup congruence over 
-    <Rees 0-matrix semigroup 2x2 over Sym( [ 1 .. 3 ] )>>, 
-  <semigroup congruence over <Rees 0-matrix semigroup 2x2 over 
-      Sym( [ 1 .. 3 ] )> with linked triple (1,2,2)>, 
-  <semigroup congruence over <Rees 0-matrix semigroup 2x2 over 
-      Sym( [ 1 .. 3 ] )> with linked triple (3,2,2)>, 
-  <semigroup congruence over <Rees 0-matrix semigroup 2x2 over 
-      Sym( [ 1 .. 3 ] )> with linked triple (S3,2,2)> ]]]></Example>
+gap> StructureDescription(UnderlyingSemigroup(s));
+"S3"
+gap> congs := CongruencesOfSemigroup(s);;
+gap> Set(congs);
+[ <semigroup congruence over <Rees 0-matrix semigroup 2x2 over S3>
+      with linked triple (1,2,2)>, 
+  <semigroup congruence over <Rees 0-matrix semigroup 2x2 over S3>
+      with linked triple (S3,2,2)>, 
+  <semigroup congruence over <Rees 0-matrix semigroup 2x2 over S3>
+      with linked triple (3,2,2)>, 
+  <universal semigroup congruence over 
+    <Rees 0-matrix semigroup 2x2 over S3>> ]
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>


### PR DESCRIPTION
This issue was caused by a change in the order of the list given by `CongruencesOfSemigroup` for a Rees matrix semigroup.  As such, it was a harmless diff, and I've modified the tests so that they don't rely on ordering.
