### PR TITLE
Change EquivalenceRelationPartition to match documentation

### DIFF
--- a/gap/congruences/congpairs.gi
+++ b/gap/congruences/congpairs.gi
@@ -60,7 +60,10 @@ function(cong)
   part := FiniteCongruenceByGeneratingPairsPartition(cong);
   out := [];
   for class in part do
-    Add(out, List(class, i -> EN_SEMI_ELEMENT_NUMBER(Range(cong), i)));
+    if Size(class) > 1 then
+      # Non-trivial classes only
+      Add(out, List(class, i -> EN_SEMI_ELEMENT_NUMBER(Range(cong), i)));
+    fi;
   od;
   return out;
 end);

--- a/tst/standard/congpairs.tst
+++ b/tst/standard/congpairs.tst
@@ -496,9 +496,7 @@ gap> pair := [[Bipartition([[1, 2], [-1], [-2]]),
 >              Bipartition([[1, -1], [2], [-2]])]];;
 gap> cong := SemigroupCongruence(S, pair);;
 gap> EquivalenceRelationPartition(cong);
-[ [ <block bijection: [ 1, -1 ], [ 2, -2 ]> ], 
-  [ <block bijection: [ 1, -2 ], [ 2, -1 ]> ], 
-  [ <bipartition: [ 1, 2 ], [ -1, -2 ]>, 
+[ [ <bipartition: [ 1, 2 ], [ -1, -2 ]>, 
       <bipartition: [ 1 ], [ 2 ], [ -1, -2 ]> ], 
   [ <bipartition: [ 1, -1 ], [ 2 ], [ -2 ]>, 
       <bipartition: [ 1 ], [ 2, -1 ], [ -2 ]>, 
@@ -507,7 +505,7 @@ gap> EquivalenceRelationPartition(cong);
       <bipartition: [ 1 ], [ 2, -2 ], [ -1 ]>, 
       <bipartition: [ 1 ], [ 2 ], [ -1 ], [ -2 ]> ] ]
 gap> cong := SemigroupCongruence(S, []);;
-gap> SortedList(EquivalenceRelationPartition(cong)) = List(Elements(S), x->[x]);
+gap> EquivalenceRelationPartition(cong) = [];
 true
 gap> cong := UniversalSemigroupCongruence(S);;
 gap> Length(EquivalenceRelationPartition(cong)) = 1;


### PR DESCRIPTION
Modify `EquivalenceRelationPartition` so that it excludes non-trivial classes, to match the definition in the GAP library.