### PR TITLE
Fix IsSemigroupWithCommutingIdempotents

### DIFF
--- a/doc/properties.xml
+++ b/doc/properties.xml
@@ -94,12 +94,10 @@ true]]></Example>
 <#GAPDoc Label="IsBlockGroup">
   <ManSection>
     <Prop Name = "IsBlockGroup" Arg = "S"/>
-    <Prop Name = "IsSemigroupWithCommutingIdempotents" Arg = "S"/>
     <Returns><K>true</K> or <K>false</K>.</Returns>
     <Description>
-      <C>IsBlockGroup</C> and <C>IsSemigroupWithCommutingIdempotents</C> return
-      <K>true</K> if the semigroup <A>S</A> is a block group and <K>false</K>
-      if it is not.<P/>
+      <C>IsBlockGroup</C> returns <K>true</K> if the semigroup <A>S</A> is a
+      block group and <K>false</K> if it is not.<P/>
 
       A semigroup <A>S</A> is a <E>block group</E> if every &L;-class and every
       &R;-class of <A>S</A> contains at most one idempotent. Every semigroup
@@ -843,6 +841,40 @@ gap> S := Semigroup(Transformation([1, 2, 3, 3, 1]),
 gap> IsRightZeroSemigroup(S);
 true]]></Example>
     </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsSemigroupWithCommutingIdempotents">
+  <ManSection>
+    <Prop Name = "IsSemigroupWithCommutingIdempotents" Arg = "S"/>
+    <Returns><K>true</K> or <K>false</K>.</Returns>
+    <Description>
+      <C>IsSemigroupWithIdempotents</C> returns <K>true</K> if the idempotents
+      of the semigroup <A>S</A> commute, and <K>false</K> if they do not. Note
+      that such an semigroup is also a block group; see <Ref
+        Prop="IsBlockGroup"/>. <P/>
+
+      Note that the idempotents commute in any inverse semigroup, in any
+      semigroup of partial permutations, and in any semigroup of block
+      bijections. 
+      <Example><![CDATA[
+gap> x := Transformation([2, 2]);;
+gap> y := Transformation([1, 3, 3]);;
+gap> S := Semigroup(x, y);
+<transformation semigroup of degree 3 with 2 generators>
+gap> IsSemigroupWithCommutingIdempotents(S);
+true
+gap> S := FullTransformationMonoid(4);
+<full transformation monoid of degree 4>
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
+gap> W := Semigroup([
+>  Bipartition([[1, 2, 3, -1, -2, -4], [4, -3]]),
+>  Bipartition([[1, 2, -4], [3, -3], [4, -1, -2]])]);
+<block bijection semigroup of degree 4 with 2 generators>
+gap> IsSemigroupWithCommutingIdempotents(S);
+true]]></Example>
+    </Description> 
   </ManSection>
 <#/GAPDoc>
 

--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -407,6 +407,9 @@ end);
 InstallMethod(StructureDescription, "for a group as semigroup",
 [IsGroupAsSemigroup],
 function(S)
+  if IsGroup(S) then
+    TryNextMethod();
+  fi;
   return StructureDescription(Range(IsomorphismPermGroup(S)));
 end);
 

--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -31,7 +31,7 @@ DeclareProperty("IsMonogenicInverseMonoid", IsMonoid);
 DeclareOperation("IsRegularSemigroupElementNC",
                  [IsSemigroup, IsMultiplicativeElement]);
 DeclareProperty("IsRightSimple", IsSemigroup);
-DeclareSynonymAttr("IsSemigroupWithCommutingIdempotents", IsBlockGroup);
+DeclareProperty("IsSemigroupWithCommutingIdempotents", IsSemigroup);
 DeclareProperty("IsUnitRegularMonoid", IsSemigroup);
 DeclareProperty("IsZeroRectangularBand", IsSemigroup);
 DeclareProperty("IsCongruenceFreeSemigroup", IsSemigroup);
