### PR TITLE
Add operation to convert a partial perm bipartition to a block bijection

### DIFF
--- a/doc/bipart.xml
+++ b/doc/bipart.xml
@@ -433,8 +433,8 @@ the argument does not define a partial perm,]]></Example>
 
       If the optional second argument <A>n</A> is not present, then the maximum
       of the degree and codegree of <A>x</A> plus 1 is used by default. If the
-      second argument <A>n</A> is not greater than this maximum, then
-      <K>fail</K> is returned.
+      second argument <A>n</A> is not greater than this maximum, then an Error
+      is returned.
       <P/>
 
       This is the value at <A>x</A> of the embedding of the symmetric inverse
@@ -450,8 +450,8 @@ gap> AsBipartition(x, 11);
  [ -3 ], [ -4 ], [ -10 ], [ -11 ]>
 gap> AsBlockBijection(x, 10);
 Error, Semigroups: AsBlockBijection (for a partial perm and pos int):
-the 2nd argument must be at least the maximum of the degree and
-codegree of the 1st argument,
+the 2nd argument must be strictly greater than the maximum of the
+degree and codegree of the 1st argument,
 gap> AsBlockBijection(x, 11);
 <block bijection: [ 1, -9 ], [ 2, -5 ], [ 3, -6 ], 
  [ 4, 5, 8, 9, 11, -2, -3, -4, -10, -11 ], [ 6, -1 ], [ 7, -7 ], 

--- a/doc/bipart.xml
+++ b/doc/bipart.xml
@@ -433,16 +433,21 @@ the argument does not define a partial perm,]]></Example>
 
       If the optional second argument <A>n</A> is not present, then the maximum
       of the degree and codegree of <A>x</A> plus 1 is used by default. If the
-      second argument <A>n</A> is not greater than this maximum, then an Error
-      is returned.
+      second argument <A>n</A> is not greater than this maximum, then an error
+      is given.
       <P/>
 
       This is the value at <A>x</A> of the embedding of the symmetric inverse
       monoid into the dual symmetric inverse monoid given in the
       FitzGerald-Leech Theorem <Cite Key = "Fitzgerald1998aa"/>. 
+      <P/>
+
+      When the argument <A>x</A> is a partial perm bipartition (see <Ref
+        Prop="IsPartialPermBipartition" />) then this operation
+      returns <C>AsBlockBijection(AsPartialPerm(<A>x</A>)[, <A>n</A>])</C>.
 
 <Example><![CDATA[
-gap> x := PartialPerm([1, 2, 3, 6, 7, 10], [9, 5, 6, 1, 7, 8]) ;  
+gap> x := PartialPerm([1, 2, 3, 6, 7, 10], [9, 5, 6, 1, 7, 8]);
 [2,5][3,6,1,9][10,8](7)
 gap> AsBipartition(x, 11);
 <bipartition: [ 1, -9 ], [ 2, -5 ], [ 3, -6 ], [ 4 ], [ 5 ], 
@@ -455,7 +460,12 @@ degree and codegree of the 1st argument,
 gap> AsBlockBijection(x, 11);
 <block bijection: [ 1, -9 ], [ 2, -5 ], [ 3, -6 ], 
  [ 4, 5, 8, 9, 11, -2, -3, -4, -10, -11 ], [ 6, -1 ], [ 7, -7 ], 
- [ 10, -8 ]>]]></Example>
+ [ 10, -8 ]>
+gap> x := Bipartition([[1, -3], [2], [3, -2], [-1]]);;
+gap> IsPartialPermBipartition(x);
+true
+gap> AsBlockBijection(x);
+<block bijection: [ 1, -3 ], [ 2, 4, -1, -4 ], [ 3, -2 ]>]]></Example>
   </Description>
   </ManSection>
 <#/GAPDoc>

