### PR TITLE
Fix Issue #253 (IsIdempotentGenerated)

### DIFF
--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -553,10 +553,13 @@ end);
 InstallMethod(IdempotentGeneratedSubsemigroup, "for a semigroup",
 [IsSemigroup],
 function(S)
+  local out;
   if not IsFinite(S) then
     TryNextMethod();
   fi;
-  return Semigroup(Idempotents(S), rec(small := true));
+  out := Semigroup(Idempotents(S), rec(small := true));
+  SetIsIdempotentGenerated(out, true);
+  return out;
 end);
 
 InstallMethod(InjectionPrincipalFactor, "for a Green's D-class (Semigroups)",

--- a/gap/attributes/attrinv.gi
+++ b/gap/attributes/attrinv.gi
@@ -15,12 +15,15 @@ InstallMethod(IdempotentGeneratedSubsemigroup,
 "for an inverse semigroup with inverse op",
 [IsInverseSemigroup and IsGeneratorsOfInverseSemigroup],
 function(S)
+  local out;
   if not IsFinite(S) then
     TryNextMethod();
   fi;
   # Use acting := false since the output of this is a semilattice which is
   # J-trivial and hence it is better to use the Froidure-Pin Algorithm
-  return InverseSemigroup(Idempotents(S), rec(small := true, acting := false));
+  out := InverseSemigroup(Idempotents(S), rec(small := true, acting := false));
+  SetIsSemilattice(out, true);
+  return out;
 end);
 
 # fall back method

--- a/gap/semigroups/semirms.gi
+++ b/gap/semigroups/semirms.gi
@@ -898,6 +898,21 @@ function(R)
   return Semigroup(Filtered(MatrixEntries(N), x -> x <> 0)) = U;
 end);
 
+InstallMethod(IsIdempotentGenerated, "for a Rees matrix subsemigroup",
+[IsReesMatrixSubsemigroup],
+function(R)
+  local U, N;
+  if not IsReesMatrixSemigroup(R) then
+    TryNextMethod();
+  fi;
+  U := UnderlyingSemigroup(R);
+  if not IsGroupAsSemigroup(U) then
+    TryNextMethod();
+  fi;
+  N := Range(RMSNormalization(R));
+  return Semigroup(MatrixEntries(N)) = U;
+end);
+
 # The next two methods are just copies of the methods in the library but with
 # the rank increased so they are used in favour of the method for
 # IsEnumerableSemigroupRep

--- a/gap/semigroups/semirms.gi
+++ b/gap/semigroups/semirms.gi
@@ -881,16 +881,21 @@ function(R)
   return MagmaIsomorphismByFunctionsNC(R, S, iso, inv);
 end);
 