@@ -48,8 +48,12 @@ InstallTrueMethod(IsGeneratorsOfInverseSemigroup,
 InstallTrueMethod(IsGeneratorsOfInverseSemigroup, 
                   IsInverseSemigroup and IsPartialPermBipartitionSemigroup);
 
-InstallTrueMethod(IsBlockGroup, IsInverseSemigroup);
-InstallTrueMethod(IsBlockGroup, IsPartialPermSemigroup);
+InstallTrueMethod(IsSemigroupWithCommutingIdempotents, IsCommutativeSemigroup);
+InstallTrueMethod(IsSemigroupWithCommutingIdempotents, IsInverseSemigroup);
+InstallTrueMethod(IsSemigroupWithCommutingIdempotents, IsPartialPermSemigroup);
+InstallTrueMethod(IsSemigroupWithCommutingIdempotents, IsBlockBijectionSemigroup);
+InstallTrueMethod(IsSemigroupWithCommutingIdempotents, IsNilpotentSemigroup);
+InstallTrueMethod(IsBlockGroup, IsSemigroupWithCommutingIdempotents);
 InstallTrueMethod(IsDTrivial, IsSemilattice);
 InstallTrueMethod(IsHTrivial, IsLTrivial);
 InstallTrueMethod(IsHTrivial, IsRTrivial);

--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -72,6 +72,27 @@ function(S)
   return true;
 end);
 
