### PR TITLE
Add Lookup and CanonicalLookup methods for generic congruences

### DIFF
--- a/doc/cong.xml
+++ b/doc/cong.xml
@@ -392,9 +392,9 @@ gap> CongruencesOfLattice(latt);
     <Attr Name = "EquivalenceRelationLookup" Arg = "cong"/>
     <Returns>A list.</Returns>
     <Description>
-      This attribute describes the semigroup congruence <A>cong</A> as a list
-      of positive integers with length the size of the semigroup over which
-      <A>cong</A> is defined.<P/>
+      This attribute describes the (left, right or two-sided) semigroup
+      congruence <A>cong</A> as a list of positive integers with length the size
+      of the finite semigroup over which <A>cong</A> is defined.<P/>
 
       Each position in the list corresponds to an element of the semigroup (in a
       consistent canonical order) and the integer at that position is a unique
@@ -405,7 +405,9 @@ gap> CongruencesOfLattice(latt);
 
       Note that the order in which numbers appear in the list is
       non-deterministic, and two congruence objects which describe the same
-      equivalence relation might therefore have different lookups.  However, see
+      equivalence relation might therefore have different lookups.  Note also
+      that the maximum value of the list may not be the number of classes of
+      <A>cong</A>, and that any integer might not be included.  However, see
       <Ref Attr = "EquivalenceRelationCanonicalLookup"/>.<P/>
 
       See also <Ref Attr = "EquivalenceRelationPartition" BookName = "ref"/>.
@@ -428,8 +430,8 @@ false]]></Example>
     <Attr Name = "EquivalenceRelationCanonicalLookup" Arg = "cong"/>
     <Returns>A list.</Returns>
     <Description>
-      This attribute describes the semigroup congruence <A>cong</A> as a list
-      of positive integers with length the size of the semigroup over which
+      This attribute describes the semigroup congruence <A>cong</A> as a list of
+      positive integers with length the size of the finite semigroup over which
       <A>cong</A> is defined.<P/>
 
       Each position in the list corresponds to an element of the semigroup (in a
@@ -437,16 +439,18 @@ false]]></Example>
       identifier for that element's congruence class under <A>cong</A>.  The
       value of <C>EquivalenceRelationCanonicalLookup</C> has the property that
       the first appearance of the value <C>i</C> is strictly later than the
-      first appearance of <C>i-1</C>.  As such, two congruences on a given
-      semigroup are equal if and only if their canonical lookups are equal.<P/>
+      first appearance of <C>i-1</C>, and that all entries in the list will be
+      from the range <C>[1 .. NrEquivalenceClasses(<A>cong</A>)]</C>.  As such,
+      two congruences on a given semigroup are equal if and only if their
+      canonical lookups are equal.<P/>
       
       Two elements of the semigroup on which the congruence is defined
       are related in the congruence if and only if they have
       the same number at their respective positions in the lookup.
       <P/>
 
