### PR TITLE
Fix broken conginv.tst

### DIFF
--- a/gap/congruences/conginv.gi
+++ b/gap/congruences/conginv.gi
@@ -472,7 +472,7 @@ SEMIGROUPS.KernelTraceClosure := function(S, kernel, traceBlocks, pairstoapply)
   # "traceBlocks" in its trace, and containing all the given pairs
   # TODO Review this JDM for use of Elements, AsList etc. Could iterators work
   # better?
-  local idsmgp, idsdata, idslist, slist, kernelgenstoapply, gen, nrk, nr,
+  local idsmgp, idslist, slist, kernelgenstoapply, gen, nrk, nr,
         traceUF, i, pos1, j, pos, hashlen, ht, treehashsize, right, genstoapply,
         NormalClosureInverseSemigroup, enumerate_trace, enforce_conditions,
         compute_kernel, oldLookup, oldKernel, trace_unchanged, kernel_unchanged;
@@ -490,16 +490,16 @@ SEMIGROUPS.KernelTraceClosure := function(S, kernel, traceBlocks, pairstoapply)
   od;
   nrk := Length(kernelgenstoapply);
   Elements(kernel);
-  pairstoapply := List(pairstoapply, x -> [Position(idsdata, RightOne(x[1])),
-                                           Position(idsdata, RightOne(x[2]))]);
+  pairstoapply := List(pairstoapply, x -> [Position(idsmgp, RightOne(x[1])),
+                                           Position(idsmgp, RightOne(x[2]))]);
   nr := Length(pairstoapply);
 
   # Calculate traceUF from traceBlocks
   traceUF := UF_NEW(Length(idslist));
   for i in [1 .. Length(traceBlocks)] do
-    pos1 := Position(idsdata, traceBlocks[i][1]);
+    pos1 := Position(idsmgp, traceBlocks[i][1]);
     for j in [2 .. Length(traceBlocks[i])] do
-      UF_UNION(traceUF, [pos1, Position(idsdata, traceBlocks[i][j])]);
+      UF_UNION(traceUF, [pos1, Position(idsmgp, traceBlocks[i][j])]);
     od;
   od;
   UF_FLATTEN(traceUF);
@@ -549,8 +549,8 @@ SEMIGROUPS.KernelTraceClosure := function(S, kernel, traceBlocks, pairstoapply)
           UF_UNION(traceUF, x);
           # Add each pair's "conjugate" pairs
           for a in GeneratorsOfSemigroup(S) do
-            z := [Position(idsdata, a ^ -1 * idslist[x[1]] * a),
-                  Position(idsdata, a ^ -1 * idslist[x[2]] * a)];
+            z := [Position(idsmgp, a ^ -1 * idslist[x[1]] * a),
+                  Position(idsmgp, a ^ -1 * idslist[x[2]] * a)];
             if z[1] <> z[2] and HTValue(ht, z) = fail then
               HTAdd(ht, z, true);
               nr := nr + 1;
@@ -575,8 +575,8 @@ SEMIGROUPS.KernelTraceClosure := function(S, kernel, traceBlocks, pairstoapply)
           UF_UNION(traceUF, y);
           # Add the pair's "conjugate" pairs
           for a in GeneratorsOfSemigroup(S) do
-            z := [Position(idsdata, a ^ -1 * idslist[x[1]] * a),
-                  Position(idsdata, a ^ -1 * idslist[x[2]] * a)];
+            z := [Position(idsmgp, a ^ -1 * idslist[x[1]] * a),
+                  Position(idsmgp, a ^ -1 * idslist[x[2]] * a)];
             if z[1] <> z[2] and HTValue(ht, z) = fail then
               HTAdd(ht, z, true);
               nr := nr + 1;
@@ -596,14 +596,14 @@ SEMIGROUPS.KernelTraceClosure := function(S, kernel, traceBlocks, pairstoapply)
     traceBlocks := UF_BLOCKS(traceUF);
     for a in slist do
       if a in kernel then
-        e := Position(idsdata, LeftOne(a));
-        f := Position(idsdata, RightOne(a));
+        e := Position(idsmgp, LeftOne(a));
+        f := Position(idsmgp, RightOne(a));
         if traceTable[e] <> traceTable[f] then
           nr := nr + 1;
           pairstoapply[nr] := [e, f];
         fi;
       else
-        classno := traceTable[Position(idsdata, RightOne(a))];
+        classno := traceTable[Position(idsmgp, RightOne(a))];
         for e in traceBlocks[classno] do
           if a * idslist[e] in kernel then
             nrk := nrk + 1;


### PR DESCRIPTION
The problem was related to the removal of `GenericSemigroupData`.  We used to have `idsdata := GenericSemigroupData(idsmgp)`, and then we'd look up positions in `idsdata`.  Sensibly, we've removed the line where we set `idsdata`, but it was still trying to look things up in it.

I've now removed the variable, and we just look things up **in the semigroup itself**, using `Position(idsmgp, x)` and so on, which I understand is now the way we do things.