### PR TITLE
Rename *FactorisableDualSymmetricInverseSemigroup to *FactorisableDualSymmetricInverseMonoid

### DIFF
--- a/doc/properties.xml
+++ b/doc/properties.xml
@@ -396,7 +396,7 @@ gap> IsFactorisableInverseMonoid(SymmetricInverseSemigroup(5));
 true
 gap> IsFactorisableInverseMonoid(DualSymmetricInverseMonoid(5));
 false
-gap> S := FactorisableDualSymmetricInverseSemigroup(5);;
+gap> S := FactorisableDualSymmetricInverseMonoid(5);;
 gap> IsFactorisableInverseMonoid(S);
 true]]></Example>
   </Description>
@@ -868,7 +868,7 @@ gap> A := Semigroup(Idempotents(S));
 <transformation semigroup of degree 7 with 32 generators>
 gap> IsSemilattice(A);
 true
-gap> S := FactorisableDualSymmetricInverseSemigroup(5);;
+gap> S := FactorisableDualSymmetricInverseMonoid(5);;
 gap> S := IdempotentGeneratedSubsemigroup(S);;
 gap> IsSemilattice(S);
 true]]></Example>

--- a/doc/semiex.xml
+++ b/doc/semiex.xml
@@ -157,10 +157,10 @@ gap> Size(S);
 <#GAPDoc Label="UniformBlockBijectionMonoid">
    <ManSection>
     <Oper Name="UniformBlockBijectionMonoid" Arg="n"/>
-    <Oper Name="FactorisableDualSymmetricInverseSemigroup" Arg="n"/>
+    <Oper Name="FactorisableDualSymmetricInverseMonoid" Arg="n"/>
     <Oper Name="SingularUniformBlockBijectionMonoid" Arg="n"/>
     <Oper Name="PartialUniformBlockBijectionMonoid" Arg="n"/>
-    <Oper Name="SingularFactorisableDualSymmetricInverseSemigroup" Arg="n"/>
+    <Oper Name="SingularFactorisableDualSymmetricInverseMonoid" Arg="n"/>
     <Oper Name="PlanarUniformBlockBijectionMonoid" Arg="n"/>
     <Oper Name="SingularPlanarUniformBlockBijectionMonoid" Arg="n"/>
     <Returns>An inverse bipartition monoid.</Returns>
@@ -171,7 +171,7 @@ gap> Size(S);
       block bijections of degree &n; where the number of positive integers in a
       block equals the number of negative integers in that block. 
       The uniform block bijection monoid is also referred to as the 
-      <E>factorisable dual symmetric inverse semigroup</E>. <P/>
+      <E>factorisable dual symmetric inverse monoid</E>. <P/>
 
       <C>SingularUniformBlockBijectionMonoid</C> returns the ideal of the
       uniform block bijection monoid consisting of the non-invertible elements

--- a/gap/obsolete.gd
+++ b/gap/obsolete.gd
@@ -25,3 +25,7 @@ DeclareOperation("AsBlockBijectionSemigroup", [IsSemigroup]);
 
 DeclareOperation("IsomorphismBipartitionSemigroup", [IsSemigroup]);
 DeclareOperation("IsomorphismBlockBijectionSemigroup", [IsSemigroup]);
+
+DeclareOperation("FactorisableDualSymmetricInverseSemigroup", [IsPosInt]);
+DeclareOperation("SingularFactorisableDualSymmetricInverseSemigroup",
+                 [IsPosInt]);

--- a/gap/obsolete.gi
+++ b/gap/obsolete.gi
@@ -119,3 +119,22 @@ function(S)
                            "IsBlockBijectionSemigroup, S)");
   return IsomorphismSemigroup(IsBlockBijectionSemigroup, S);
 end);
+
+InstallMethod(FactorisableDualSymmetricInverseSemigroup, "for a positive integer",
+[IsPosInt],
+function(n)
+  SEMIGROUPS.PrintObsolete("FactorisableDualSymmetricInverseSemigroup",
+                           "FactorisableDualSymmetricInverseMonoid(",
+                           n, ")");
+  return FactorisableDualSymmetricInverseMonoid(n);
+end);
+
+InstallMethod(SingularFactorisableDualSymmetricInverseSemigroup,
+"for a positive integer",
+[IsPosInt],
+function(n)
+  SEMIGROUPS.PrintObsolete("SingularFactorisableDualSymmetricInverseSemigroup",
+                           "SingularFactorisableDualSymmetricInverseMonoid(",
+                           n, ")");
+  return SingularFactorisableDualSymmetricInverseMonoid(n);
+end);

--- a/gap/semigroups/semiex.gd
+++ b/gap/semigroups/semiex.gd
@@ -55,9 +55,9 @@ DeclareOperation("PartialUniformBlockBijectionMonoid", [IsPosInt]);
 DeclareOperation("SingularUniformBlockBijectionMonoid", [IsPosInt]);
 DeclareOperation("PlanarUniformBlockBijectionMonoid", [IsPosInt]);
 DeclareOperation("SingularPlanarUniformBlockBijectionMonoid", [IsPosInt]);
-DeclareSynonym("FactorisableDualSymmetricInverseSemigroup",
+DeclareSynonym("FactorisableDualSymmetricInverseMonoid",
                UniformBlockBijectionMonoid);
-DeclareSynonym("SingularFactorisableDualSymmetricInverseSemigroup",
+DeclareSynonym("SingularFactorisableDualSymmetricInverseMonoid",
                SingularUniformBlockBijectionMonoid);
 
 DeclareOperation("ApsisMonoid", [IsPosInt, IsPosInt]);

--- a/tst/standard/properties.tst
+++ b/tst/standard/properties.tst
@@ -435,7 +435,7 @@ gap> S := DualSymmetricInverseMonoid(3);
 <inverse block bijection monoid of degree 3 with 3 generators>
 gap> IsFactorisableInverseMonoid(S);
 false
-gap> T := InverseSemigroup(FactorisableDualSymmetricInverseSemigroup(3));
+gap> T := InverseSemigroup(FactorisableDualSymmetricInverseMonoid(3));
 <inverse block bijection monoid of degree 3 with 3 generators>
 gap> IsFactorisableInverseMonoid(T);
 true


### PR DESCRIPTION
They're monoids, so for consistency with the other standard examples, we should call them monoids.

The previous names are now in `obselete.g*`.