### PR TITLE
Improve Idempotents by rank for a transformation semigroup

### DIFF
--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -328,17 +328,30 @@ SEMIGROUPS.GraphOfRightActionOnPairs := function(gens, n, stop_on_isolated_pair)
 end;
 
 # FIXME can probably do better than this
+# WW has improved this
 
 InstallMethod(Idempotents, "for a transformation semigroup and pos int",
 [IsTransformationSemigroup, IsPosInt],
 function(S, rank)
-  local deg;
+  local deg, out, d;
+
   deg := DegreeOfTransformationSemigroup(S);
   if rank > deg then
     return [];
+  elif rank = 1 then
+    if IsSynchronizingSemigroup(S) then
+      return Elements(MinimalIdeal(S));
+    fi;
+    return [];
   fi;
-  return Filtered(Idempotents(S),
-                              x -> RankOfTransformation(x, deg) = rank);
+  out := [];
+  for d in DClasses(S) do
+    if RankOfTransformation(Representative(d), deg) = rank
+        and IsRegularDClass(d) then
+      Append(out, Idempotents(d));
+    fi;
+  od;
+  return out;
 end);
 
 InstallMethod(IteratorSorted, "for an acting transformation semigroup",

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -216,10 +216,12 @@ gap> Idempotents(FullTransformationMonoid(3), 4);
 [  ]
 gap> Idempotents(FullTransformationMonoid(3), 3);
 [ IdentityTransformation ]
-gap> Idempotents(FullTransformationMonoid(3), 2);
-[ Transformation( [ 1, 2, 1 ] ), Transformation( [ 1, 2, 2 ] ), 
-  Transformation( [ 3, 2, 3 ] ), Transformation( [ 2, 2 ] ), 
-  Transformation( [ 1, 3, 3 ] ), Transformation( [ 1, 1 ] ) ]
+gap> x := Idempotents(FullTransformationMonoid(3), 2);;
+gap> Sort(x);
+gap> x;
+[ Transformation( [ 1, 1 ] ), Transformation( [ 1, 2, 1 ] ), 
+  Transformation( [ 1, 2, 2 ] ), Transformation( [ 1, 3, 3 ] ), 
+  Transformation( [ 2, 2 ] ), Transformation( [ 3, 2, 3 ] ) ]
 gap> Idempotents(FullTransformationMonoid(3), 1);
 [ Transformation( [ 1, 1, 1 ] ), Transformation( [ 2, 2, 2 ] ), 
   Transformation( [ 3, 3, 3 ] ) ]


### PR DESCRIPTION
This addresses a FIXME in the `semitrans.gi` file.

Instead of calculating all the idempotents and then filtering them for the ones of correct rank, we now only enumerate those idempotents which are in a regular D-class of the appropriate rank.