### PR TITLE
Rename OutNeighboursCopy to OutNeighboursMutableCopy (digraphs)

### DIFF
--- a/gap/greens/gren.gi
+++ b/gap/greens/gren.gi
@@ -530,7 +530,7 @@ function(S)
   gr := Digraph(List([1 .. Length(l)], i -> Concatenation(l[i], r[i])));
   gr := QuotientDigraph(gr, GreensDRelation(S)!.data.comps);
 
-  return List(OutNeighboursCopy(gr), Set);
+  return List(OutNeighbours(gr), Set);
 end);
 
 #############################################################################


### PR DESCRIPTION
I just made a pull request in Digraphs which changes the name of `OutNeighboursCopy` to `OutNeighboursMutableCopy`.  This change keeps compatibility between the two packages.