-      See also <Ref Attr = "EquivalenceRelationPartition" BookName = "ref"/> and
-      <Ref Attr = "EquivalenceRelationLookup"/>.
+      See also <Ref Attr = "EquivalenceRelationLookup"/> and
+      <Ref Attr = "EquivalenceRelationPartition" BookName = "ref"/>.
       <Example><![CDATA[
 gap> S := Monoid(Transformation([1, 2, 2]),
 >                Transformation([3, 1, 3]));;

--- a/gap/congruences/cong.gi
+++ b/gap/congruences/cong.gi
@@ -21,9 +21,32 @@
 ## cong.gd contains declarations for many of these.
 ##
 
+InstallMethod(\=, "for two semigroup congruences",
+[IsSemigroupCongruence, IsSemigroupCongruence],
+function(c1, c2)
+  if not IsFinite(Range(c1)) then
+    TryNextMethod();
+  fi;
+  return Range(c1) = Range(c2)
+         and EquivalenceRelationCanonicalLookup(c1) =
+             EquivalenceRelationCanonicalLookup(c2);
+end);
+
+InstallMethod(\=, "for two semigroup congruences with generating pairs",
+[IsSemigroupCongruence and HasGeneratingPairsOfMagmaCongruence,
+ IsSemigroupCongruence and HasGeneratingPairsOfMagmaCongruence],
+function(c1, c2)
+  return Range(c1) = Range(c2)
+         and ForAll(GeneratingPairsOfSemigroupCongruence(c1), p -> p in c2)
+         and ForAll(GeneratingPairsOfSemigroupCongruence(c2), p -> p in c1);
+end);
+
 InstallMethod(\=, "for a left and a right semigroup congruence",
 [IsLeftSemigroupCongruence, IsRightSemigroupCongruence],
 function(c1, c2)
+  if not IsFinite(Range(c1)) then
+    TryNextMethod();
+  fi;
   return Range(c1) = Range(c2)
          and EquivalenceRelationCanonicalLookup(c1) =
              EquivalenceRelationCanonicalLookup(c2);
@@ -32,6 +55,9 @@ end);
 InstallMethod(\=, "for a right and a left semigroup congruence",
 [IsRightSemigroupCongruence, IsLeftSemigroupCongruence],
 function(c1, c2)
+  if not IsFinite(Range(c1)) then
+    TryNextMethod();
+  fi;
   return Range(c1) = Range(c2)
          and EquivalenceRelationCanonicalLookup(c1) =
              EquivalenceRelationCanonicalLookup(c2);
@@ -50,6 +76,14 @@ function(class1, class2)
   return EquivalenceClassOfElementNC(EquivalenceClassRelation(class1),
                                      Representative(class1) *
                                      Representative(class2));
+end);
+
+InstallMethod(\=,
+"for two congruence classes",
+[IsCongruenceClass, IsCongruenceClass],
+function(class1, class2)
+  return EquivalenceClassRelation(class1) = EquivalenceClassRelation(class2)
+         and Representative(class1) in class2;
 end);
 
 InstallMethod(\<,
@@ -143,10 +177,10 @@ function(arg)
       and Parent(arg[2]) = S then
     return ReesCongruenceOfSemigroupIdeal(arg[2]);
   elif Length(arg) = 3
-      and IsInverseSemigroup(arg[2]) 
+      and IsInverseSemigroup(arg[2])
       and IsGeneratorsOfInverseSemigroup(arg[2])
       and IsDenseList(arg[3])
-      and IsInverseSemigroup(S) 
+      and IsInverseSemigroup(S)
       and IsGeneratorsOfInverseSemigroup(S) then
     # We should have the kernel and trace of a congruence on an inverse
     # semigroup
@@ -390,17 +424,69 @@ function(class, elm)
   return EquivalenceClassOfElementNC(cong, Representative(class) * elm);
 end);
 
+SEMIGROUPS.GenericCongLookup := function(cong)
+  local S, lookup, class, nr, elm;
+  S := Range(cong);
+  if not IsFinite(S) then
+    ErrorNoReturn("Semigroups: SEMIGROUPS.GenericCongLookup: usage,\n",
+                  "<cong> must be over a finite semigroup,");
+  fi;
+  lookup := [1 .. Size(S)];
+  for class in NonTrivialEquivalenceClasses(cong) do
+    nr := PositionCanonical(S, Representative(class));
+    for elm in class do
+      lookup[PositionCanonical(S, elm)] := nr;
+    od;
+  od;
+  return lookup;
+end;
+
 InstallMethod(EquivalenceRelationLookup,
 "for a semigroup congruence",
 [IsSemigroupCongruence],
-EquivalenceRelationCanonicalLookup);
+SEMIGROUPS.GenericCongLookup);
 
 InstallMethod(EquivalenceRelationLookup,
 "for a left semigroup congruence",
 [IsLeftSemigroupCongruence],
-EquivalenceRelationCanonicalLookup);
+SEMIGROUPS.GenericCongLookup);
 
 InstallMethod(EquivalenceRelationLookup,
 "for a right semigroup congruence",
 [IsRightSemigroupCongruence],
-EquivalenceRelationCanonicalLookup);
+SEMIGROUPS.GenericCongLookup);
+
+SEMIGROUPS.GenericCongCanonicalLookup := function(cong)
+  local lookup, max, dictionary, next, out, i, new_nr;
+  lookup := EquivalenceRelationLookup(cong);
+  max := Maximum(lookup);
+  # We do not know whether the maximum is NrEquivalenceClasses(cong)
+  dictionary := ListWithIdenticalEntries(max, 0);
+  next := 1;
+  out := EmptyPlist(max);
+  for i in [1 .. Length(lookup)] do
+    new_nr := dictionary[lookup[i]];
+    if new_nr = 0 then
+      dictionary[lookup[i]] := next;
+      new_nr := next;
+      next := next + 1;
+    fi;
+    out[i] := new_nr;
+  od;
+  return out;
+end;
+
+InstallMethod(EquivalenceRelationCanonicalLookup,
+"for a semigroup congruence",
+[IsSemigroupCongruence],
+SEMIGROUPS.GenericCongCanonicalLookup);
+
+InstallMethod(EquivalenceRelationCanonicalLookup,
+"for a left semigroup congruence",
+[IsLeftSemigroupCongruence],
+SEMIGROUPS.GenericCongCanonicalLookup);
+
+InstallMethod(EquivalenceRelationCanonicalLookup,
+"for a right semigroup congruence",
+[IsRightSemigroupCongruence],
+SEMIGROUPS.GenericCongCanonicalLookup);