-InstallMethod(IsIdempotentGenerated, "for a Rees 0-matrix semigroup",
-[IsReesZeroMatrixSemigroup],
+InstallMethod(IsIdempotentGenerated, "for a Rees 0-matrix subsemigroup",
+[IsReesZeroMatrixSubsemigroup],
 function(R)
-  local RR;
-  if not IsConnectedDigraph(RZMSDigraph(R)) then
+  local U, N;
+  if not IsReesZeroMatrixSemigroup(R) then
+    TryNextMethod();
+  elif not IsConnectedDigraph(RZMSDigraph(R)) then
     return false;
   fi;
-  RR := Range(RZMSNormalization(R));
-  return Group(Filtered(MatrixEntries(RR), x -> x <> 0)) =
-    UnderlyingSemigroup(RR);
+  U := UnderlyingSemigroup(R);
+  if not IsGroupAsSemigroup(U) then
+    TryNextMethod();
+  fi;
+  N := Range(RZMSNormalization(R));
+  return Semigroup(Filtered(MatrixEntries(N), x -> x <> 0)) = U;
 end);
 
 # The next two methods are just copies of the methods in the library but with

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -716,6 +716,8 @@ gap> StructureDescriptionMaximalSubgroups(S);
 #T# attr: IdempotentGeneratedSubsemigroup
 gap> S := RegularBooleanMatMonoid(3);;
 gap> T := IdempotentGeneratedSubsemigroup(S);;
+gap> HasIsIdempotentGenerated(T) and IsIdempotentGenerated(T);
+true
 gap> Size(T);
 381
 
@@ -833,8 +835,10 @@ Error, no 3rd choice method found for `MinimalIdeal' on 1 arguments
 
 #T# attr: IdempotentGeneratedSubsemigroup, inverse op 1/1
 gap> S := DualSymmetricInverseMonoid(2);;
-gap> IdempotentGeneratedSubsemigroup(S);
+gap> T := IdempotentGeneratedSubsemigroup(S);
 <commutative inverse block bijection monoid of degree 2 with 1 generator>
+gap> HasIsIdempotentGenerated(T) and IsIdempotentGenerated(T);
+true
 
 #T# attr: MultiplicativeZero, infinite 1/1
 #gap> MultiplicativeZero(FreeMonoid(2)); 

--- a/tst/standard/attrinv.tst
+++ b/tst/standard/attrinv.tst
@@ -1006,7 +1006,9 @@ gap> S := InverseSemigroup([
 >  PartialPerm([1, 2, 3, 4], [6, 2, 4, 3]),
 >  PartialPerm([1, 2, 3, 5], [5, 6, 3, 2]),
 >  PartialPerm([1, 2, 5], [3, 5, 4])]);;
-gap> IdempotentGeneratedSubsemigroup(S);;
+gap> S := IdempotentGeneratedSubsemigroup(S);;
+gap> HasIsIdempotentGenerated(S) and IsIdempotentGenerated(S);
+true
 
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(D);

--- a/tst/standard/properties.tst
+++ b/tst/standard/properties.tst
@@ -712,7 +712,7 @@ gap> S := Semigroup([PartialPerm([1, 2, 4, 5], [1, 2, 4, 5]),
 gap> IsIdempotentGenerated(S);
 false
 
-#T# properties: IsIdempotentGenerated, 4
+#T# properties: IsIdempotentGenerated, 6
 gap> S := FreeSemigroup(1);;
 gap> IsIdempotentGenerated(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
@@ -722,6 +722,38 @@ Error, no 3rd choice method found for `IsIdempotentGenerated' on 1 arguments
 gap> S := AsSemigroup(IsBooleanMatSemigroup, 
 >                     SingularTransformationMonoid(3));;
 gap> IsIdempotentGenerated(S);
+true
+
+#T# properties: IsIdempotentGenerated, 7
+
+# Performance testing: T_9 used to take seconds
+gap> S := FullTransformationMonoid(9);;
+gap> S := Monoid(S, rec(acting := true));;
+gap> IsIdempotentGenerated(S);
+false
+gap> S := Semigroup(GeneratorsOfMonoid(S), rec(acting := true));;
+gap> IsIdempotentGenerated(S);
+false
+
+# Coverage and performance testing
+gap> S := FullTransformationMonoid(8);;
+gap> S := Semigroup(GeneratorsOfMonoid(S), rec(acting := true));;
+gap> IsIdempotentGenerated(S);
+false
+gap> S := Semigroup(S, rec(acting := true));;
+gap> Idempotents(S);;
+gap> IsIdempotentGenerated(S);
+false
+
+#T# properties: IsIdempotentGenerated, 8
+gap> S := Semigroup([Transformation([3, 2, 1]), Transformation([2, 2, 2])]);
+<transformation semigroup of degree 3 with 2 generators>
+gap> IsIdempotentGenerated(S);
+false
+gap> I := SemigroupIdeal(S, S.1 ^ 2);;
+gap> IsIdempotentGenerated(I);
+false
+gap> I = S;
 true
 
 #T# properties: IsInverseSemigroup, 1

--- a/tst/standard/semirms.tst
+++ b/tst/standard/semirms.tst
@@ -2284,7 +2284,7 @@ gap> Idempotents(R);
 [ (1,Transformation( [ 1, 1, 1 ] ),1), (2,Transformation( [ 1, 1, 1 ] ),1), 0 
  ]
 
-# Test IsIdempotentGenerated
+#T# IsIdempotentGenerated, for an RZMS
 gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(4),
 > [[(1, 3, 2), (), (1, 4, 2)],
 >  [(), (1, 3)(2, 4), (1, 2, 3, 4)],
@@ -2302,6 +2302,50 @@ gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(4),
 gap> IsIdempotentGenerated(R);
 false
 
+# ReesZeroMatrixSubsemigroup is not a ReesZeroMatrixSemigroup
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[(), 0], [0, ()]]);
+<Rees 0-matrix semigroup 2x2 over Group(())>
+gap> S := Semigroup(Idempotents(R));
+<subsemigroup of 2x2 Rees 0-matrix semigroup with 3 generators>
+gap> IsIdempotentGenerated(S);
+true
+
+# UnderlyingSemigroup is not IsGroup
+gap> R := ReesZeroMatrixSemigroup(Semigroup(Transformation([2, 1])),
+> [[Transformation([2, 1])]]);
+<Rees 0-matrix semigroup 1x1 over <commutative transformation semigroup of 
+  degree 2 with 1 generator>>
+gap> IsIdempotentGenerated(R);
+false
+gap> R := ReesZeroMatrixSemigroup(Semigroup(Transformation([2, 1])),
+> [[IdentityTransformation, IdentityTransformation],
+>  [IdentityTransformation, Transformation([2, 1])]]);
+<Rees 0-matrix semigroup 2x2 over <commutative transformation semigroup of 
+  degree 2 with 1 generator>>
+gap> IsIdempotentGenerated(R);
+true
+
+# UnderlyingSemigroup is not IsGroupAsSemigroup
+gap> mat := [[
+>  Transformation([2, 3, 1]),
+>  Transformation([2, 1]),
+>  Transformation([1, 2, 1])]];;
+gap> R := ReesZeroMatrixSemigroup(FullTransformationMonoid(3), mat);
+<Rees 0-matrix semigroup 3x1 over <full transformation monoid of degree 3>>
+gap> IsIdempotentGenerated(R);
+false
+gap> R = Semigroup(Idempotents(R));
+false
+gap> S := Monoid([
+>  Transformation([1, 2, 3, 1]), Transformation([2, 1, 3, 1]),
+>  Transformation([2, 3, 3, 1]), Transformation([3, 2, 3, 1]),
+>  Transformation([3, 3, 1, 2]), Transformation([3, 4, 1, 1]),
+>  Transformation([4, 1, 2, 2]), Transformation([4, 2, 3, 3])]);;
+gap> R := ReesZeroMatrixSemigroup(S, [[IdentityTransformation]]);
+<Rees 0-matrix semigroup 1x1 over <transformation monoid of degree 4 with 8 
+  generators>>
+gap> IsIdempotentGenerated(R);
+true
 # Test Size for infinite RMS and RZMS
 gap> S := FreeSemigroup(2);;
 gap> R := ReesZeroMatrixSemigroup(S, [[S.1]]);

