### PR TITLE
Make GraphOfRightActionOnPairs a digraph object

### DIFF
--- a/doc/semitrans.xml
+++ b/doc/semitrans.xml
@@ -209,7 +209,10 @@ gap> CyclesOfTransformationSemigroup(S);
 
 <#GAPDoc Label="IsSynchronizingSemigroup">
   <ManSection>
-    <Oper Name = "IsSynchronizingSemigroup" Arg = "S[, n]"/>
+    <Prop Name = "IsSynchronizingSemigroup" Arg = "S"
+      Label = "for a transformation semigroup" />
+    <Oper Name = "IsSynchronizingSemigroup" Arg = "S, n"
+      Label = "for a transformation semigroup and a positive integer" />
     <Returns><K>true</K> or <K>false</K>.</Returns>
     <Description>
       For a positive integer <A>n</A>,
@@ -226,9 +229,10 @@ gap> CyclesOfTransformationSemigroup(S);
       <A>S</A>.
       <P/>
       
-      Note that the semigroup consisting of the identity
-      transformation has degree <C>0</C>, and for this special case the
-      function <C>IsSynchronizingSemigroup</C> will return <K>false</K>.<P/>
+      Note that the semigroup consisting of the identity transformation is the
+      unique transformation semigroup with degree <C>0</C>. In this special
+      case, the function <C>IsSynchronizingSemigroup</C> will return
+      <K>false</K>.<P/>
 
       <Example><![CDATA[
 gap> S := Semigroup(

--- a/doc/semitrans.xml
+++ b/doc/semitrans.xml
@@ -246,3 +246,77 @@ Transformation( [ 7, 8, 8, 7, 8, 8, 8, 7, 8, 8 ] )]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="DigraphOfActionOnPairs">
+  <ManSection>
+    <Attr Name = "DigraphOfActionOnPairs" Arg = "S"
+      Label = "for a transformation semigroup" />
+    <Oper Name = "DigraphOfActionOnPairs" Arg = "S, n"
+      Label = "for a transformation semigroup and an integer" />
+    <Returns>A digraph, or <K>fail</K>.</Returns>
+    <Description>
+      If <A>S</A> is a transformation semigroup and <A>n</A> is a non-negative
+      integer such that <A>S</A> acts on the points <C>[1 .. <A>n</A>]</C>, then
+      <C>DigraphOfActionOnPairs(<A>S</A>, <A>n</A>)</C> returns a digraph
+      representing the <Ref Oper="OnSets" BookName="ref"/> action of <A>S</A> on
+      the pairs of points in <C>[1 ..  <A>n</A>]</C>.
+      <P/>
+      
+      If the optional argument <A>n</A> is not specified, then by default the
+      degree of <A>S</A> will be chosen for <A>n</A>; see <Ref
+        Attr="DegreeOfTransformationSemigroup" BookName="ref" />. If the
+      semigroup <A>S</A> does not act on <C>[1 ..  <A>n</A>]</C>, then
+      <C>DigraphOfActionOnPairs(<A>S</A>, <A>n</A>)</C> returns <K>fail</K>.
+      <P/>
+
+      The digraph returned by <C>DigraphOfActionOnPairs</C> has <M><A>n</A> + {n
+        \choose 2}</M> vertices: the vertices <C>[1 .. <A>n</A>]</C> correspond
+      to the points in <C>[1 .. <A>n</A>]</C>, and the remaining vertices
+      correspond to the pairs of points in <C>[1 .. <A>n</A>]</C>. This
+      correspondence is stored in the vertex labels of the digraph; see <Ref
+        Oper="DigraphVertexLabels" BookName="Digraphs" />.
+      <P/>
+
+      The edges of the digraph are defined as follows. For each pair <C>{i,
+        j}</C> in <C>[1 .. <A>n</A>]</C>, and for each generator <C>f</C> in
+      <C>GeneratorsOfSemigroup(<A>S</A>)</C> (see <Ref
+        Attr="GeneratorsOfSemigroup" BookName="ref" />), there is an edge from
+      the vertex corresponding to <C>{i, j}</C> to the vertex corresponding to
+      <C>{i ^ f, j ^ f}</C>.  Since <C>f</C> is a transformation, the set <C>{i
+        ^ f, j ^ f}</C> may correspond to a pair (in the case that <C>i ^ f
+        &lt;&gt; j ^ f</C>), or to a point (in the case that <C>i ^ f = j ^
+        f</C>).  The label of an edge (<Ref Oper="DigraphEdgeLabels"
+        BookName="Digraphs" />) is the position of the first transformation
+      within <C>GeneratorsOfSemigroup(<A>S</A>)</C> that maps the pair
+      corresponding to the source vertex to the pair/point corresponding to the
+      range vertex.
+      <P/>
+
+      Note that the digraph returned by <C>DigraphOfActionOnPairs</C> has no
+      multiple edges; see <Ref Prop="IsMultiDigraph" BookName="Digraphs"/>.
+
+      <Example><![CDATA[
+gap> x := Transformation([2, 4, 3, 4, 7, 1, 6]);;
+gap> y := Transformation([3, 3, 2, 3, 5, 1, 5]);;
+gap> S := Semigroup(x, y);
+<transformation semigroup of degree 7 with 2 generators>
+gap> gr := DigraphOfActionOnPairs(S);
+<digraph with 28 vertices, 41 edges>
+gap> OnSets([2, 5], x);
+[ 4, 7 ]
+gap> DigraphVertexLabel(gr, 16);
+[ 2, 5 ]
+gap> DigraphVertexLabel(gr, 25);
+[ 4, 7 ]
+gap> DigraphEdgeLabel(gr, 16, 25);
+1
+gap> gr := DigraphOfActionOnPairs(S, 4);
+<digraph with 10 vertices, 11 edges>
+gap> DigraphVertexLabels(gr);
+[ 1, 2, 3, 4, [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], 
+  [ 3, 4 ] ]
+gap> DigraphOfActionOnPairs(S, 5);
+fail]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/semitrans.xml
+++ b/doc/semitrans.xml
@@ -210,7 +210,6 @@ gap> CyclesOfTransformationSemigroup(S);
 <#GAPDoc Label="IsSynchronizingSemigroup">
   <ManSection>
     <Oper Name = "IsSynchronizingSemigroup" Arg = "S[, n]"/>
-    <Oper Name = "IsSynchronizingTransformationCollection" Arg = "coll[, n]"/>
     <Returns><K>true</K> or <K>false</K>.</Returns>
     <Description>
       For a positive integer <A>n</A>,
@@ -226,10 +225,6 @@ gap> CyclesOfTransformationSemigroup(S);
       <Ref Oper = "DegreeOfTransformationSemigroup" BookName = "ref"/> for
       <A>S</A>.
       <P/>
-
-      The operation <C>IsSynchronizingTransformationCollection</C> behaves in
-      the same way as <C>IsSynchronizingSemigroup</C> but can be applied to any
-      collection of transformations and not only semigroups. <P/>
       
       Note that the semigroup consisting of the identity
       transformation has degree <C>0</C>, and for this special case the

--- a/doc/z-chap15.xml
+++ b/doc/z-chap15.xml
@@ -191,9 +191,10 @@
     <#Include Label = "ComponentRepsOfTransformationSemigroup">
     <#Include Label = "ComponentsOfTransformationSemigroup">
     <#Include Label = "CyclesOfTransformationSemigroup">
+    <#Include Label = "DigraphOfActionOnPairs">
+    <#Include Label = "GeneratorsSmallest">
     <#Include Label = "IsTransitive">
     <#Include Label = "SmallestElementSemigroup">
-    <#Include Label = "GeneratorsSmallest">
   
   </Section>
   

--- a/gap/obsolete.gd
+++ b/gap/obsolete.gd
@@ -29,3 +29,6 @@ DeclareOperation("IsomorphismBlockBijectionSemigroup", [IsSemigroup]);
 DeclareOperation("FactorisableDualSymmetricInverseSemigroup", [IsPosInt]);
 DeclareOperation("SingularFactorisableDualSymmetricInverseSemigroup",
                  [IsPosInt]);
+
+DeclareOperation("IsSynchronizingTransformationCollection",
+                 [IsTransformationCollection, IsPosInt]);

--- a/gap/obsolete.gi
+++ b/gap/obsolete.gi
@@ -138,3 +138,12 @@ function(n)
                            n, ")");
   return SingularFactorisableDualSymmetricInverseMonoid(n);
 end);
+
+InstallMethod(IsSynchronizingTransformationCollection,
+"for a transformation collection and a positive integer",
+[IsTransformationCollection, IsPosInt],
+function(coll, n)
+  SEMIGROUPS.PrintObsolete("IsSynchronizingTransformationCollection",
+                           "IsSynchronizingSemigroup(Semigroup(coll), n)");
+  return IsSynchronizingSemigroup(Semigroup(coll), n);
+end);

--- a/gap/semigroups/semitrans.gd
+++ b/gap/semigroups/semitrans.gd
@@ -13,6 +13,9 @@ DeclareAttribute("FixedPoints", IsTransformationSemigroup);
 DeclareAttribute("DigraphOfActionOnPoints", IsTransformationSemigroup);
 DeclareOperation("DigraphOfActionOnPoints",
                  [IsTransformationSemigroup, IsPosInt]);
+DeclareAttribute("DigraphOfActionOnPairs", IsTransformationSemigroup);
+DeclareOperation("DigraphOfActionOnPairs",
+                 [IsTransformationSemigroup, IsInt]);
 
 DeclareAttribute("ComponentRepsOfTransformationSemigroup",
                  IsTransformationSemigroup);

--- a/gap/semigroups/semitrans.gd
+++ b/gap/semigroups/semitrans.gd
@@ -26,8 +26,6 @@ DeclareAttribute("CyclesOfTransformationSemigroup",
 DeclareOperation("IsSynchronizingSemigroup", [IsTransformationSemigroup]);
 DeclareOperation("IsSynchronizingSemigroup",
                  [IsTransformationSemigroup, IsPosInt]);
-DeclareOperation("IsSynchronizingTransformationCollection",
-                 [IsTransformationCollection, IsPosInt]);
 
 DeclareProperty("IsTransitive", IsTransformationSemigroup);
 DeclareOperation("IsTransitive", [IsTransformationCollection, IsPosInt]);

--- a/gap/semigroups/semitrans.gd
+++ b/gap/semigroups/semitrans.gd
@@ -26,7 +26,7 @@ DeclareProperty("IsConnectedTransformationSemigroup",
 DeclareAttribute("CyclesOfTransformationSemigroup",
                  IsTransformationSemigroup);
 
-DeclareOperation("IsSynchronizingSemigroup", [IsTransformationSemigroup]);
+DeclareProperty("IsSynchronizingSemigroup", IsTransformationSemigroup);
 DeclareOperation("IsSynchronizingSemigroup",
                  [IsTransformationSemigroup, IsPosInt]);
 

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -207,7 +207,13 @@ InstallMethod(DigraphOfActionOnPoints,
 "for a transformation semigroup with known generators",
 [IsTransformationSemigroup and HasGeneratorsOfSemigroup],
 function(S)
-  return DigraphOfActionOnPoints(S, DegreeOfTransformationSemigroup(S));
+  local n;
+
+  n := DegreeOfTransformationSemigroup(S);
+  if n = 0 then
+    return EmptyDigraph(0);
+  fi;
+  return DigraphOfActionOnPoints(S, n);
 end);
 
 InstallMethod(DigraphOfActionOnPoints,
@@ -222,6 +228,9 @@ function(S, n)
     x := gens[i];
     for j in [1 .. n] do
       k := j ^ x;
+      if k > n then
+        return fail;
+      fi;
       AddSet(out[j], k);
     od;
   od;

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -550,30 +550,21 @@ function(S)
   return IsSynchronizingSemigroup(S, deg);
 end);
 
+# this method comes from PJC's slides from the Lisbon Workshop in July 2014
+
 # same method for ideals
 
 InstallMethod(IsSynchronizingSemigroup,
 "for a transformation semigroup and positive integer",
 [IsTransformationSemigroup, IsPosInt],
 function(S, n)
-  local gens;
+  local gens, all_perms, r, graph, marked, squashed, x, i, j;
 
   if HasGeneratorsOfSemigroup(S) then
     gens := GeneratorsOfSemigroup(S);
   else
     gens := GeneratorsOfSemigroup(SupersemigroupOfIdeal(S));
   fi;
-
-  return IsSynchronizingTransformationCollection(gens, n);
-end);
-
-# this method comes from PJC's slides from the Lisbon Workshop in July 2014
-
-InstallMethod(IsSynchronizingTransformationCollection,
-"for a transformation collection and positive integer",
-[IsTransformationCollection, IsPosInt],
-function(gens, n)
-  local all_perms, r, graph, marked, squashed, x, i, j;
 
   if n = 1 then
     return true;

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -283,49 +283,77 @@ SEMIGROUPS.LargestElementRClass := function(R)
   return SEMIGROUPS.ElementRClass(R, true);
 end;
 
-# stop_on_isolated_pair:
-#   if true, this function returns false if there is an isolated pair-vertex
-# TODO should this be a Digraph??
-# FIXME make this a digraph
-SEMIGROUPS.GraphOfRightActionOnPairs := function(gens, n, stop_on_isolated_pair)
-  local nrgens, nrpairs, PairNumber, NumberPair, in_nbs, labels, pair,
-  isolated_pair, act, range, i, j;
-  nrgens     := Length(gens);
-  nrpairs    := Binomial(n, 2);
+InstallMethod(DigraphOfActionOnPairs,
+"for a transformation semigroup",
+[IsTransformationSemigroup],
+function(S)
+  local n;
+
+  n := DegreeOfTransformationSemigroup(S);
+  if n = 0 then
+    return EmptyDigraph(0);
+  fi;
+  return DigraphOfActionOnPairs(S, n);
+end);
+
+InstallMethod(DigraphOfActionOnPairs,
+"for a transformation semigroup and int",
+[IsTransformationSemigroup, IsInt],
+function(S, n)
+  local gens, PairNumber, NumberPair, nr, nrpairs, out_nbs, inn_nbs, label,
+  pair, range, gr, i, j;
+
+  if n < 0 then
+    ErrorNoReturn("Semigroups: DigraphOfActionOnPairs: usage,\n",
+                  "the second argument <n> must be non-negative,");
+  fi;
+
+  gens := GeneratorsOfSemigroup(S);
+
+  if ForAny(gens, x -> ForAny([1 .. n], i -> i ^ x > n)) then
+    return fail;
+  elif n <= 1 then
+    return EmptyDigraph(n);
+  fi;
+
+  if HasDigraphOfActionOnPairs(S)
+      and DegreeOfTransformationSemigroup(S) = n then
+    return DigraphOfActionOnPairs(S);
+  fi;
+
   PairNumber := Concatenation([1 .. n], Combinations([1 .. n], 2));
-  # Currently assume <x> is sorted and is a valid combination of [1 .. n]
   NumberPair := function(n, x)
+    # This function assumes that <x> is a sorted subset of [1 .. n]
     if Length(x) = 1 then
       return x[1];
     fi;
     return n + Binomial(n, 2) - Binomial(n + 1 - x[1], 2) + x[2] - x[1];
   end;
 
-  in_nbs := List([1 .. n + nrpairs], x -> []);
-  labels := List([1 .. n + nrpairs], x -> []);
-  for i in [(n + 1) .. (n + nrpairs)] do
+  nr := Length(gens);
+  nrpairs := Binomial(n, 2);
+  out_nbs := List([1 .. n + nrpairs], x -> []);
+  inn_nbs := List([1 .. n + nrpairs], x -> []);
+  label   := List([1 .. n + nrpairs], x -> []);
+
+  for i in [n + 1 .. n + nrpairs] do
     pair := PairNumber[i];
-    isolated_pair := true;
-    for j in [1 .. nrgens] do
-      act := OnSets(pair, gens[j]);
-      range := NumberPair(n, act);
-      Add(in_nbs[range], i);
-      Add(labels[range], j);
-      if range <> i and isolated_pair then
-        isolated_pair := false;
+    for j in [1 .. nr] do
+      range := NumberPair(n, OnSets(pair, gens[j]));
+      if not i in inn_nbs[range] then
+        Add(inn_nbs[range], i);
+        Add(out_nbs[i], range);
+        Add(label[i], j);
       fi;
     od;
-    if stop_on_isolated_pair and isolated_pair then
-      return false;
-    fi;
   od;
 
-  return rec(degree := n,
-             in_nbs := in_nbs,
-             labels := labels,
-             PairNumber := PairNumber,
-             NumberPair := NumberPair);
-end;
+  gr := Digraph(out_nbs);
+  SetInNeighbours(gr, inn_nbs);
+  SetDigraphEdgeLabels(gr, label);
+  SetDigraphVertexLabels(gr, PairNumber);
+  return gr;
+end);
 
 # FIXME can probably do better than this
 
@@ -558,16 +586,16 @@ InstallMethod(IsSynchronizingSemigroup,
 "for a transformation semigroup and positive integer",
 [IsTransformationSemigroup, IsPosInt],
 function(S, n)
-  local gens, all_perms, r, graph, marked, squashed, x, i, j;
+  local gens, all_perms, r, gr, inn, marked, squashed, x, i, j;
+
+  if n = 1 then
+    return true;
+  fi;
 
   if HasGeneratorsOfSemigroup(S) then
     gens := GeneratorsOfSemigroup(S);
   else
     gens := GeneratorsOfSemigroup(SupersemigroupOfIdeal(S));
-  fi;
-
-  if n = 1 then
-    return true;
   fi;
 
   all_perms := true;
@@ -583,16 +611,24 @@ function(S, n)
     return false; # S = <gens> is a group of transformations
   fi;
 
-  graph := SEMIGROUPS.GraphOfRightActionOnPairs(gens, n, true);
+  if n = DegreeOfTransformationSemigroup(S) then
+    gr := DigraphOfActionOnPairs(S);
+  else
+    gr := DigraphOfActionOnPairs(S, n);
+  fi;
 
-  if graph = false then
+  # Check if any pairs are isolated in gr
+  if ForAny([n + 1 .. DigraphNrVertices(gr)],
+            v -> OutDegreeOfVertex(gr, v) = 0) then
     return false;
   fi;
 
-  marked := BlistList([1 .. n + Binomial(n, 2)], []);
+  inn := InNeighbours(gr);
+
+  marked := BlistList(DigraphVertices(gr), []);
   squashed := [1 .. n];
   for i in squashed do
-    for j in graph.in_nbs[i] do
+    for j in inn[i] do
       if not marked[j] then
         marked[j] := true;
         Add(squashed, j);
@@ -600,15 +636,15 @@ function(S, n)
     od;
   od;
 
-  return Length(squashed) = n + Binomial(n, 2);
+  return Length(squashed) = DigraphNrVertices(gr);
 end);
 
 InstallMethod(RepresentativeOfMinimalIdealNC, "for a transformation semigroup",
 [IsTransformationSemigroup], RankFilter(IsActingSemigroup),
 # to beat the default method for acting semigroups
 function(S)
-  local gens, nrgens, n, min_rank, rank, min_rank_index, graph, nrpairs, elts,
-  marked, squashed, j, t, im, reduced, y, i, k, x;
+  local n, gens, nrgens, min_rank, rank, min_rank_index, gr, inn, elts, marked,
+  squashed, j, t, im, NumberPair, reduced, y, i, k, x;
 
   n := DegreeOfTransformationSemigroup(S); # Smallest n such that S <= T_n
                                            # We must have n >= 2.
@@ -636,22 +672,22 @@ function(S)
     TryNextMethod();
   fi;
 
-  graph := SEMIGROUPS.GraphOfRightActionOnPairs(gens, n, false);
+  gr := DigraphOfActionOnPairs(S);
+  inn := InNeighbours(gr);
 
   # find a word describing a path from each collapsible pair to a singleton
-  nrpairs := Binomial(n, 2);
-  elts := EmptyPlist(n + nrpairs);
-  marked := BlistList([1 .. n + nrpairs], []);
+  elts := EmptyPlist(DigraphNrVertices(gr));
+  marked := BlistList(DigraphVertices(gr), []);
   squashed := [1 .. n];
   for i in squashed do
-    for k in [1 .. Length(graph.in_nbs[i])] do
-      j := graph.in_nbs[i][k];
+    for k in [1 .. Length(inn[i])] do
+      j := inn[i][k];
       if not marked[j] then
         marked[j] := true;
         if i <= n then
-          elts[j] := [graph.labels[i][k]];
+          elts[j] := [DigraphEdgeLabel(gr, j, i)];
         else
-          elts[j] := Concatenation([graph.labels[i][k]], elts[i]);
+          elts[j] := Concatenation([DigraphEdgeLabel(gr, j, i)], elts[i]);
         fi;
         Add(squashed, j);
       fi;
@@ -661,11 +697,16 @@ function(S)
   t := gens[min_rank_index];
   im := ImageSetOfTransformation(t, n);
 
+  NumberPair := function(n, x)
+    # This function assumes that <x> is a sorted 2-subset of [1 .. n]
+    return n + Binomial(n, 2) - Binomial(n + 1 - x[1], 2) + x[2] - x[1];
+  end;
+
   # find a word in S of minimal rank by repeatedly collapsing pairs in im(t)
   while true do
     reduced := false;
     for x in IteratorOfCombinations(im, 2) do
-      y := graph.NumberPair(n, x);
+      y := NumberPair(n, x);
       if marked[y] then
         t := t * EvaluateWord(gens, elts[y]);
         im := ImageSetOfTransformation(t, n);

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -590,6 +590,9 @@ function(S, n)
 
   if n = 1 then
     return true;
+  elif HasIsSynchronizingSemigroup(S)
+      and n <= DegreeOfTransformationSemigroup(S) then
+    return IsSynchronizingSemigroup(S);
   fi;
 
   if HasGeneratorsOfSemigroup(S) then

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -871,6 +871,10 @@ function(S)
   return U;
 end);
 
+InstallMethod(DegreeOfTransformationCollection,
+"for a transformation semigroup",
+[IsTransformationSemigroup], DegreeOfTransformationSemigroup);
+
 InstallMethod(DegreeOfTransformationSemigroup,
 "for a transformation semigroup ideal",
 [IsTransformationSemigroup and IsSemigroupIdeal],

--- a/tst/standard/obsolete.tst
+++ b/tst/standard/obsolete.tst
@@ -81,5 +81,13 @@ gap> IsomorphismBlockBijectionSemigroup(SymmetricInverseMonoid(3));;
 #I  `IsomorphismBlockBijectionSemigroup` is no longer supported
 #I  use `IsomorphismSemigroup(IsBlockBijectionSemigroup, S)` instead!
 
+# IsSynchronizingTransformationCollection
+gap> IsSynchronizingTransformationCollection([
+>  Transformation([2, 3, 4, 1]),
+>  Transformation([2, 1]),
+>  Transformation([1, 2, 3, 1])], 4);;
+#I  `IsSynchronizingTransformationCollection` is no longer supported
+#I  use `IsSynchronizingSemigroup(Semigroup(coll), n)` instead!
+
 #
 gap> STOP_TEST("Semigroups package: standard/obsolete.tst");

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -2318,6 +2318,41 @@ gap> Size(T);
 gap> IsMonoid(T);
 true
 
+#T# semitrans: DigraphOfActionOnPairs, 1
+gap> gr := DigraphOfActionOnPairs(FullTransformationMonoid(1));
+<digraph with 0 vertices, 0 edges>
+gap> gr := DigraphOfActionOnPairs(FullTransformationMonoid(1), 1);
+<digraph with 1 vertex, 0 edges>
+gap> gr := DigraphOfActionOnPairs(FullTransformationMonoid(1), 3);
+<digraph with 6 vertices, 3 edges>
+gap> gr := DigraphOfActionOnPairs(FullTransformationMonoid(1), 2);
+<digraph with 3 vertices, 1 edge>
+gap> gr := DigraphOfActionOnPairs(FullTransformationMonoid(1), 0);
+<digraph with 0 vertices, 0 edges>
+gap> IsEmptyDigraph(gr);
+true
+gap> gr := DigraphOfActionOnPairs(FullTransformationMonoid(2), 0);
+<digraph with 0 vertices, 0 edges>
+gap> IsEmptyDigraph(gr);
+true
+gap> gr := DigraphOfActionOnPairs(FullTransformationMonoid(1), -1);
+Error, Semigroups: DigraphOfActionOnPairs: usage,
+the second argument <n> must be non-negative,
+gap> S := FullTransformationMonoid(4);
+<full transformation monoid of degree 4>
+gap> gr := DigraphOfActionOnPairs(S);
+<digraph with 10 vertices, 19 edges>
+gap> HasDigraphOfActionOnPairs(S);
+true
+gap> OutNeighbours(gr);
+[ [  ], [  ], [  ], [  ], [ 5, 8 ], [ 6, 9, 8 ], [ 7, 5, 9, 1 ], 
+  [ 8, 10, 6 ], [ 9, 6, 7, 5 ], [ 10, 7, 6 ] ]
+gap> DigraphVertexLabels(gr);
+[ 1, 2, 3, 4, [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], [ 3, 4 ] ]
+gap> DigraphEdgeLabels(gr);
+[ [  ], [  ], [  ], [  ], [ 1, 2 ], [ 1, 2, 3 ], [ 1, 2, 3, 4 ], [ 1, 2, 3 ], 
+  [ 1, 2, 3, 4 ], [ 1, 2, 4 ] ]
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);


### PR DESCRIPTION
`SEMIGROUPS.GraphOfActionOnPairs` is now a Digraph, and is called `DigraphOfActionOnPairs`.

`IsSynchronizingSemigroup` and `RepresentativeOfMinimalIdeal` were the only methods which used it. These have been updated.