--- a/gap/congruences/cong.gi
+++ b/gap/congruences/cong.gi
@@ -424,12 +424,15 @@ function(class, elm)
   return EquivalenceClassOfElementNC(cong, Representative(class) * elm);
 end);
 
-SEMIGROUPS.GenericCongLookup := function(cong)
+BindGlobal("_GenericCongLookup",
+function(cong)
   local S, lookup, class, nr, elm;
   S := Range(cong);
   if not IsFinite(S) then
-    ErrorNoReturn("Semigroups: SEMIGROUPS.GenericCongLookup: usage,\n",
+    ErrorNoReturn("Semigroups: EquivalenceRelationLookup: usage,\n",
                   "<cong> must be over a finite semigroup,");
+  elif not IsEnumerableSemigroupRep(S) then
+    TryNextMethod();
   fi;
   lookup := [1 .. Size(S)];
   for class in NonTrivialEquivalenceClasses(cong) do
@@ -439,24 +442,28 @@ SEMIGROUPS.GenericCongLookup := function(cong)
     od;
   od;
   return lookup;
-end;
+end);
 
 InstallMethod(EquivalenceRelationLookup,
 "for a semigroup congruence",
 [IsSemigroupCongruence],
-SEMIGROUPS.GenericCongLookup);
+_GenericCongLookup);
 
 InstallMethod(EquivalenceRelationLookup,
 "for a left semigroup congruence",
 [IsLeftSemigroupCongruence],
-SEMIGROUPS.GenericCongLookup);
+_GenericCongLookup);
 
 InstallMethod(EquivalenceRelationLookup,
 "for a right semigroup congruence",
 [IsRightSemigroupCongruence],
-SEMIGROUPS.GenericCongLookup);
+_GenericCongLookup);
 