--- a/tst/standard/semirms.tst
+++ b/tst/standard/semirms.tst
@@ -2346,6 +2346,63 @@ gap> R := ReesZeroMatrixSemigroup(S, [[IdentityTransformation]]);
   generators>>
 gap> IsIdempotentGenerated(R);
 true
+
+#T# IsIdempotentGenerated, for an RMS
+gap> R := ReesMatrixSemigroup(SymmetricGroup(4),
+> [[(1, 3, 2), (), (1, 4, 2)],
+>  [(), (1, 3)(2, 4), (1, 2, 3, 4)],
+>  [(3, 4), (), (1, 2, 4, 3)],
+>  [(), (2, 4, 3), (1, 2)]]);;
+gap> IsIdempotentGenerated(R);
+true
+
+# ReesMatrixSubsemigroup is not a ReesMatrixSemigroup
+gap> R := ReesMatrixSemigroup(SymmetricInverseMonoid(1),
+> [[PartialPerm([]), PartialPerm([])]]);
+<Rees matrix semigroup 2x1 over <symmetric inverse monoid of degree 1>>
+gap> S := Semigroup(RMSElement(R, 1, PartialPerm([1]), 1),
+>                   RMSElement(R, 2, PartialPerm([]), 1));
+<subsemigroup of 2x1 Rees matrix semigroup with 2 generators>
+gap> IsIdempotentGenerated(S);
+false
+
+# UnderlyingSemigroup is not IsGroup
+gap> R := ReesMatrixSemigroup(Semigroup(Transformation([2, 1])),
+> [[Transformation([2, 1])]]);
+<Rees matrix semigroup 1x1 over <commutative transformation semigroup of 
+  degree 2 with 1 generator>>
+gap> IsIdempotentGenerated(R);
+false
+gap> R := ReesMatrixSemigroup(Semigroup(Transformation([2, 1])),
+> [[IdentityTransformation, IdentityTransformation],
+>  [IdentityTransformation, Transformation([2, 1])]]);
+<Rees matrix semigroup 2x2 over <commutative transformation semigroup of 
+  degree 2 with 1 generator>>
+gap> IsIdempotentGenerated(R);
+true
+
+# UnderlyingSemigroup is not IsGroupAsSemigroup
+gap> mat := [[
+>  Transformation([2, 3, 1]),
+>  Transformation([2, 1]),
+>  Transformation([1, 2, 1])]];;
+gap> R := ReesMatrixSemigroup(FullTransformationMonoid(3), mat);
+<Rees matrix semigroup 3x1 over <full transformation monoid of degree 3>>
+gap> IsIdempotentGenerated(R);
+false
+gap> R = Semigroup(Idempotents(R));
+false
+gap> S := Monoid([
+>  Transformation([1, 2, 3, 1]), Transformation([2, 1, 3, 1]),
+>  Transformation([2, 3, 3, 1]), Transformation([3, 2, 3, 1]),
+>  Transformation([3, 3, 1, 2]), Transformation([3, 4, 1, 1]),
+>  Transformation([4, 1, 2, 2]), Transformation([4, 2, 3, 3])]);;
+gap> R := ReesMatrixSemigroup(S, [[IdentityTransformation]]);
+<Rees matrix semigroup 1x1 over <transformation monoid of degree 4 with 8 
+  generators>>
+gap> IsIdempotentGenerated(R);
+true
+
 # Test Size for infinite RMS and RZMS
 gap> S := FreeSemigroup(2);;
 gap> R := ReesZeroMatrixSemigroup(S, [[S.1]]);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1514,6 +1514,19 @@ gap> Set(PrimitiveIdempotents(T));
   Transformation( [ 6, 6, 6, 4, 6, 6 ] ), 
   Transformation( [ 6, 6, 6, 6, 5, 6 ] ) ]
 