+InstallMethod(IsSemigroupWithCommutingIdempotents, "for a semigroup",
+[IsSemigroup],
+function(S)
+  local ids, n, i, j;
+  ids := Idempotents(S);
+  n := Length(ids);
+  for i in [1 .. n - 1] do
+    for j in [i + 1 .. n] do
+      if ids[i] * ids[j] <> ids[j] * ids[i] then
+        return false;
+      fi;
+    od;
+  od;
+  return true;
+end);
+
+InstallMethod(IsSemigroupWithCommutingIdempotents,
+"for a semigroup with idempotent generated subsemigroup",
+[IsSemigroup and HasIdempotentGeneratedSubsemigroup],
+S -> IsCommutativeSemigroup(IdempotentGeneratedSubsemigroup(S)));
+
 # same method for ideals
 
 InstallMethod(IsBrandtSemigroup, "for a semigroup",

--- a/tst/extreme/examples.tst
+++ b/tst/extreme/examples.tst
@@ -49,6 +49,8 @@ gap> Size(MinimalIdeal(S));
 8
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -125,6 +127,8 @@ gap> Size(MinimalIdeal(S));
 8
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -200,6 +204,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 8
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -283,6 +289,8 @@ gap> Size(MinimalIdeal(S));
 7
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -357,6 +365,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 5
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -434,6 +444,8 @@ gap> Size(MinimalIdeal(S));
 4
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -509,6 +521,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 4
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -586,6 +600,8 @@ gap> Size(MinimalIdeal(S));
 4
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -659,6 +675,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 20160
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -736,6 +754,8 @@ gap> Size(MinimalIdeal(S));
 8
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -809,6 +829,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 11
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -885,6 +907,8 @@ gap> Size(MinimalIdeal(S));
 10
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -960,6 +984,8 @@ gap> Size(MinimalIdeal(S));
 5
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -1033,6 +1059,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 1
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -1108,6 +1136,8 @@ gap> Size(MinimalIdeal(S));
 12
 gap> IsBlockGroup(S);
 true
+gap> IsSemigroupWithCommutingIdempotents(S);
+true
 gap> IsCliffordSemigroup(S);
 true
 gap> IsCommutative(S);
@@ -1182,6 +1212,8 @@ gap> Size(MinimalIdeal(S));
 1
 gap> IsBlockGroup(S);
 true
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -1255,6 +1287,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 36
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -1330,6 +1364,8 @@ gap> Size(MinimalIdeal(S));
 96
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -1403,6 +1439,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 8
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -1478,6 +1516,8 @@ gap> Size(MinimalIdeal(S));
 10080
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -1551,6 +1591,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 8
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -1626,6 +1668,8 @@ gap> Size(MinimalIdeal(S));
 1
 gap> IsBlockGroup(S);
 true
+gap> IsSemigroupWithCommutingIdempotents(S);
+true
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -1699,6 +1743,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 1
 gap> IsBlockGroup(S);
+true
+gap> IsSemigroupWithCommutingIdempotents(S);
 true
 gap> IsCliffordSemigroup(S);
 false
@@ -1774,6 +1820,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 720
 gap> IsBlockGroup(S);
+true
+gap> IsSemigroupWithCommutingIdempotents(S);
 true
 gap> IsCliffordSemigroup(S);
 true
@@ -1857,6 +1905,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 1
 gap> IsBlockGroup(S);
+true
+gap> IsSemigroupWithCommutingIdempotents(S);
 true
 gap> IsCliffordSemigroup(S);
 true
@@ -1950,6 +2000,8 @@ gap> Size(MinimalIdeal(S));
 24
 gap> IsBlockGroup(S);
 true
+gap> IsSemigroupWithCommutingIdempotents(S);
+true
 gap> IsCliffordSemigroup(S);
 true
 gap> IsCommutative(S);
@@ -2025,6 +2077,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 16
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -2105,6 +2159,8 @@ gap> Size(MinimalIdeal(S));
 1152
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -2180,6 +2236,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 16
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false
@@ -2261,6 +2319,8 @@ gap> Size(MinimalIdeal(S));
 7
 gap> IsBlockGroup(S);
 false
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
 gap> IsCliffordSemigroup(S);
 false
 gap> IsCommutative(S);
@@ -2336,6 +2396,8 @@ gap> if GroupOfUnits(S) <> fail then
 gap> Size(MinimalIdeal(S));
 9
 gap> IsBlockGroup(S);
+false
+gap> IsSemigroupWithCommutingIdempotents(S);
 false
 gap> IsCliffordSemigroup(S);
 false

--- a/tst/standard/cong.tst
+++ b/tst/standard/cong.tst
@@ -58,7 +58,7 @@ true
 gap> IsRegularSemigroup(S);
 true
 gap> SemigroupCongruence(S, [S.1, S.1]);
-<semigroup congruence over <commutative 0-simple regular transformation 
+<semigroup congruence over <commutative 0-simple inverse transformation 
  monoid of degree 2 with 1 generator> with linked triple (1,1,1)>
 
 #T# SemigroupCongruence: Inverse semigroup
@@ -122,7 +122,7 @@ gap> pairs := [ReesZeroMatrixSemigroupElement(R, 1, (), 1),
 >              ReesZeroMatrixSemigroupElement(R, 1, (), 1)];;
 gap> rmscong := SemigroupCongruence(R, pairs);;
 gap> SemigroupCongruence(S, iso, rmscong);
-<semigroup congruence over <commutative 0-simple regular transformation 
+<semigroup congruence over <commutative 0-simple inverse transformation 
  monoid of degree 2 with 1 generator> with linked triple (1,1,1)>
 
 #T# SemigroupCongruence: Bad R(Z)MS Input

--- a/tst/standard/properties.tst
+++ b/tst/standard/properties.tst
@@ -172,6 +172,9 @@ true
 #T# properties: IsBlockGroup, for an infinite semigroup, 5/?
 gap> S := FreeSemigroup(1);;
 gap> IsBlockGroup(S);
+true
+gap> S := FreeSemigroup(2);;
+gap> IsBlockGroup(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 3rd choice method found for `IsBlockGroup' on 1 arguments
 
@@ -1772,6 +1775,59 @@ false
 gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(4), [[(1,3,2), (4,2)]]);
 <Rees 0-matrix semigroup 2x1 over Sym( [ 1 .. 4 ] )>
 gap> IsSemigroupWithAdjoinedZero(S);
+true
+
+#T# properties: IsSemigroupWithCommutingIdempotents, 1
+gap> S := SymmetricInverseMonoid(3);;
+gap> IsSemigroupWithCommutingIdempotents(S);
+true
+gap> S := FullTransformationMonoid(4);;
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
+
+# Example of a block group whose idempotents do not commute
+gap> S := Semigroup([Transformation([2, 2]), Transformation([1, 3, 3])]);;
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
+gap> IsBlockGroup(S);
+true
+
+#
+gap> S := MonogenicSemigroup(5, 8);;
+gap> IsSemigroupWithCommutingIdempotents(S);
+true
+gap> S := Semigroup([
+> Transformation([6, 9, 9, 10, 13, 1, 9, 9, 9, 4, 9, 9, 5, 9, 9, 9, 9, 9,
+>  9, 1]),
+> Transformation([7, 9, 9, 11, 14, 2, 9, 9, 9, 16, 9, 9, 18, 9, 9, 9, 9, 9,
+>  9, 2]),
+> Transformation([8, 9, 9, 12, 15, 3, 9, 9, 9, 17, 9, 9, 19, 9, 9, 9, 9, 9,
+>  9, 3]),
+> Transformation([9, 6, 9, 9, 9, 9, 1, 9, 9, 9, 4, 9, 9, 5, 9, 10, 9, 13, 9,
+>  4]),
+> Transformation([9, 9, 6, 9, 9, 9, 9, 1, 9, 9, 9, 4, 9, 9, 5, 9, 10, 9, 13,
+>  5])]);;
+gap> IsSemigroupWithCommutingIdempotents(S);
+true
+
+#T# properties: IsSemigroupWithCommutingIdempotents, 2
+gap> S := FullTransformationMonoid(3);;
+gap> IdempotentGeneratedSubsemigroup(S);;
+gap> IsSemigroupWithCommutingIdempotents(S);
+false
+gap> S := Semigroup([
+> Transformation([6, 9, 9, 10, 13, 1, 9, 9, 9, 4, 9, 9, 5, 9, 9, 9, 9, 9,
+>  9, 1]),
+> Transformation([7, 9, 9, 11, 14, 2, 9, 9, 9, 16, 9, 9, 18, 9, 9, 9, 9, 9,
+>  9, 2]),
+> Transformation([8, 9, 9, 12, 15, 3, 9, 9, 9, 17, 9, 9, 19, 9, 9, 9, 9, 9,
+>  9, 3]),
+> Transformation([9, 6, 9, 9, 9, 9, 1, 9, 9, 9, 4, 9, 9, 5, 9, 10, 9, 13, 9,
+>  4]),
+> Transformation([9, 9, 6, 9, 9, 9, 9, 1, 9, 9, 9, 4, 9, 9, 5, 9, 10, 9, 13,
+>  5])]);;
+gap> IdempotentGeneratedSubsemigroup(S);;
+gap> IsSemigroupWithCommutingIdempotents(S);
 true
 
 #T# SEMIGROUPS_UnbindVariables

--- a/tst/standard/semiex.tst
+++ b/tst/standard/semiex.tst
@@ -1144,7 +1144,7 @@ false
 gap> StructureDescriptionMaximalSubgroups(S);
 [ "1", "C2", "S4" ]
 gap> S := ModularPartitionMonoid(5, 4);
-<regular block bijection *-monoid of degree 4 with 3 generators>
+<inverse block bijection monoid of degree 4 with 3 generators>
 gap> Size(S);
 131
 gap> Size(Generators(S));
@@ -1224,7 +1224,7 @@ false
 gap> StructureDescriptionMaximalSubgroups(S);
 [ "1", "C2" ]
 gap> S := SingularModularPartitionMonoid(5, 4);
-<regular bipartition *-semigroup ideal of degree 4 with 1 generator>
+<inverse bipartition semigroup ideal of degree 4 with 1 generator>
 gap> Size(S);
 107
 gap> Size(Generators(S));
@@ -1666,7 +1666,7 @@ gap> NrIdempotents(S);
 gap> IsRegularSemigroup(S);
 true
 gap> S := PartialOrderEndomorphisms(1);
-<commutative regular transformation monoid of degree 2 with 1 generator>
+<commutative inverse transformation monoid of degree 2 with 1 generator>
 
 # Test OrderAntiEndomorphisms
 gap> S := OrderAntiEndomorphisms(4);
@@ -1710,7 +1710,7 @@ gap> S := PartialOrderAntiEndomorphisms(1);
 
 # Test PartialTranformationMonoid
 gap> S := PartialTransformationMonoid(1);
-<commutative regular transformation monoid of degree 2 with 1 generator>
+<commutative inverse transformation monoid of degree 2 with 1 generator>
 gap> Size(S);
 2
 gap> NrLClasses(S);
@@ -1817,7 +1817,7 @@ gap> JonesMonoid(0);
 gap> JonesMonoid(1);
 <trivial block bijection group of degree 1 with 1 generator>
 gap> JonesMonoid(2);
-<commutative regular bipartition *-monoid of degree 2 with 1 generator>
+<commutative inverse bipartition monoid of degree 2 with 1 generator>
 gap> JonesMonoid(5);
 <regular bipartition *-monoid of degree 5 with 4 generators>
 
@@ -1923,8 +1923,7 @@ gap> SingularJonesMonoid(1);
 Error, Semigroups: SingularJonesMonoid: usage,
 the argument must be greater than 1,
 gap> SingularJonesMonoid(2);
-<commutative regular bipartition *-semigroup ideal of degree 2 with
-  1 generator>
+<commutative inverse bipartition semigroup ideal of degree 2 with 1 generator>
 gap> SingularJonesMonoid(5);
 <regular bipartition *-semigroup ideal of degree 5 with 1 generator>
 


### PR DESCRIPTION
Previously `IsSemigroupWithCommutingIdempotents` was a synonym for `IsBlockGroup`. This was mathematically incorrect.

A semigroup with commuting idempotents is necessarily a block group, but the converse is not necessarily true.