-SEMIGROUPS.GenericCongCanonicalLookup := function(cong)
+MakeReadWriteGlobal("_GenericCongLookup");
+Unbind(_GenericCongLookup);
+
+BindGlobal("_GenericCongCanonicalLookup",
+function(cong)
   local lookup, max, dictionary, next, out, i, new_nr;
   lookup := EquivalenceRelationLookup(cong);
   max := Maximum(lookup);
@@ -474,19 +481,22 @@ SEMIGROUPS.GenericCongCanonicalLookup := function(cong)
     out[i] := new_nr;
   od;
   return out;
-end;
+end);
 
 InstallMethod(EquivalenceRelationCanonicalLookup,
 "for a semigroup congruence",
 [IsSemigroupCongruence],
-SEMIGROUPS.GenericCongCanonicalLookup);
+_GenericCongCanonicalLookup);
 
 InstallMethod(EquivalenceRelationCanonicalLookup,
 "for a left semigroup congruence",
 [IsLeftSemigroupCongruence],
-SEMIGROUPS.GenericCongCanonicalLookup);
+_GenericCongCanonicalLookup);
 
 InstallMethod(EquivalenceRelationCanonicalLookup,
 "for a right semigroup congruence",
 [IsRightSemigroupCongruence],
-SEMIGROUPS.GenericCongCanonicalLookup);
+_GenericCongCanonicalLookup);
+
+MakeReadWriteGlobal("_GenericCongCanonicalLookup");
+Unbind(_GenericCongCanonicalLookup);

--- a/gap/congruences/congrees.gi
+++ b/gap/congruences/congrees.gi
@@ -200,6 +200,18 @@ function(cong)
   return classes;
 end);
 
