### PR TITLE
Left/right congruences: add missing doc

### DIFF
--- a/doc/cong.xml
+++ b/doc/cong.xml
@@ -461,7 +461,6 @@ gap> EquivalenceRelationCanonicalLookup(cong);
 <#GAPDoc Label="NrEquivalenceClasses">
   <ManSection> 
     <Attr Name = "NrEquivalenceClasses" Arg = "eq"/>
-    <Oper Name = "NrCongruenceClasses" Arg = "cong"/>
     <Returns>A positive integer.</Returns>
     <Description>
       If <A>eq</A> is an equivalence relation, then this attribute describes
@@ -473,6 +472,36 @@ gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3),
 gap> cong := CongruencesOfSemigroup(S)[3];;
 gap> NrEquivalenceClasses(cong);
 9]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="NrCongruenceClasses">
+  <ManSection>
+    <Oper Name = "NrCongruenceClasses" Arg = "cong"/>
+    <Oper Name = "NrLeftCongruenceClasses" Arg = "cong"/>
+    <Oper Name = "NrRightCongruenceClasses" Arg = "cong"/>
+    <Returns>A list of equivalence classes.</Returns>
+    <Description>
+      These operations act as a synonym of <C>NrEquivalenceClasses</C> in the
+      case that the argument <A>cong</A> is a congruence, left congruence, or
+      right congruence (respectively) of a semigroup.<P/>
+
+      See <Ref Filt="IsLeftSemigroupCongruence"/>,
+      <Ref Filt="IsRightSemigroupCongruence"/>, and
+      <Ref Filt="IsSemigroupCongruence"/>.<P/>
+
+      <Example><![CDATA[
+gap> S := Monoid([Transformation([1, 2, 2]),
+>                 Transformation([3, 1, 3])]);;
+gap> pair := [Transformation([1, 2, 1]), Transformation([2, 1, 2])];;
+gap> cong := SemigroupCongruence(S, pair);;
+gap> NrCongruenceClasses(cong);
+6
+gap> cong := RightSemigroupCongruence(S, pair);;
+gap> NrRightCongruenceClasses(cong);
+10
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -500,8 +529,7 @@ gap> AsSemigroupCongruenceByGeneratingPairs(cong);
 <#GAPDoc Label="NonTrivialEquivalenceClasses">
   <ManSection>
     <Attr Name = "NonTrivialEquivalenceClasses" Arg = "eq"/>
-    <Oper Name = "NonTrivialCongruenceClasses" Arg = "cong"/>
-    <Returns>A list.</Returns>
+    <Returns>A list of equivalence classes.</Returns>
     <Description>
       If <A>eq</A> is an equivalence relation, then this attribute returns a
       list of all equivalence classes of <A>eq</A> which contain more than one
@@ -519,6 +547,35 @@ gap> Set(classes);
   <congruence class of Transformation( [ 1, 2, 2 ] )>, 
   <congruence class of Transformation( [ 3, 1, 3 ] )>, 
   <congruence class of Transformation( [ 3, 1, 1 ] )> ]]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="NonTrivialCongruenceClasses">
+  <ManSection>
+    <Oper Name = "NonTrivialCongruenceClasses" Arg = "cong"/>
+    <Oper Name = "NonTrivialLeftCongruenceClasses" Arg = "cong"/>
+    <Oper Name = "NonTrivialRightCongruenceClasses" Arg = "cong"/>
+    <Returns>A list of equivalence classes.</Returns>
+    <Description>
+      These operations act as a synonym of <C>NonTrivialEquivalenceClasses</C>
+      in the case that the argument <A>cong</A> is a congruence, left
+      congruence, or right congruence (respectively) of a semigroup.<P/>
+
+      See <Ref Filt="IsLeftSemigroupCongruence"/>,
+      <Ref Filt="IsRightSemigroupCongruence"/>, and
+      <Ref Filt="IsSemigroupCongruence"/>.<P/>
+
+      <Example><![CDATA[
+gap> S := Monoid([Transformation([1, 2, 2]),
+>                 Transformation([3, 1, 3])]);;
+gap> cong := RightSemigroupCongruence(S, [Transformation([1, 2, 1]),
+>                                         Transformation([2, 1, 2])]);;
+gap> classes := NonTrivialRightCongruenceClasses(cong);;
+gap> Set(classes);
+[ <right congruence class of Transformation( [ 2, 1, 2 ] )>, 
+  <right congruence class of Transformation( [ 3, 1, 3 ] )> ]
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -595,48 +652,63 @@ true]]></Example>
 <#/GAPDoc>
 
 <#GAPDoc Label="CongruenceClassOfElement">