+#T# Issue 253: IsIdempotentGenerated
+
+# Problem with IsIdempotentGenerated for ideals
+gap> S := Semigroup([Transformation([3, 2, 1]), Transformation([2, 2, 2])]);
+<transformation semigroup of degree 3 with 2 generators>
+gap> IsIdempotentGenerated(S);
+false
+gap> I := SemigroupIdeal(S, S.1 ^ 2);;
+gap> IsIdempotentGenerated(I);
+false
+gap> I = S;
+true
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(D);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1527,6 +1527,17 @@ false
 gap> I = S;
 true
 
+# Problem with IsIdempotentGenerated for Rees 0-matrix semigroups over
+# non-groups
+gap> mat := [[
+>  Transformation([2, 3, 1]),
+>  Transformation([2, 1]),
+>  Transformation([1, 2, 1])]];;
+gap> R := ReesZeroMatrixSemigroup(FullTransformationMonoid(3), mat);
+<Rees 0-matrix semigroup 3x1 over <full transformation monoid of degree 3>>
+gap> IsIdempotentGenerated(R);
+false
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(D);


### PR DESCRIPTION
This PR addresses Issue #253 and makes some small improvements.

The default `IsIdempotentGenerated` method, given a semigroup `S`, first checks where the "generators" of `S` are idempotents. That's a good idea for semigroups and semigroup generating sets, but for ideals it was using the ideal generating set. Therefore I've replaced `Generators` by `GeneratorsOfSemigroup`.

I've added another check here, for monoids. The only elements of a monoid which can be multiplied together to produce an element of the group of units are themselves units. Since the only unit which is an idempotent is the identity, and since the subsemigroup generated by the identity is trivial, the idempotent generated subsemigroup of a monoid has a trivial group of units. Therefore, for a monoid to be idempotent generated, its group of units must be trivial.

When none of the easy cases give an answer, the method then creates the idempotent generated subsemigroup, or, when the semigroup is an acting semigroup, a (possibly smaller) idempotent generated subsemigroup, in order to check whether the generators of `S` are contained in this subsemigroup. This code called `Idempotent(S)` and then filtered them by rank. In the case that we know the idempotents already, that's fine. However, my experiments have shown that when the idempotents are not known, it's best to find the idempotents of the particular ranks that we want, using `Idempotents(S, rank)` for each appropriate rank.

Also, for this special code which applies only to acting semigroups, I now create this idempotent generated subsemigroup as an acting semigroup. This allows me to include examples such as
 ```IsIdempotentGeneratedSemigroup(Semigroup(FullTransformationMonoid(9), rec(acting := true)));```
in the tests.

Finally, I fixed the issues that I found with `IsIdempotentGenerated` for a RZMS (it gave an error when the underlying semigroup was not `IsGroup`; it now works for the more general `IsGroupAsSemigroup` but properly tries the next method otherwise), and I've introduced an analogous method for RMS's.

I made a related change: the idempotent generated subsemigroup of a semigroup now knows that it is idempotent generated, and the idempotent generated subsemigroup of an inverse semigroup now knows that it is a semilattice.