+InstallMethod(NonTrivialEquivalenceClasses,
+"for a Rees congruence",
+[IsReesCongruence],
+function(cong)
+  local I;
+  I := SemigroupIdealOfReesCongruence(cong);
+  if Size(I) = 1 then
+    return [];
+  fi;
+  return [EquivalenceClassOfElementNC(cong, I.1)];
+end);
+
 InstallMethod(EquivalenceClassOfElement,
 "for a Rees congruence and a multiplicative element",
 [IsReesCongruence, IsMultiplicativeElement],

--- a/tst/standard/cong.tst
+++ b/tst/standard/cong.tst
@@ -392,10 +392,10 @@ Error, no 2nd choice method found for `ImagesSet' on 2 arguments
 gap> F := FreeSemigroup(2);;
 gap> cong := ReesCongruenceOfSemigroupIdeal(SemigroupIdeal(F, [F.1]));;
 gap> EquivalenceRelationLookup(cong);
-Error, Semigroups: SEMIGROUPS.GenericCongLookup: usage,
+Error, Semigroups: EquivalenceRelationLookup: usage,
 <cong> must be over a finite semigroup,
 gap> EquivalenceRelationCanonicalLookup(cong);
-Error, Semigroups: SEMIGROUPS.GenericCongLookup: usage,
+Error, Semigroups: EquivalenceRelationLookup: usage,
 <cong> must be over a finite semigroup,
 
 #T# Equality for different types of congruence, both with pairs

--- a/tst/standard/cong.tst
+++ b/tst/standard/cong.tst
@@ -324,10 +324,98 @@ gap> cong2 := SemigroupCongruence(S, pair2);;
 gap> IsSuperrelation(cong1, cong2);
 true
 
+#T# Equality for different types of congruence class
+gap> S := FullTransformationMonoid(4);;
+gap> I := SemigroupIdeal(S, Transformation([1,1,2,2]));;
+gap> reescong := ReesCongruenceOfSemigroupIdeal(I);;
+gap> pair := [Transformation([1, 1, 2, 2]), Transformation([1, 1, 1, 1])];;
+gap> cong := SemigroupCongruence(S, pair);;
+gap> reesclass := EquivalenceClassOfElement(reescong, pair[1]);
+<congruence class of Transformation( [ 1, 1, 2, 2 ] )>
+gap> class := EquivalenceClassOfElement(cong, Transformation([1,1,2,2]));
+<congruence class of Transformation( [ 1, 1, 2, 2 ] )>
+gap> class = reesclass;
+true
+gap> cong := SemigroupCongruence(S, []);;
+gap> class := EquivalenceClassOfElement(cong, Transformation([1,1,2,2]));;
+gap> class = reesclass;
+false
+gap> cong := UniversalSemigroupCongruence(S);;
+gap> class := EquivalenceClassOfElement(cong, Transformation([1,1,2,2]));;
+gap> class = reesclass;
+false
+
+#T# EquivalenceRelation(Canonical)Lookup
+gap> S := FullTransformationMonoid(3);;
+gap> I := SemigroupIdeal(S, Transformation([1, 1, 2]));;
+gap> cong := ReesCongruenceOfSemigroupIdeal(I);;
+gap> EquivalenceRelationLookup(cong);
+[ 1, 2, 3, 11, 5, 6, 11, 8, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 
+  11, 11, 11, 11, 11, 11, 11 ]
+gap> EquivalenceRelationCanonicalLookup(cong);
+[ 1, 2, 3, 4, 5, 6, 4, 7, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 
+  4, 4 ]
+
+# EquivalenceRelationCanonicalLookup with an RMS cong
+gap> S := ReesMatrixSemigroup(SymmetricGroup(3), [[(1,2), ()], [(), (1,3)]]);
+<Rees matrix semigroup 2x2 over Sym( [ 1 .. 3 ] )>
+gap> cong := RMSCongruenceByLinkedTriple(S, Group((1,2,3)),
+>                                        [[1],[2]], [[1,2]]);;
+gap> ccong := AsSemigroupCongruenceByGeneratingPairs(cong);;
+gap> cong := RMSCongruenceByLinkedTriple(S, Group((1,2,3)),
+>                                        [[1],[2]], [[1,2]]);;
+gap> EquivalenceRelationCanonicalLookup(cong);
+[ 1, 2, 3, 1, 2, 2, 2, 1, 1, 3, 4, 4, 2, 1, 1, 2, 3, 4, 4, 4, 3, 3, 3, 4 ]
+gap> EquivalenceRelationCanonicalLookup(ccong);
+[ 1, 2, 3, 1, 2, 2, 2, 1, 1, 3, 4, 4, 2, 1, 1, 2, 3, 4, 4, 4, 3, 3, 3, 4 ]
+gap> cong = ccong;
+true
+
+# Two infinite congruences (will try next method)
+gap> F := FreeSemigroup(2);;
+gap> cong1 := ReesCongruenceOfSemigroupIdeal(SemigroupIdeal(F, [F.1]));;
+gap> cong2 := SemigroupCongruence(F, [F.1, F.1^2]);;
+gap> cong1 = cong2;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `PreImagesSet' on 2 arguments
+gap> F := FreeSemigroup(2);;
+gap> cong1 := LeftSemigroupCongruence(F, [F.1, F.2]);;
+gap> cong2 := RightSemigroupCongruence(F, [F.1, F.2]);;
+gap> cong1 = cong2;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `ImagesSet' on 2 arguments
+gap> cong2 = cong1;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `ImagesSet' on 2 arguments
+
+# EquivalenceRelationLookup with an infinite semigroup
+gap> F := FreeSemigroup(2);;
+gap> cong := ReesCongruenceOfSemigroupIdeal(SemigroupIdeal(F, [F.1]));;
+gap> EquivalenceRelationLookup(cong);
+Error, Semigroups: SEMIGROUPS.GenericCongLookup: usage,
+<cong> must be over a finite semigroup,
+gap> EquivalenceRelationCanonicalLookup(cong);
+Error, Semigroups: SEMIGROUPS.GenericCongLookup: usage,
+<cong> must be over a finite semigroup,
+
+#T# Equality for different types of congruence, both with pairs
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3),
+>                                 [[(1,2), ()], [(), (1,3)]]);;
+gap> cong1 := RMSCongruenceByLinkedTriple(S, Group((1,2,3)),
+>                                         [[1], [2]], [[1, 2]]);;
+gap> ideal := SemigroupIdeal(S, [MultiplicativeZero(S)]);;
+gap> cong2 := ReesCongruenceOfSemigroupIdeal(ideal);;
+gap> GeneratingPairsOfSemigroupCongruence(cong1);;
+gap> GeneratingPairsOfSemigroupCongruence(cong2);;
+gap> cong1 = cong2;
+false
+
 #T# SEMIGROUPS_UnbindVariables