-<ManSection> 
-  <Oper Name = "CongruenceClassOfElement" Arg = "cong, elm"/>
-  <Returns>A congruence class.</Returns>  
-  <Description>
-    This operation is a synonym of <C>EquivalenceClassOfElement</C> in the case
-    that the argument <A>cong</A> is a congruence of a semigroup.<P/>
+  <ManSection>
+    <Oper Name = "CongruenceClassOfElement" Arg = "cong, elm"/>
+    <Oper Name = "LeftCongruenceClassOfElement" Arg = "cong, elm"/>
+    <Oper Name = "RightCongruenceClassOfElement" Arg = "cong, elm"/>
+    <Returns>An equivalence class.</Returns>
+    <Description>
+      These operations act as a synonym of <C>EquivalenceClassOfElement</C> in
+      the case that the argument <A>cong</A> is a congruence, left congruence,
+      or right congruence (respectively) of a semigroup.<P/>
+
+      See <Ref Filt="IsLeftSemigroupCongruence"/>,
+      <Ref Filt="IsRightSemigroupCongruence"/>, and
+      <Ref Filt="IsSemigroupCongruence"/>.<P/>
 
     <Example><![CDATA[
-gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3), 
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3),
 > [[(), (1, 3, 2)], [(1, 2), 0]]);;
 gap> cong := CongruencesOfSemigroup(S)[3];;
 gap> elm := ReesZeroMatrixSemigroupElement(S, 1, (1,3,2), 1);;
 gap> CongruenceClassOfElement(cong, elm);
-<congruence class of (1,(1,3,2),1)>]]></Example>
+<congruence class of (1,(1,3,2),1)>
+]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
 
 <#GAPDoc Label="CongruenceClasses">
-<ManSection> 
-  <Oper Name = "CongruenceClasses" Arg = "cong"/>
-  <Oper Name = "LeftCongruenceClasses" Arg = "cong"/>
-  <Oper Name = "RightCongruenceClasses" Arg = "cong"/>
-  <Returns>A list of equivalence classes.</Returns>  
-  <Description>
-    These operations acts as a synonym of <C>EquivalenceClasses</C> in the case
-    that the argument <A>cong</A> is a congruence, left congruence, or right
-    congruence (respectively) of a semigroup.<P/>
+  <ManSection>
+    <Oper Name = "CongruenceClasses" Arg = "cong"/>
+    <Oper Name = "LeftCongruenceClasses" Arg = "cong"/>
+    <Oper Name = "RightCongruenceClasses" Arg = "cong"/>
+    <Returns>A list of equivalence classes.</Returns>
+    <Description>
+      These operations act as a synonym of <C>EquivalenceClasses</C> in the
+      case that the argument <A>cong</A> is a congruence, left congruence, or
+      right congruence (respectively) of a semigroup.<P/>
 
-    See <Ref Filt="IsLeftSemigroupCongruence"/>, <Ref
-    Filt="IsRightSemigroupCongruence"/>, and <Ref
-    Filt="IsSemigroupCongruence"/>.<P/>
+      See <Ref Filt="IsLeftSemigroupCongruence"/>,
+      <Ref Filt="IsRightSemigroupCongruence"/>, and
+      <Ref Filt="IsSemigroupCongruence"/>.<P/>
 
-    <Example><![CDATA[
-gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3), 
-> [[(), (1, 3, 2)], [(1, 2), 0]]);;
-gap> cong := CongruencesOfSemigroup(S)[3];;
-gap> elm := ReesZeroMatrixSemigroupElement(S, 1, (1,3,2), 1);;
-gap> CongruenceClassOfElement(cong, elm);
-<congruence class of (1,(1,3,2),1)>]]></Example>
-  </Description>
-</ManSection>
+      <Example><![CDATA[
+gap> S := Monoid([Transformation([1, 2, 2]),
+>                 Transformation([3, 1, 3])]);;
+gap> pair := [Transformation([1, 2, 1]), Transformation([2, 1, 2])];;
+gap> cong := SemigroupCongruence(S, pair);;
+gap> classes := CongruenceClasses(cong);;
+gap> Set(classes);
+[ <congruence class of Transformation( [ 3, 3, 3 ] )>, 
+  <congruence class of Transformation( [ 2, 1, 2 ] )>, 
+  <congruence class of Transformation( [ 1, 2, 2 ] )>, 
+  <congruence class of IdentityTransformation>, 
+  <congruence class of Transformation( [ 3, 1, 3 ] )>, 
+  <congruence class of Transformation( [ 3, 1, 1 ] )> ]
+]]></Example>
+    </Description>
+  </ManSection>
 <#/GAPDoc>
 
 <#GAPDoc Label="IsSubrelation">

--- a/doc/z-chap19.xml
+++ b/doc/z-chap19.xml
@@ -72,7 +72,9 @@
     <#Include Label = "CongruenceClassOfElement">
     <#Include Label = "CongruenceClasses">
     <#Include Label = "NonTrivialEquivalenceClasses">
+    <#Include Label = "NonTrivialCongruenceClasses">
     <#Include Label = "NrEquivalenceClasses">
+    <#Include Label = "NrCongruenceClasses">
     <#Include Label = "CongruencesOfSemigroup">
     <#Include Label = "MinimalCongruencesOfSemigroup">
     <#Include Label = "PrincipalCongruencesOfSemigroup">


### PR DESCRIPTION
A few operations for left and right congruences (essentially synonyms for equivalence versions) weren't documented.