--- a/gap/elements/bipart.gd
+++ b/gap/elements/bipart.gd
@@ -62,6 +62,8 @@ DeclareOperation("AsBipartition", [IsPBR]);
 
 DeclareOperation("AsBlockBijection", [IsPartialPerm, IsPosInt]);
 DeclareOperation("AsBlockBijection", [IsPartialPerm]);
+DeclareOperation("AsBlockBijection", [IsBipartition, IsPosInt]);
+DeclareOperation("AsBlockBijection", [IsBipartition]);
 
 DeclareProperty("IsBlockBijection", IsBipartition);
 DeclareProperty("IsUniformBlockBijection", IsBipartition);

--- a/gap/elements/bipart.gd
+++ b/gap/elements/bipart.gd
@@ -61,7 +61,6 @@ DeclareOperation("AsBipartition", [IsPBR, IsZeroCyc]);
 DeclareOperation("AsBipartition", [IsPBR]);
 
 DeclareOperation("AsBlockBijection", [IsPartialPerm, IsPosInt]);
-DeclareOperation("AsBlockBijection", [IsPartialPerm, IsZeroCyc]);
 DeclareOperation("AsBlockBijection", [IsPartialPerm]);
 
 DeclareProperty("IsBlockBijection", IsBipartition);

--- a/gap/elements/bipart.gi
+++ b/gap/elements/bipart.gi
@@ -911,6 +911,28 @@ function(f, n)
   return out;
 end);
 
+InstallMethod(AsBlockBijection, "for a bipartition and pos int",
+[IsBipartition, IsPosInt],
+function(x, n)
+  if not IsPartialPermBipartition(x) then
+    ErrorNoReturn("Semigroups: AsBlockBijection (for a bipartition and pos ",
+                  "int):\n",
+                  "the argument <x> must be a partial perm bipartition,");
+  fi;
+  return AsBlockBijection(AsPartialPerm(x), n);
+end);
+
+InstallMethod(AsBlockBijection, "for a bipartition",
+[IsBipartition],
+function(x)
+  if not IsPartialPermBipartition(x) then
+    ErrorNoReturn("Semigroups: AsBlockBijection (for a bipartition):\n",
+                  "the argument <x> must be a partial perm bipartition,");
+  fi;
+  return AsBlockBijection(AsPartialPerm(x));
+end);
+
+
 InstallMethod(NaturalLeqBlockBijection, "for a bipartition and bipartition",
 IsIdenticalObj, [IsBipartition, IsBipartition],
 function(x, y)

--- a/gap/elements/bipart.gi
+++ b/gap/elements/bipart.gi
@@ -882,8 +882,8 @@ function(f, n)
   if n <= Maximum(DegreeOfPartialPerm(f), CodegreeOfPartialPerm(f)) then
     ErrorNoReturn("Semigroups: AsBlockBijection (for a partial perm and pos ",
                   "int):\n",
-                  "the 2nd argument must be at least the maximum of the ",
-                  "degree and\ncodegree of the 1st argument,");
+                  "the 2nd argument must be strictly greater than the maximum ",
+                  "of the\ndegree and codegree of the 1st argument,");
   fi;
 
   nr := 0;

--- a/gap/elements/bipart.gi
+++ b/gap/elements/bipart.gi
@@ -554,12 +554,6 @@ function(x)
                                      CodegreeOfPartialPerm(x)) + 1);
 end);
 