+gap> Unbind(F);
 gap> Unbind(I);
 gap> Unbind(R);
 gap> Unbind(S);
+gap> Unbind(ccong);
 gap> Unbind(class);
 gap> Unbind(class1a);
 gap> Unbind(class1b);
@@ -337,6 +425,7 @@ gap> Unbind(cong);
 gap> Unbind(cong1);
 gap> Unbind(cong2);
 gap> Unbind(elm);
+gap> Unbind(ideal);
 gap> Unbind(iso);
 gap> Unbind(ker);
 gap> Unbind(lcong);
@@ -345,6 +434,8 @@ gap> Unbind(pair1);
 gap> Unbind(pair2);
 gap> Unbind(pairs);
 gap> Unbind(rcong);
+gap> Unbind(reesclass);
+gap> Unbind(reescong);
 gap> Unbind(rmscong);
 gap> Unbind(trc);
 gap> Unbind(x);

--- a/tst/standard/congpairs.tst
+++ b/tst/standard/congpairs.tst
@@ -32,7 +32,7 @@ gap> gens in cong;
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `in' on 2 arguments
 gap> EquivalenceRelationLookup(cong);
-Error, Semigroups: SEMIGROUPS.GenericCongLookup: usage,
+Error, Semigroups: EquivalenceRelationLookup: usage,
 <cong> must be over a finite semigroup,
 gap> NrCongruenceClasses(cong);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound

--- a/tst/standard/congpairs.tst
+++ b/tst/standard/congpairs.tst
@@ -32,9 +32,8 @@ gap> gens in cong;
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `in' on 2 arguments
 gap> EquivalenceRelationLookup(cong);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `EquivalenceRelationCanonicalLookup' on \
-1 arguments
+Error, Semigroups: SEMIGROUPS.GenericCongLookup: usage,
+<cong> must be over a finite semigroup,
 gap> NrCongruenceClasses(cong);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 2nd choice method found for `NrEquivalenceClasses' on 1 arguments

--- a/tst/standard/congrees.tst
+++ b/tst/standard/congrees.tst
@@ -241,6 +241,27 @@ gap> IsSubrelation(c4, c1);
 Error, Semigroups: IsSubrelation: usage,
 congruences must be defined over the same semigroup,
 
+#T# EquivalenceRelation(Canonical)Lookup
+gap> S := FullTransformationMonoid(3);;
+gap> I := SemigroupIdeal(S, Transformation([1, 1, 2]));;
+gap> cong := ReesCongruenceOfSemigroupIdeal(I);
+<Rees congruence of <regular transformation semigroup ideal of degree 3 with
+  1 generator> over <full transformation monoid of degree 3>>
+gap> EquivalenceRelationLookup(cong);
+[ 1, 2, 3, 11, 5, 6, 11, 8, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 
+  11, 11, 11, 11, 11, 11, 11 ]
+gap> EquivalenceRelationCanonicalLookup(cong);
+[ 1, 2, 3, 4, 5, 6, 4, 7, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 
+  4, 4 ]
+
+#T# Trivial congruence as Rees
+gap> S := SymmetricInverseMonoid(3);;
+gap> cong := ReesCongruenceOfSemigroupIdeal(MinimalIdeal(S));;
+gap> EquivalenceRelationLookup(cong) = [1 .. 34];
+true
+gap> EquivalenceRelationCanonicalLookup(cong) = [1 .. 34];
+true
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(I);
 gap> Unbind(J);


### PR DESCRIPTION
`EquivalenceRelationLookup` and `EquivalenceRelationCanonicalLookup` now have methods for generic congruences.  This allows us to compare congruences of different types, and to compare their classes (a test which is readded here, having been unwisely removed a few commits ago).

Doc and tests are adjusted, and a few other little features are added.