-InstallMethod(AsBlockBijection, "for a partial perm and zero",
-[IsPartialPerm, IsZeroCyc],
-function(x, n)
-  return Bipartition([]);
-end);
-
 # Viewing, printing etc
 
 InstallMethod(ViewString, "for a bipartition",

--- a/tst/standard/bipart.tst
+++ b/tst/standard/bipart.tst
@@ -397,7 +397,8 @@ gap> AsBipartition(Bipartition([[1, 2, -1, -2], [3, -3]]), 0);
 
 # bipartition: AsBlockBijection, for a partial perm and 0 1/1
 gap> AsBlockBijection(PartialPerm([4, 1, 3, 2]), 0);
-<empty bipartition>
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `AsBlockBijection' on 2 arguments
 
 # bipartition: AsBlockBijection, for a partial perm and pos int, error 1/1
 gap> AsBlockBijection(PartialPerm([1, 3, 2, 4]), 1);

--- a/tst/standard/bipart.tst
+++ b/tst/standard/bipart.tst
@@ -402,8 +402,8 @@ gap> AsBlockBijection(PartialPerm([4, 1, 3, 2]), 0);
 # bipartition: AsBlockBijection, for a partial perm and pos int, error 1/1
 gap> AsBlockBijection(PartialPerm([1, 3, 2, 4]), 1);
 Error, Semigroups: AsBlockBijection (for a partial perm and pos int):
-the 2nd argument must be at least the maximum of the degree and
-codegree of the 1st argument,
+the 2nd argument must be strictly greater than the maximum of the
+degree and codegree of the 1st argument,
 
 # bipartition: IsUniformBlockBijection, for a bipartition 1/3
 gap> IsUniformBlockBijection(Bipartition([[1, 2, -1, -2], [3, -3]]));

--- a/tst/standard/bipart.tst
+++ b/tst/standard/bipart.tst
@@ -668,6 +668,47 @@ true
 gap> PrintString(IdentityBipartition(0));
 "\>\>Bipartition(\< \>[]\<)\<"
 
+#T# bipartition: AsBlockBijection, for a partial perm bipartition
+gap> x := Bipartition([[1, 3], [2, 4, -2], [5, -1, -3, -4], [-5]]);;
+gap> AsBlockBijection(x);
+Error, Semigroups: AsBlockBijection (for a bipartition):
+the argument <x> must be a partial perm bipartition,
+gap> AsBlockBijection(x, 3);
+Error, Semigroups: AsBlockBijection (for a bipartition and pos int):
+the argument <x> must be a partial perm bipartition,
+gap> n := 4;;
+gap> S := SymmetricInverseMonoid(n);
+<symmetric inverse monoid of degree 4>
+gap> gens := List(GeneratorsOfInverseMonoid(S), AsBipartition);;
+gap> ForAll(gens, IsPartialPermBipartition);
+true
+gap> for x in gens do
+>   for y in gens do
+>     if not AsBlockBijection(x * y, n + 1)
+>         = AsBlockBijection(x, n + 1) * AsBlockBijection(y, n + 1) then
+>       Print("fail\n");
+>     fi;
+>   od;
+> od;
+gap> AsBlockBijection(One(gens[1])) = IdentityBipartition(5);
+true
+gap> x := Bipartition([[1, -4], [2, -1], [3], [4], [-2], [-3]]);;
+gap> AsBlockBijection(x, 0);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `AsBlockBijection' on 2 arguments
+gap> AsBlockBijection(x, 3);
+Error, Semigroups: AsBlockBijection (for a partial perm and pos int):
+the 2nd argument must be strictly greater than the maximum of the
+degree and codegree of the 1st argument,
+gap> AsBlockBijection(x, 4);
+Error, Semigroups: AsBlockBijection (for a partial perm and pos int):
+the 2nd argument must be strictly greater than the maximum of the
+degree and codegree of the 1st argument,
+gap> AsBlockBijection(x);
+<block bijection: [ 1, -4 ], [ 2, -1 ], [ 3, 4, 5, -2, -3, -5 ]>
+gap> AsBlockBijection(x, 6);
+<block bijection: [ 1, -4 ], [ 2, -1 ], [ 3, 4, 5, 6, -2, -3, -5, -6 ]>
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(N);


### PR DESCRIPTION
This addresses a card from Trello.

A partial perm bipartition naturally defines a partial perm, and a partial perm can be converted into a block bijection in a nice way (via a monoid embedding). Thus we should be able to convert partial perm bipartitions to block bijections in this way.

I believe that the resulting conversion is indeed a monoid embedding.