### PR TITLE
Use gaplint and code-coverage in the Travis tests

### DIFF
--- a/.covignore
+++ b/.covignore
@@ -1,0 +1,1 @@
+idealenum.tst

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ env:
     - IO=io-4.4.6
     - GAPDOC=GAPDoc-1.5.1
     - ORB=orb-4.7.6
+    - PROFILING=1.3.0
     - GENSS=genss-1.6.4
   matrix:
-    - GAP_BRANCH=master GAP_FORK=gap-system
+    - GAP_BRANCH=master GAP_FORK=gap-system COVERAGE=1
     - GAP_BRANCH=master GAP_FORK=gap-system GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"
       # - GAP_BRANCH=stable-4.8 GAP_FORK=gap-system
       # - GAP_BRANCH=stable-4.8 GAP_FORK=gap-system GAP_FLAGS="ABI=32 --host=i686-linux-gnumake" PKG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 --host=i686-linux-gnu"

--- a/gap/main/setup.gi
+++ b/gap/main/setup.gi
@@ -1,28 +1,12 @@
 ###########################################################################
 ##
 #W  setup.gi
-#Y  Copyright (C) 2013-15                                James D. Mitchell
+#Y  Copyright (C) 2013-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
 #############################################################################
 ##
-
-SEMIGROUPS.HashFunctionRZMSE := function(x, data, func, dataishashlen)
-  if x![1] = 0 then
-    return 1;
-  fi;
-  #Use some big primes that are near the default hash table size
-  if IsNBitsPcWordRep(x![2]) then
-    return (104723 * x![1] + 104729 * x![3] + func(x![2], data))
-      mod data[2] + 1;
-  elif dataishashlen then
-    return (104723 * x![1] + 104729 * x![3] + func(x![2], data)) mod data + 1;
-  else
-    ErrorNoReturn("Semigroups: SEMIGROUPS.HashFunctionRZMSE: error,\n",
-                  "this shouldn't happen,");
-  fi;
-end;
 
 ###############################################################################
 # Setup - install the basic things required for specific acting semigroups    #
@@ -197,7 +181,7 @@ function(s)
   return RankOfPartialPerm;
 end);
 
-InstallMethod(ActionRank, "for a bipartition",
+InstallMethod(ActionRank, "for a bipartition and integer",
 [IsBipartition, IsInt], BIPART_RANK);
 
 InstallMethod(ActionRank, "for a bipartition semigroup",
@@ -439,9 +423,8 @@ InstallMethod(LambdaFunc, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], R -> function(x)
   if x![1] <> 0 then
     return x![3];
-  else
-    return 0;
   fi;
+  return 0;
 end);
 
 InstallMethod(LambdaFunc, "for a matrix semigroup",
@@ -527,10 +510,7 @@ InstallMethod(RhoRank, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], R -> LambdaRank(R));
 
 InstallMethod(RhoRank, "for a matrix semigroup",
-[IsMatrixOverFiniteFieldSemigroup],
-function(S)
-  return LambdaRank(S);
-end);
+[IsMatrixOverFiniteFieldSemigroup], S -> LambdaRank(S));
 
 # if g=LambdaInverse(X, f) and X^f=Y, then Y^g=X and g acts on the right
 # like the inverse of f on Y.
@@ -701,13 +681,13 @@ InstallMethod(RhoIdentity, "for a partial perm semigroup",
     return ();
   end);
 
-InstallMethod(LambdaIdentity, "for a partial perm semigroup",
+InstallMethod(LambdaIdentity, "for a bipartition semigroup",
 [IsBipartitionSemigroup],
   s -> function(r)
     return ();
   end);
 
-InstallMethod(RhoIdentity, "for a partial perm semigroup",
+InstallMethod(RhoIdentity, "for a bipartition semigroup",
 [IsBipartitionSemigroup],
   s -> function(r)
     return ();
@@ -966,7 +946,25 @@ InstallMethod(FakeOne, "for an FFE coll coll coll",
 [IsFFECollCollColl], One);
 
 # missing hash functions
-InstallMethod(ChooseHashFunction, "for a Rees 0-matrix semigroup element",
+
+SEMIGROUPS.HashFunctionRZMSE := function(x, data, func, dataishashlen)
+  if x![1] = 0 then
+    return 1;
+  fi;
+  #Use some big primes that are near the default hash table size
+  if IsNBitsPcWordRep(x![2]) then
+    return (104723 * x![1] + 104729 * x![3] + func(x![2], data))
+      mod data[2] + 1;
+  elif dataishashlen then
+    return (104723 * x![1] + 104729 * x![3] + func(x![2], data)) mod data + 1;
+  else
+    ErrorNoReturn("Semigroups: SEMIGROUPS.HashFunctionRZMSE: error,\n",
+                  "this shouldn't happen,");
+  fi;
+end;
+
+InstallMethod(ChooseHashFunction,
+"for a Rees 0-matrix semigroup element and integer",
 [IsReesZeroMatrixSemigroupElement, IsInt],
 function(x, hashlen)
   local R, data, under, func, dataishashlen;

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -67,3 +67,7 @@ cd digraphs
 ./configure $PKG_FLAGS
 make
 cd ../../..
+
+# Get gaplint
+echo "Downloading gaplint..."
+hg clone https://bitbucket.org/james-d-mitchell/gaplint

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -57,6 +57,16 @@ cd $ORB
 ./configure $PKG_FLAGS
 make
 cd ..
+echo "Downloading $PROFILING..."
+curl -LO https://github.com/gap-packages/profiling/releases/download/v$PROFILING/profiling-$PROFILING.tar.gz
+tar xzf profiling-$PROFILING.tar.gz
+rm profiling-$PROFILING.tar.gz
+mv profiling-$PROFILING profiling
+cd profiling
+./autogen.sh
+./configure $PKG_FLAGS
+make
+cd ..
 echo "Downloading $GENSS..."
 curl -LO http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$GENSS.tar.gz
 tar xzf $GENSS.tar.gz

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -8,7 +8,6 @@ $CXX --version
 SEMIDIR=$(pwd)
 
 # Get libsemigroups if appropriate
-echo -en 'travis_fold:start:GetLIBSEMIGROUPS\r'
 if [ -d src ]
 then
     cd src
@@ -16,20 +15,16 @@ then
     cd ..
 fi
 cd ..
-echo -en 'travis_fold:end:GetLIBSEMIGROUPS\r'
 
 # Download and compile GAP
-echo -en 'travis_fold:start:InstallGAP\r'
 git clone -b $GAP_BRANCH --depth=1 https://github.com/$GAP_FORK/gap.git
 cd gap
 ./configure --with-gmp=system $GAP_FLAGS
 make
 mkdir pkg
 cd ..
-echo -en 'travis_fold:end:InstallGAP\r'
 
 # Compile the Semigroups package
-echo -en 'travis_fold:start:BuildSemigroups\r'
 mv $SEMIDIR gap/pkg/semigroups
 cd gap/pkg/semigroups
 if [ -d src ]
@@ -39,10 +34,8 @@ then
     make
 fi
 cd ../..
-echo -en 'travis_fold:end:BuildSemigroups\r'
 
 # Get the packages
-echo -en 'travis_fold:start:InstallPackages\r'
 cd pkg
 echo "Downloading $GAPDOC..."
 curl -LO http://www.gap-system.org/pub/gap/gap4/tar.gz/packages/$GAPDOC.tar.gz
@@ -74,4 +67,3 @@ cd digraphs
 ./configure $PKG_FLAGS
 make
 cd ../../..
-echo -en 'travis_fold:end:InstallPackages\r'

--- a/scripts/travis-coverage.py
+++ b/scripts/travis-coverage.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import tempfile, subprocess, sys, os, ntpath, re
+from os.path import exists, isdir, isfile
+
+_ERR_PREFIX = '\033[31mtravis-coverage.py: error: '
+_WARN_PREFIX = '\033[31mtravis-coverage.py: warning: '
+_BOLD_PREFIX = '\033[1m'
+_BLUE_PREFIX = '\033[34m'
+
+f = str(sys.argv[1])
+if not (exists(f) and isfile(f)):
+    sys.exit(_ERR_PREFIX + f + ' does not exist!\033[0m')
+
+_DIR = tempfile.mkdtemp()
+_COMMANDS = 'echo "Test(\\"' + f + '\\");;\n'
+_COMMANDS += '''UncoverageLineByLine();;
+LoadPackage(\\"profiling\\", false);;
+filesdir := \\"''' + os.getcwd() + '''/gap/\\";;\n'''
+_COMMANDS += 'outdir := \\"' + _DIR + '\\";;\n'
+_COMMANDS += 'x := ReadLineByLineProfile(\\"' + _DIR + '/profile.gz\\");;\n'
+_COMMANDS += 'OutputAnnotatedCodeCoverageFiles(x, filesdir, outdir);"'
+
+pro1 = subprocess.Popen(_COMMANDS, stdout=subprocess.PIPE, shell=True)
+_RUN_GAP = '../../bin/gap.sh -A -q -r -m 1g -T --cover ' + _DIR + '/profile.gz'
+
+try:
+    pro2 = subprocess.Popen(_RUN_GAP,
+                            stdin=pro1.stdout,
+                            shell=True)
+    pro2.wait()
+except KeyboardInterrupt:
+    pro1.terminate()
+    pro1.wait()
+    pro2.terminate()
+    pro2.wait()
+    sys.exit('\033[31mKilled!\033[0m')
+except (subprocess.CalledProcessError, IOError, OSError):
+    sys.exit(_ERR_PREFIX + 'Something went wrong calling GAP!\033[0m')
+
+filename = _DIR + '/index.html'
+if not (exists(filename) and isfile(filename)):
+    sys.exit('\n' + _ERR_PREFIX + 'Failed to find file://' + filename + '\033[0m')
+
+gi_file = ntpath.basename(f).split('.')[0] + '.gi'
+for line in open(filename):
+    if gi_file in line:
+        break
+
+search = re.search('coverage\d\d+[\'"]>(\d+)</td><td>([\d,]+)</td><td>([\d,]+)</td>', line)
+if search == None:
+    print _WARN_PREFIX + 'Could not find .gi file to which this .tst refers\033[0m'
+    sys.exit(0)
+
+percentage = search.group(1)
+print _BLUE_PREFIX + gi_file + ' has ' + percentage + '% coverage: ' + search.group(2) + '/' + search.group(3) + ' lines\033[0m'
+
+if int(percentage) < 95:
+    print _WARN_PREFIX + percentage + '% is insufficient code coverage for ' + gi_file + ' \033[0m'
+
+sys.exit(0)

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -18,5 +18,20 @@ cd pkg/semigroups
 echo -e "\nRunning gaplint..."
 ../../../gaplint/gaplint.py gap/*/*.gi | tee -a ../../testlog.txt
 
+# Run coverage checks
+if [ ! -z "$COVERAGE" ]; then
+  echo -e "\nPerforming code coverage tests..."
+  for testfile in tst/standard/*.tst; do
+    filename=${testfile##*/}
+    if [ ! `grep -E "$filename" .covignore` ]; then
+      scripts/travis-coverage.py $testfile | tee -a ../../testlog.txt
+    else
+      echo -e "\033[35mignoring $filename, since it is listed in .covignore\033[0m"
+    fi
+  done
+else
+  echo -e "\nNot performing code coverage tests..."
+fi
+
 # Check the logs for invalid phrases
-( ! grep -E "Diff|brk>|#E|Error|error|# WARNING|fail|Syntax warning|Couldn't open saved workspace" ../../testlog.txt )
+( ! grep -E "Diff|brk>|#E|Error|error|# WARNING|fail|Syntax warning|Couldn't open saved workspace|insufficient" ../../testlog.txt )

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -13,5 +13,10 @@ echo "LoadPackage(\"semigroups\", false); SemigroupsTestInstall(); Test(\"pkg/se
 echo "LoadPackage(\"semigroups\", false); Test(\"pkg/semigroups/tst/workspaces/load-workspace.tst\"); SemigroupsTestInstall(); quit; quit; quit;" | bin/gap.sh -L pkg/semigroups/tst/workspaces/test-output.w -A -r -m 1g -T 2>&1 | tee -a testlog.txt
 rm pkg/semigroups/tst/workspaces/test-output.w
 
+# Run gaplint
+cd pkg/semigroups
+echo -e "\nRunning gaplint..."
+../../../gaplint/gaplint.py gap/*/*.gi | tee -a ../../testlog.txt
+
 # Check the logs for invalid phrases
-( ! grep -E "Diff|brk>|#E|Error|error|# WARNING|fail|Syntax warning|Couldn't open saved workspace" testlog.txt )
+( ! grep -E "Diff|brk>|#E|Error|error|# WARNING|fail|Syntax warning|Couldn't open saved workspace" ../../testlog.txt )

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -3,17 +3,15 @@ set -e
 set -o pipefail
 
 # Run the standard tests and manual examples
-echo -en 'travis_fold:start:RunTests\r'
 cd ../..
+echo -e "\nRunning standard tests and manual examples..."
 echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples(); quit; quit; quit;" | bin/gap.sh -A -r -m 1g -T 2>&1 | tee testlog.txt
-echo -en 'travis_fold:end:RunTests\r'
 
 # Run the SaveWorkspace tests
-echo -en 'travis_fold:start:SaveWorkspaceTests\r'
+echo -e "\nRunning SaveWorkspace tests..."
 echo "LoadPackage(\"semigroups\", false); SemigroupsTestInstall(); Test(\"pkg/semigroups/tst/workspaces/save-workspace.tst\"); quit; quit; quit;" | bin/gap.sh -A -r -m 1g -T 2>&1 | tee -a testlog.txt
 echo "LoadPackage(\"semigroups\", false); Test(\"pkg/semigroups/tst/workspaces/load-workspace.tst\"); SemigroupsTestInstall(); quit; quit; quit;" | bin/gap.sh -L pkg/semigroups/tst/workspaces/test-output.w -A -r -m 1g -T 2>&1 | tee -a testlog.txt
 rm pkg/semigroups/tst/workspaces/test-output.w
-echo -en 'travis_fold:end:SaveWorkspaceTests\r'
 
 # Check the logs for invalid phrases
 ( ! grep -E "Diff|brk>|#E|Error|error|# WARNING|fail|Syntax warning|Couldn't open saved workspace" testlog.txt )

--- a/tst/standard/setup.tst
+++ b/tst/standard/setup.tst
@@ -1,7 +1,8 @@
 #############################################################################
 ##
 #W  standard/setup.tst
-#Y  Copyright (C) 2016                                   James D. Mitchell
+#Y  Copyright (C) 2016-17                                James D. Mitchell
+##                                                       Wilfred A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -14,23 +15,147 @@ gap> LoadPackage("semigroups", false);;
 gap> SEMIGROUPS.StartTest();
 gap> SEMIGROUPS.DefaultOptionsRec.acting := true;;
 
-# SEMIGROUPS.HashFunctionRZMSE
-gap> SEMIGROUPS.HashFunctionRZMSE([1, (), 2], "bananas", ReturnFail, false);
-Error, Semigroups: SEMIGROUPS.HashFunctionRZMSE: error,
-this shouldn't happen,
+#T# IsGeneratorsOfActingSemigroup
+gap> IsGeneratorsOfActingSemigroup([Transformation([2, 2])]);
+true
+gap> IsGeneratorsOfActingSemigroup([PartialPerm([1])]);
+true
+gap> IsGeneratorsOfActingSemigroup([Bipartition([[1, -1]])]);
+true
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> IsGeneratorsOfActingSemigroup(R);
+true
+gap> IsGeneratorsOfActingSemigroup(Elements(R));
+true
+gap> IsGeneratorsOfActingSemigroup(SLM(2, 2));
+true
 
-# ActionDegree for an RZMS
-gap> R := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
->  [(), (), ()]]);;
-gap> ActionDegree([R.1]);
-1
+#T# ActionDegree
 
-# ActionDegree for matrix over finite field semigroup
-gap> S := GLM(2, 2);;
-gap> ActionDegree([S.1]);
+# ActionDegree, for a partial perm
+gap> ActionDegree(PartialPerm([]));
+0
+gap> ActionDegree(PartialPerm([2]));
+2
+gap> ActionDegree(PartialPerm([0, 1]));
 2
 
-# ActionRank for an RZMS
+# ActionDegree, for a bipartition
+gap> ActionDegree(Bipartition([[1, 3], [2, 4, -2], [5, -1, -3, -4], [-5]]));
+5
+
+# ActionDegree, for an RZMS element
+gap> R := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
+>  [(), (), ()]]);;
+gap> ActionDegree(R.1);
+1
+gap> ActionDegree(MultiplicativeZero(R));
+0
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[()]]);;
+gap> Set(R, ActionDegree);
+[ 0, 1, 3, 4 ]
+
+# ActionDegree, for a matrix over finite field object
+gap> ActionDegree(Matrix(GF(2 ^ 2),
+>                        [[Z(2) ^ 0, 0 * Z(2)], [0 * Z(2), 0 * Z(2)]]));
+2
+
+# ActionDegree, for a transformation collection
+gap> ActionDegree(FullTransformationMonoid(3));
+3
+gap> ActionDegree([IdentityTransformation]);
+0
+
+# ActionDegree, for a partial perm collection
+gap> ActionDegree([PartialPerm([2, 3]), PartialPerm([2, 1, 3])]);
+3
+gap> ActionDegree([PartialPerm([])]);
+0
+
+# ActionDegree, for a bipartition collection
+gap> ActionDegree([Bipartition([[1, 2, -2], [-1]]),
+>                  Bipartition([[1], [2, -2], [-1]])]);
+2
+
+# ActionDegree, for an RZMS element collection
+gap> R := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
+>  [(), (), ()]]);;
+gap> ActionDegree([R.1, MultiplicativeZero(R)]);
+1
+gap> ActionDegree([MultiplicativeZero(R)]);
+0
+
+# ActionDegree, for a matrix object collection
+gap> ActionDegree([Matrix(GF(2),
+>                         [[0 * Z(2), 0 * Z(2)], [0 * Z(2), 0 * Z(2)]]),
+>                  Matrix(GF(2),
+>                         [[Z(2) ^ 0, Z(2) ^ 0], [Z(2) ^ 0, 0 * Z(2)]])]);
+2
+
+# ActionDegree, for a transformation semigroup
+gap> ActionDegree(FullTransformationSemigroup(2));
+2
+
+# ActionDegree, for a partial perm semigroup
+gap> ActionDegree(MonogenicSemigroup(IsPartialPermSemigroup, 3, 3));
+6
+
+# ActionDegree, for a partial perm inverse semigroup
+gap> ActionDegree(SymmetricInverseMonoid(4));
+4
+
+# ActionDegree, for a bipartition semigroup
+gap> ActionDegree(PartitionMonoid(10));
+10
+
+# ActionDegree, for a Rees 0-matrix subsemigroup with generators
+gap> R := ReesZeroMatrixSemigroup(Group([(1, 2)]), [[()]]);;
+gap> GeneratorsOfSemigroup(R);;
+gap> ActionDegree(R);
+3
+gap> ActionDegree(Semigroup(MultiplicativeZero(R)));
+0
+
+# ActionDegree, for a matrix over finite field semigroup
+gap> ActionDegree(GLM(2, 2));
+2
+gap> ActionDegree(SLM(2, 2));
+2
+
+#T# ActionRank
+
+# ActionRank, for a transformation and integer
+gap> ActionRank(Transformation([2, 3, 4, 5, 5, 6]), 5);
+4
+gap> ActionRank(Transformation([2, 3, 4, 5, 5, 6]), 6);
+5
+
+# ActionRank, for a transformation semigroup
+gap> rank := ActionRank(FullTransformationMonoid(4));;
+gap> rank(IdentityTransformation);
+4
+
+# ActionRank, for a partial perm and integer
+gap> ActionRank(PartialPerm([0, 3, 0, 6]), 8);
+2
+
+# ActionRank, for a partial perm semigroup
+gap> rank := ActionRank(SymmetricInverseSemigroup(2));;
+gap> rank(PartialPerm([]));
+0
+gap> rank(PartialPerm([2, 1]));
+2
+
+# ActionRank, for a bipartition and integer
+gap> ActionRank(Bipartition([[1, 3], [2, -1], [-2, -3]]), 3);
+1
+
+# ActionRank, for a bipartition semigroup
+gap> rank := ActionRank(PartitionMonoid(3));;
+gap> rank(Bipartition([[1, 3], [2, -1], [-2, -3]]));
+1
+
+# ActionRank, for an RZMS element and integer
 gap> R := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
 >  [(), (), ()]]);;
 gap> ActionRank(R.1, 10);
@@ -38,52 +163,787 @@ gap> ActionRank(R.1, 10);
 gap> ActionRank(MultiplicativeZero(R), 10);
 0
 
-# ActionRank for a matrix over FF
+# ActionRank, for a Rees 0-matrix subsemigroup
+gap> R := ReesZeroMatrixSemigroup(Group([(2, 3)]), [[()]]);;
+gap> rank := ActionRank(R);;
+gap> rank(RMSElement(R, 1, (2, 3), 1));
+3
+gap> rank(MultiplicativeZero(R));
+0
+
+# ActionRank, for a matrix over FF
 gap> x := Matrix(GF(2), [[0*Z(2), 0*Z(2)], [0*Z(2), Z(2)^0]]);;
-gap> ActionRank(GLM(2, 2))(x);
-1
 gap> ActionRank(x, 10);
 1
 
-# MinActionRank for a RZMS
+# ActionRank, for a matrix over FF semigroup
+gap> rank := ActionRank(GLM(2, 2));;
+gap> rank(Matrix(GF(2), [[0 * Z(2), 0 * Z(2)], [0 * Z(2), 0 * Z(2)]]));
+0
+gap> rank(Matrix(GF(2), [[Z(2) ^ 0, 0 * Z(2)], [0 * Z(2), 0 * Z(2)]]));
+1
+
+#T# MinActionRank
+
+# MinActionRank, for a transformation semigroup
+gap> MinActionRank(FullTransformationMonoid(2));
+1
+
+# MinActionRank, for a partial perm semigroup
+gap> MinActionRank(SymmetricInverseSemigroup(2));
+0
+
+# MinActionRank, for a bipartition semigroup
+gap> MinActionRank(PartitionMonoid(2));
+0
+
+# MinActionRank, for a RZMS
 gap> R := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
 >  [(), (), ()]]);;
 gap> MinActionRank(R);
 0
 
 # MinActionRank for a matrix over FF semigroup
-gap> S := GLM(2, 2);;
-gap> MinActionRank(S);
+gap> MinActionRank(GLM(2, 2));
 0
 
-# Rho/LambdaInverse for a RZMS
+#T# Rho/LambdaOrbOpts
+
+# Rho/LambdaOrbOpts, for a transformation semigroup
+gap> LambdaOrbOpts(FullTransformationMonoid(2));
+rec( forflatplainlists := true )
+gap> RhoOrbOpts(FullTransformationMonoid(2));
+rec( forflatplainlists := true )
+
+# Rho/LambdaOrbOpts, for a partial perm semigroup
+gap> LambdaOrbOpts(SymmetricInverseSemigroup(2));
+rec( forflatplainlists := true )
+gap> RhoOrbOpts(SymmetricInverseSemigroup(2));
+rec( forflatplainlists := true )
+
+# Rho/LambdaOrbOpts, for a bipartition semigroup
+gap> LambdaOrbOpts(PartitionMonoid(2));
+rec(  )
+gap> RhoOrbOpts(PartitionMonoid(2));
+rec(  )
+
+# Rho/LambdaOrbOpts, for a RZMS
 gap> R := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
 >  [(), (), ()]]);;
-gap> LambdaInverse(R)(2, MultiplicativeZero(R));
-0
-gap> LambdaInverse(R)(0, R.1);
-(1,(),1)
-gap> RhoInverse(R)(2, MultiplicativeZero(R));
-0
-gap> RhoInverse(R)(0, R.1);
-(1,(),1)
+gap> LambdaOrbOpts(R);
+rec(  )
+gap> RhoOrbOpts(R);
+rec(  )
 
-# RhoInverse for a matrix over FF semigroup
+# Rho/LambdaOrbOpts for a matrix over FF semigroup
+gap> LambdaOrbOpts(GLM(2, 2));
+rec(  )
+gap> RhoOrbOpts(GLM(2, 2));
+rec(  )
+
+#T# Rho/LambdaAct
+
+# Rho/LambdaAct, for a transformation semigroup
+gap> x := LambdaAct(FullTransformationMonoid(10));;
+gap> x([2, 4, 7], Transformation([4, 2, 6, 6, 3, 1, 6, 5, 3, 7]));
+[ 2, 6 ]
+gap> x := RhoAct(FullTransformationMonoid(5));;
+gap> x([1, 2, 1, 1, 3], Transformation([3, 2, 4, 3, 2]));
+[ 1, 2, 1, 1, 2 ]
+
+# Rho/LambdaAct, for a partial perm semigroup
+gap> x := LambdaAct(SymmetricInverseMonoid(3));;
+gap> x([2, 4], PartialPerm([4, 3, 2, 0]));
+[ 3 ]
+gap> x := RhoAct(SymmetricInverseMonoid(3));;
+gap> x([2, 4], PartialPerm([4, 3, 2, 0]));
+[ 1, 3 ]
+
+# Rho/LambdaAct, for a bipartition semigroup
+gap> S := PartitionMonoid(3);;
+gap> r := BlocksNC([[1, 2], [-3]]);;
+gap> s := Bipartition([[1], [2, -1, -2], [3, -3]]);;
+gap> x := LambdaAct(S);;
+gap> x(r, s);
+<blocks: [ 1*, 2* ], [ 3 ]>
+gap> x := RhoAct(S);;
+gap> x(r, s);
+<blocks: [ 1 ], [ 2* ], [ 3 ]>
+
+# Rho/LambdaAct, for an RZMS
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[(), 0], [0, ()]]);;
+gap> r := RMSElement(R, 1, (1, 3, 2), 1);;
+gap> s := RMSElement(R, 1, (2, 3), 2);;
+gap> x := LambdaAct(R);;
+gap> x(1, MultiplicativeZero(R));
+0
+gap> x(0, r);
+0
+gap> x(-1, r);
+1
+gap> x(1, r);
+1
+gap> x(2, r);
+0
+gap> x(1, s);
+2
+gap> x(2, s);
+0
+gap> x := RhoAct(R);;
+gap> x(1, MultiplicativeZero(R));
+0
+gap> x(0, r);
+0
+gap> x(-1, r);
+1
+gap> x(1, r);
+1
+gap> x(2, r);
+0
+gap> x(1, s);
+0
+gap> x(2, s);
+1
+
+# Rho/LambdaAct, for a matrix over FF semigroup
+gap> r := Matrix(GF(2), [[Z(2) ^ 0, Z(2) ^ 0], [Z(2) ^ 0, 0 * Z(2)]]);;
+gap> s := Matrix(GF(2), [[Z(2) ^ 0, Z(2) ^ 0], [0 * Z(2), 0 * Z(2)]]);;
+gap> b := NewRowBasisOverFiniteField(IsPlistRowBasisOverFiniteFieldRep,
+>                                    GF(2),
+>                                    [[Z(2) ^ 0, 0 * Z(2)],
+>                                     [0 * Z(2), Z(2) ^ 0]]);
+<rowbasis of rank 2 over GF(2)>
+gap> x := LambdaAct(GLM(2, 2));;
+gap> x(b, r);
+<rowbasis of rank 2 over GF(2)>
+gap> x := RhoAct(GLM(2, 2));;
+gap> x(b, s);
+<rowbasis of rank 1 over GF(2)>
+
+#T# Rho/LambdaOrbSeed
+
+# Rho/LambdaOrbSeed, for a transformation semigroup
+gap> LambdaOrbSeed(FullTransformationMonoid(4));
+[ 0 ]
+gap> RhoOrbSeed(FullTransformationMonoid(4));
+[ 0 ]
+
+# Rho/LambdaOrbSeed, for a partial perm semigroup
+gap> LambdaOrbSeed(SymmetricInverseSemigroup(3));
+[ 0 ]
+gap> RhoOrbSeed(SymmetricInverseSemigroup(3));
+[ 0 ]
+
+# Rho/LambdaOrbSeed, for a bipartition semigroup
+gap> LambdaOrbSeed(PartitionMonoid(3));
+<blocks: [ 1*, 2*, 3*, 4* ]>
+gap> RhoOrbSeed(PartitionMonoid(3));
+<blocks: [ 1*, 2*, 3*, 4* ]>
+
+# Rho/LambdaOrbSeed, for an RZMS
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> LambdaOrbSeed(R);
+-1
+gap> RhoOrbSeed(R);
+-1
+
+# Rho/LambdaOrbSeed, for a matrix over FF semigroup
+gap> LambdaOrbSeed(GLM(2, 2));
+<rowbasis of rank 3 over GF(2)>
+gap> RhoOrbSeed(SLM(2, 2));
+<rowbasis of rank 3 over GF(2)>
+
+#T# Rho/LambdaFunc
+
+# Rho/LambdaFunc, for a transformation semigroup
+gap> S := FullTransformationMonoid(3);;
+gap> x := LambdaFunc(S);;
+gap> x(Transformation([2, 3, 3]));
+[ 2, 3 ]
+gap> x(IdentityTransformation);
+[ 1, 2, 3 ]
+gap> x := RhoFunc(S);;
+gap> x(Transformation([2, 3, 3]));
+[ 1, 2, 2 ]
+gap> x(IdentityTransformation);
+[ 1, 2, 3 ]
+
+# Rho/LambdaFunc, for a partial perm semigroup
+gap> S := SymmetricInverseMonoid(3);;
+gap> x := LambdaFunc(S);;
+gap> x(PartialPerm([1, 2], [1, 3]));
+[ 1, 3 ]
+gap> x := RhoFunc(S);;
+gap> x(PartialPerm([1, 2], [1, 3]));
+[ 1, 2 ]
+
+# Rho/LambdaFunc, for a bipartition semigroup
+gap> S := PartitionMonoid(3);;
+gap> x := LambdaFunc(S);;
+gap> x(Bipartition([[1], [2], [3, -1, -2, -3]]));
+<blocks: [ 1*, 2*, 3* ]>
+gap> x := RhoFunc(S);;
+gap> x(Bipartition([[1], [2], [3, -1, -2, -3]]));
+<blocks: [ 1 ], [ 2 ], [ 3* ]>
+
+# Rho/LambdaFunc, for an RZMS
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[(), 0], [0, ()]]);;
+gap> x := LambdaFunc(S);;
+gap> x(MultiplicativeZero(S));
+0
+gap> x(RMSElement(S, 1, (1, 3), 2));
+2
+gap> x := RhoFunc(S);;
+gap> x(MultiplicativeZero(S));
+0
+gap> x(RMSElement(S, 1, (1, 3), 2));
+1
+
+# Rho/LambdaFunc, for a matrix over FF semigroup
+gap> S := GLM(2, 3);;
+gap> x := LambdaFunc(S);;
+gap> x(Matrix(GF(3), [[Z(3) ^ 0, 0 * Z(3)], [0 * Z(3), Z(3)]]));
+<rowbasis of rank 2 over GF(3)>
+gap> x := RhoFunc(S);;
+gap> x(Matrix(GF(3), [[Z(3) ^ 0, 0 * Z(3)], [0 * Z(3), Z(3)]]));
+<rowbasis of rank 2 over GF(3)>
+
+#T# Rho/LambdaRank
+
+# Rho/LambdaRank, for a transformation semigroup
+gap> S := FullTransformationMonoid(6);;
+gap> x := LambdaRank(S);;
+gap> x([]);
+0
+gap> x([2, 4]);
+2
+gap> x := RhoRank(S);;
+gap> x([]);
+0
+gap> x([2, 3, 1, 2, 3, 2]);
+3
+
+# Rho/LambdaRank, for a partial perm semigroup
+gap> S := SymmetricInverseMonoid(5);;
+gap> x := LambdaRank(S);;
+gap> x([2, 4]);
+2
+gap> x([]);
+0
+gap> x := RhoRank(S);;
+gap> x([4]);
+1
+gap> x([]);
+0
+
+# Rho/LambdaRank, for a bipartition semigroup
+gap> S := PartitionMonoid(3);;
+gap> x := LambdaRank(S);;
+gap> x := RhoRank(S);;
+
+# Rho/LambdaRank, for an RZMS
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[(), 0], [0, ()]]);;
+gap> x := LambdaRank(S);;
+gap> x(0);
+0
+gap> x(2);
+4
+gap> x := RhoRank(S);;
+gap> x(0);
+0
+gap> x(1);
+4
+
+# Rho/LambdaRank, for a matrix over FF semigroup
+gap> S := GLM(2, 3);;
+gap> b := NewRowBasisOverFiniteField(IsPlistRowBasisOverFiniteFieldRep,
+>                                    GF(3),
+>                                    [[Z(3) ^ 0, Z(3)]]);
+<rowbasis of rank 1 over GF(3)>
+gap> x := LambdaRank(S);;
+gap> x(b);
+1
+gap> x := RhoRank(S);;
+gap> x(b);
+1
+
+#T# Rho/LambdaInverse
+
+# Rho/LambdaInverse, for a transformation semigroup
+gap> S := FullTransformationMonoid(4);;
+gap> x := LambdaInverse(S);;
+gap> x([2, 3], Transformation([1, 4, 1, 1]));
+Transformation( [ 3, 2, 3, 2 ] )
+gap> x := RhoInverse(S);;
+gap> x([1, 2, 2, 1], Transformation([3, 2, 2, 1]));
+Transformation( [ 4, 3, 3, 4 ] )
+
+# Rho/LambdaInverse, for a partial perm semigroup
+gap> S := SymmetricInverseMonoid(4);;
+gap> x := LambdaInverse(S);;
+gap> x([1, 4], PartialPerm([1, 2, 4], [4, 1, 2]));
+(1,2,4)
+gap> x := RhoInverse(S);;
+gap> x([2, 3], PartialPerm([2, 3], [3, 2]));
+(2,3)
+
+# Rho/LambdaInverse, for a bipartition semigroup
+gap> S := PartitionMonoid(4);;
+gap> x := LambdaInverse(S);;
+gap> x(BlocksNC([[1, 2], [3], [4]]),
+>      Bipartition([[1], [2, -1, -2], [3, -3], [4, -4]]));
+<block bijection: [ 1, 2, -1, -2 ], [ 3, -3 ], [ 4, -4 ]>
+gap> x := RhoInverse(S);;
+gap> x(BlocksNC([[1, 2], [3], [4]]),
+>      Bipartition([[1], [2, -1, -2], [3, -3], [4, -4]]));
+<bipartition: [ 1, 2, -2 ], [ 3, -3 ], [ 4, -4 ], [ -1 ]>
+
+# Rho/LambdaInverse, for an RZMS
+gap> S := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0],
+>                                               [(), (), ()],
+>                                               [(), (), ()]]);;
+gap> x := LambdaInverse(S);;
+gap> x(2, MultiplicativeZero(S));
+0
+gap> x(0, S.1);
+(1,(),1)
+gap> x(2, S.1);
+(1,(),2)
+gap> x := RhoInverse(S);;
+gap> x(2, MultiplicativeZero(S));
+0
+gap> x(0, S.1);
+(1,(),1)
+gap> x(2, S.1);
+(2,(),1)
+
+# Rho/LambdaInverse, for a matrix over FF semigroup
 gap> S := GLM(2, 2);;
-gap> RhoInverse(S)(RowSpaceBasis(S.2), S.2);
+gap> x := LambdaInverse(S);;
+gap> x(RowSpaceBasis(S.2), S.2);
+Matrix(GF(2), [[0*Z(2), Z(2)^0], [Z(2)^0, 0*Z(2)]])
+gap> x := RhoInverse(S);;
+gap> x(RowSpaceBasis(S.2), S.2);
 Matrix(GF(2), [[0*Z(2), Z(2)^0], [Z(2)^0, 0*Z(2)]])
 
-# LambdaBound
+#T# Rho/LambdaBound
+
+# Rho/LambdaBound, for a transformation semigroup
+gap> S := FullTransformationMonoid(4);;
+gap> LambdaBound(S)(1000);
+infinity
+gap> LambdaBound(S)(6);
+720
+gap> RhoBound(S)(1000);
+infinity
+gap> RhoBound(S)(6);
+720
+
+# Rho/LambdaBound, for a partial perm semigroup
+gap> S := SymmetricInverseMonoid(4);;
+gap> LambdaBound(S)(1000);
+infinity
+gap> LambdaBound(S)(6);
+720
+gap> RhoBound(S)(1000);
+infinity
+gap> RhoBound(S)(6);
+720
+
+# Rho/LambdaBound, for a bipartition semigroup
 gap> S := PartitionMonoid(5);;
 gap> LambdaBound(S)(1000);
 infinity
+gap> LambdaBound(S)(6);
+720
+gap> RhoBound(S)(1000);
+infinity
+gap> RhoBound(S)(6);
+720
+
+# Rho/LambdaBound, for an RZMS
 gap> S := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
 >  [(), (), ()]]);;
 gap> LambdaBound(S)(1000);
 infinity
+gap> LambdaBound(S)(5);
+120
+gap> RhoBound(S)(1000);
+infinity
+gap> RhoBound(S)(5);
+120
+
+# Rho/LambdaBound, for a matrix over FF semigroup
 gap> S := GLM(2, 2);;
 gap> LambdaBound(S)(1000);
 infinity
+gap> LambdaBound(S)(2);
+6
+gap> LambdaBound(S)(0);
+1
+gap> RhoBound(S)(1000);
+infinity
+gap> RhoBound(S)(2);
+6
+gap> RhoBound(S)(0);
+1
 
-#
+#T# Rho/LambdaIdentity
+
+# Rho/LambdaIdentity, for a transformation semigroup
+gap> S := FullTransformationMonoid(2);;
+gap> LambdaIdentity(S)(2);
+()
+gap> RhoIdentity(S)(2);
+()
+
+# Rho/LambdaIdentity, for a partial perm semigroup
+gap> S := SymmetricInverseMonoid(2);;
+gap> LambdaIdentity(S)(2);
+()
+gap> RhoIdentity(S)(2);
+()
+
+# Rho/LambdaIdentity, for a bipartition semigroup
+gap> S := PartitionMonoid(1);;
+gap> LambdaIdentity(S)(1);
+()
+gap> RhoIdentity(S)(1);
+()
+
+# Rho/LambdaIdentity, for an RZMS
+gap> S := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> LambdaIdentity(S)(2);
+()
+gap> RhoIdentity(S)(2);
+()
+
+# Rho/LambdaIdentity, for a matrix over FF semigroup
+gap> S := SLM(2, 2);;
+gap> LambdaIdentity(S)(2);
+Matrix(GF(2), [[Z(2)^0, 0*Z(2)], [0*Z(2), Z(2)^0]])
+gap> RhoIdentity(S)(2);
+Matrix(GF(2), [[Z(2)^0, 0*Z(2)], [0*Z(2), Z(2)^0]])
+
+#T# LambdaPerm
+
+# LambdaPerm, for a transformation semigroup
+gap> x := LambdaPerm(FullTransformationMonoid(3));;
+gap> x(Transformation([2, 2]), Transformation([3, 3, 2]));
+(2,3)
+
+# LambdaPerm, for a partial perm semigroup
+gap> x := LambdaPerm(SymmetricInverseMonoid(3));;
+gap> x(PartialPerm([2, 0, 3]), PartialPerm([3, 0, 2]));
+(2,3)
+
+# LambdaPerm, for a bipartition semigroup
+gap> x := LambdaPerm(PartitionMonoid(3));;
+gap> x(Bipartition([[1, -2], [2], [3, -3], [-1]]),
+>      Bipartition([[1, -3], [2], [3, -2], [-1]]));
+(2,3)
+
+# LambdaPerm, for an RZMS
+gap> R := ReesZeroMatrixSemigroup(Group((1, 2, 3)), [[()]]);;
+gap> x := LambdaPerm(R);;
+gap> x(RMSElement(R, 1, (1, 3, 2), 1), RMSElement(R, 1, (1, 2, 3), 1));
+(1,3,2)
+gap> x(MultiplicativeZero(R), MultiplicativeZero(R));
+()
+
+# LambdaPerm, for a matrix over FF semigroup
+gap> x := LambdaPerm(GLM(2, 3));;
+gap> x(Matrix(GF(3), [[Z(3) ^ 0, Z(3) ^ 0], [0 * Z(3), 0 * Z(3)]]),
+>      Matrix(GF(3), [[Z(3), Z(3)], [0 * Z(3), 0 * Z(3)]]));
+Matrix(GF(3), [[Z(3)]])
+
+#T# LambdaConjugator
+
+# LambdaConjugator, for a transformation semigroup
+gap> x := LambdaConjugator(FullTransformationMonoid(3));;
+gap> x(Transformation([3, 1, 1]), Transformation([2, 3, 3]));
+(1,3,2)
+
+# LambdaConjugator, for a partial perm semigroup
+gap> x := LambdaConjugator(SymmetricInverseMonoid(3));;
+gap> x(PartialPerm([2]), PartialPerm([3]));
+(2,3)
+
+# LambdaConjugator, for a bipartition semigroup
+gap> x := LambdaConjugator(PartitionMonoid(3));;
+gap> x(Bipartition([[1, -1, -2], [2], [3, -3]]),
+>      Bipartition([[1, -1], [2], [3, -2], [-3]]));
+()
+
+# LambdaConjugator, for an RZMS
+gap> R := ReesZeroMatrixSemigroup(Group((1, 2, 3)), [[(), 0], [0, ()]]);;
+gap> x := LambdaConjugator(R);;
+gap> x(RMSElement(R, 1, (1, 3, 2), 1), RMSElement(R, 1, (1, 2, 3), 2));
+()
+
+# LambdaConjugator, for a matrix over FF semigroup
+gap> x := LambdaConjugator(GLM(2, 3));;
+gap> x(Matrix(GF(3), [[Z(3) ^ 0, 0 * Z(3)], [0 * Z(3), Z(3) ^ 0]]),
+>      Matrix(GF(3), [[Z(3), 0 * Z(3)], [Z(3), Z(3)]]));
+Matrix(GF(3), [[Z(3)^0, 0*Z(3)], [0*Z(3), Z(3)^0]])
+
+#T# IdempotentTester and IdempotentCreator
+
+# IdempotentTester and IdempotentCreator, for a transformation semigroup
+gap> S := FullTransformationMonoid(3);;
+gap> x := IdempotentTester(S);;
+gap> y := IdempotentCreator(S);;
+gap> x([], [1]);
+false
+gap> x([1, 2], [1]);
+false
+gap> x([], []);
+true
+gap> y([], []);
+IdentityTransformation
+gap> x([1, 2], [1, 1]);
+false
+gap> x([1, 2], [1, 2, 1]);
+true
+gap> y([1, 2], [1, 2, 1]);
+Transformation( [ 1, 2, 1 ] )
+gap> x([1], [1, 2]);
+false
+
+# IdempotentTester and IdempotentCreator, for a partial perm semigroup
+gap> S := SymmetricInverseMonoid(3);;
+gap> x := IdempotentTester(S);;
+gap> y := IdempotentCreator(S);;
+gap> x([], []);
+true
+gap> y([], []);
+<empty partial perm>
+gap> x([], [1]);
+false
+gap> x([2, 3], [2, 3]);
+true
+gap> y([2, 3], [2, 3]);
+<identity partial perm on [ 2, 3 ]>
+
+# IdempotentTester and IdempotentCreator, for a bipartition semigroup
+gap> S := PartitionMonoid(3);;
+gap> x := IdempotentTester(S);;
+gap> y := IdempotentCreator(S);;
+gap> x(BlocksNC([[1, 2], [-3]]), BlocksNC([[1, 2, 3, 4]]));
+true
+gap> y(BlocksNC([[1, 2], [-3]]), BlocksNC([[1, 2, 3, 4]]));
+<bipartition: [ 1, 2, 3, -1, -2 ], [ -3 ]>
+gap> x(BlocksNC([[1, 2], [3]]), BlocksNC([[1, 2, 3]]));
+false
+
+# IdempotentTester and IdempotentCreator, for an RZMS
+gap> S := ReesZeroMatrixSemigroup(Group([(1, 2)]), [[(), 0], [0, (1, 2)]]);;
+gap> x := IdempotentTester(S);;
+gap> y := IdempotentCreator(S);;
+gap> x(0, 0);
+true
+gap> y(0, 0);
+0
+gap> x(1, 1);
+true
+gap> y(1, 1);
+(1,(),1)
+gap> x(1, 2);
+false
+gap> x(2, 1);
+false
+gap> x(2, 2);
+true
+gap> y(2, 2);
+(2,(1,2),2)
+
+# IdempotentTester and IdempotentCreator, for a matrix over FF semigroup
+gap> S := GLM(2, 3);;
+gap> x := IdempotentTester(S);;
+gap> y := IdempotentCreator(S);;
+gap> x(NewRowBasisOverFiniteField(IsPlistRowBasisOverFiniteFieldRep, GF(3),
+>                                 [[Z(3) ^ 0, 0 * Z(3)]]),
+>      NewRowBasisOverFiniteField(IsPlistRowBasisOverFiniteFieldRep, GF(3),
+>                                 [[0 * Z(3), 0 * Z(3), 0 * Z(3)],
+>                                  [0 * Z(3), 0 * Z(3), 0 * Z(3)],
+>                                  [0 * Z(3), 0 * Z(3), 0 * Z(3)]]));
+false
+gap> x(NewRowBasisOverFiniteField(IsPlistRowBasisOverFiniteFieldRep, GF(3),
+>                                 [[0 * Z(3), Z(3) ^ 0]]),
+>      NewRowBasisOverFiniteField(IsPlistRowBasisOverFiniteFieldRep, GF(3),
+>                                 [[0 * Z(3), Z(3) ^ 0]]));
+true
+gap> y(NewRowBasisOverFiniteField(IsPlistRowBasisOverFiniteFieldRep, GF(3),
+>                                 [[0 * Z(3), Z(3) ^ 0]]),
+>      NewRowBasisOverFiniteField(IsPlistRowBasisOverFiniteFieldRep, GF(3),
+>                                 [[0 * Z(3), Z(3) ^ 0]]));
+Matrix(GF(3), [[0*Z(3), 0*Z(3)], [0*Z(3), Z(3)^0]])
+
+#T# StabilizerAction
+
+# StabilizerAction, for a transformation semigroup
+gap> x := StabilizerAction(FullTransformationMonoid(2));;
+gap> x(Transformation([2, 2]), (1, 2));
+Transformation( [ 1, 1 ] )
+
+# StabilizerAction, for a partial perm semigroup
+gap> x := StabilizerAction(SymmetricInverseMonoid(2));;
+gap> x(PartialPerm([0, 2]), (2, 1));
+[2,1]
+
+# StabilizerAction, for a bipartition semigroup
+gap> x := StabilizerAction(PartitionMonoid(3));;
+gap> x(Bipartition([[1, 3], [2, -1], [-2, -3]]), ());
+<bipartition: [ 1, 3 ], [ 2, -1 ], [ -2, -3 ]>
+
+# StabilizerAction, for an RZMS
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> x := StabilizerAction(R);;
+gap> x(MultiplicativeZero(R), ());
+0
+gap> x(RMSElement(R, 1, (), 1), ());
+(1,(),1)
+
+# StabilizerAction, for a matrix over FF semigroup
+gap> S := GLM(2, 3);;
+gap> x := StabilizerAction(S);;
+gap> x(One(S), Matrix(GF(3), [[Z(3)^0, 0*Z(3)], [0*Z(3), Z(3)^0]]));
+Matrix(GF(3), [[Z(3)^0, 0*Z(3)], [0*Z(3), Z(3)^0]])
+
+#T# IsActingSemigroupWithFixedDegreeMultiplication
+
+# IsActingSemigroupWithFixedDegreeMultiplication, for a transformation semigroup
+gap> IsActingSemigroupWithFixedDegreeMultiplication(
+> FullTransformationMonoid(4));
+false
+
+# IsActingSemigroupWithFixedDegreeMultiplication, for a partial perm semigroup
+gap> IsActingSemigroupWithFixedDegreeMultiplication(
+> SymmetricInverseMonoid(3));
+false
+
+# IsActingSemigroupWithFixedDegreeMultiplication, for a bipartition semigroup
+gap> IsActingSemigroupWithFixedDegreeMultiplication(
+> PartitionMonoid(5));
+true
+
+# IsActingSemigroupWithFixedDegreeMultiplication, for an RZMS
+gap> S := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> IsActingSemigroupWithFixedDegreeMultiplication(Semigroup(S));
+false
+
+# IsActingSemigroupWithFixedDegreeMultiplication, for a matrix over FF semigroup
+gap> IsActingSemigroupWithFixedDegreeMultiplication(
+> GLM(2, 2));
+true
+
+#T# SchutzGpMembership
+
+# SchutzGpMembership, for a transformation semigroup
+gap> S := Semigroup([Transformation([1, 2, 1]), Transformation([2, 3, 1])]);;
+gap> o := LambdaOrb(S);; Enumerate(o);;
+gap> schutz := LambdaOrbStabChain(o, 3);;
+gap> SchutzGpMembership(S)(schutz, (1, 2, 3));
+true
+
+# SchutzGpMembership, for a partial perm semigroup
+gap> S := InverseMonoid([PartialPerm([1, 3, 2]),
+>                        PartialPerm([2, 3], [1, 2])]);;
+gap> o := LambdaOrb(S);; Enumerate(o);;
+gap> schutz := LambdaOrbStabChain(o, 2);;
+gap> SchutzGpMembership(S)(schutz, (2, 3));
+true
+
+# SchutzGpMembership, for a bipartition semigroup
+gap> S := Monoid([
+>  Bipartition([[1, -1], [2, -3], [3, -2]]),
+>  Bipartition([[1, -2], [2, -3], [3], [-1]]),
+>  Bipartition([[1, 2, -1, -2], [3, -3]]),
+>  Bipartition([[1], [2, -1], [3, -2, -3]]),
+>  Bipartition([[1, -3], [2, 3, -2], [-1]]),
+>  Bipartition([[1], [2, -1], [3, -2], [-3]])]);;
+gap> o := LambdaOrb(S);; Enumerate(o);;
+gap> schutz := LambdaOrbStabChain(o, 2);;
+gap> SchutzGpMembership(S)(schutz, (2, 3));
+true
+
+# SchutzGpMembership, for an RZMS
+gap> R := ReesZeroMatrixSemigroup(Group((1, 2, 3)), [[()]]);;
+gap> R := Semigroup(Elements(R));;
+gap> o := LambdaOrb(S);; Enumerate(o);;
+gap> schutz := LambdaOrbStabChain(o, 2);;
+gap> SchutzGpMembership(R)(schutz, ());
+true
+
+# SchutzGpMembership, for a matrix over FF semigroup
+gap> S := Monoid([
+>  Matrix(GF(2), [[0 * Z(2), Z(2) ^ 0], [0 * Z(2), 0 * Z(2)]]),
+>  Matrix(GF(2), [[Z(2) ^ 0, 0 * Z(2)], [Z(2) ^ 0, 0 * Z(2)]]),
+>  Matrix(GF(2), [[Z(2) ^ 0, Z(2) ^ 0], [0 * Z(2), Z(2) ^ 0]])]);;
+gap> o := LambdaOrb(S);; Enumerate(o);;
+gap> schutz := LambdaOrbStabChain(o, 2);;
+gap> SchutzGpMembership(S)(schutz, LambdaIdentity(S)(2));
+true
+
+#T# FakeOne
+
+# FakeOne, for a transformation semigroup
+gap> FakeOne(FullTransformationMonoid(1));
+IdentityTransformation
+
+# FakeOne, for a partial perm semigroup
+gap> FakeOne(SymmetricInverseMonoid(1));
+<identity partial perm on [ 1 ]>
+
+# FakeOne, for a bipartition semigroup
+gap> FakeOne(PartitionMonoid(1));
+<block bijection: [ 1, -1 ]>
+
+# FakeOne, for an RZMS
+gap> FakeOne(ReesZeroMatrixSemigroup(Group(()), [[()]]));
+<universal fake one>
+
+# FakeOne, for a matrix over FF semigroup
+gap> FakeOne(GLM(2, 2));
+Matrix(GF(2), [[Z(2)^0, 0*Z(2)], [0*Z(2), Z(2)^0]])
+
+#T# ChooseHashFunction
+
+# SEMIGROUPS.HashFunctionRZMSE
+gap> SEMIGROUPS.HashFunctionRZMSE([1, (), 2], "bananas", ReturnFail, false);
+Error, Semigroups: SEMIGROUPS.HashFunctionRZMSE: error,
+this shouldn't happen,
+
+# ChooseHashFunction, for an RZMS element and integer
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> ChooseHashFunction(MultiplicativeZero(R), 0);
+rec( data := 0, func := function( x, hashlen ) ... end )
+gap> G := SymmetricGroup(IsPcGroup, 3);;
+gap> R := ReesZeroMatrixSemigroup(G, [[Identity(G)]]);;
+gap> x := ChooseHashFunction(MultiplicativeNeutralElement(R), 1000);
+rec( data := [ 101, 1000 ], func := function( x, hashlen ) ... end )
+gap> G := FullPBRMonoid(1);;
+gap> R := ReesZeroMatrixSemigroup(G, [[One(G)]]);;
+gap> x := ChooseHashFunction(RMSElement(R, 1, One(G), 1), 1);
+Error, Semigroups: ChooseHashFunction: error,
+cannot hash RZMS elements over this underlying semigroup,
+
+# ChooseHashFunction, for an object and integer
+gap> x := ChooseHashFunction(fail, 0);
+rec( data := fail, func := function( v, data ) ... end )
+gap> x.func(fail, fail);
+1
+
+#T# SEMIGROUPS_UnbindVariables
+gap> Unbind(b);
+gap> Unbind(o);
+gap> Unbind(r);
+gap> Unbind(s);
+gap> Unbind(x);
+gap> Unbind(y);
+gap> Unbind(S);
+gap> Unbind(R);
+gap> Unbind(schutz);
+
+#E#
 gap> STOP_TEST("Semigroups package: standard/setup.tst");


### PR DESCRIPTION
In Issue #171, @james-d-mitchell suggests adding code-coverage checking and lint checking to out Travis setup. I think these are both good intentions.

### Linting

After this PR, Travis downloads the gaplint tool. After running the normal GAP tests and the saved workspace tests, Travis now runs a linting check. **We should discuss what the linter should be run on, and what we should do when we encounter trouble.**

Currently I've got it doing `gaplint.py gap/*/*.gi`, and failing the Travis instance if _anything_ goes wrong. This checks the linting of the `.gi` files which reside in a subdirectory of the `gap` subdirectory of the package.

Today I spent a good chunk of time linting the Semigroups package and fixing the gaplint tool so that, at least in `unstable-3.0`, running `gaplint.py gap/*/*.gi` causes no warnings or errors or crashes. I'm happy with this change, as it means that from now on, we will have to make sure that we write well-formatted code in the first instance, under pain of breaking the tests.

However I am wary about extending the scope of the linter at the moment, at least in a way that would cause more Travis failures.

* in my experience, gaplint is not totally robust (no offence James), and since it is quite a complicated tool, I envisage a common occurrence: new code causes gaplint to crash or behave incorrectly, which means that the Travis tests fail. The tests will keep failing until gaplint is fixed, which renders Travis essentially useless in this interim period.
* when run on `.gd` files, Travis will complain about missing documentation, and things being in the wrong files, etc. Obviously we don't want missing documentation, but I'm not convinced that this is robust enough yet to give **no** false positives (surely we don't want false positives breaking the Travis tests). **Also, often we want to push something to our own repositories which isn't complete, and so maybe it lacks documentation, but we still want to be able to rely on Travis to tell us whether our branch is working or not.**
* when run on `.gd` files at the moment, a _lot_ goes wrong. If we started checking these files now, it would require a heck of a lot of work before the Travis tests passed again.

For these reasons, I'd argue that we should use gaplint in this more limited sense, perhaps until the release of 3.0.

### Code coverage

After this PR, Travis installs the profiling package. However, I currently only do this when GAP is compiled in 64-bit mode, since compilation seems to fail in 32-bit.

I have also adapted the code coverage script to make a version for Travis. After the linting checks, this coverage script is run on each test file in `semigroups/tst/standard`, and the coverage of its corresponding `.gi` file is found from the html output. If this coverage is below 95%, I print a warning. However, I've not yet set this up to cause the test instance to fail.

We should decide what the threshold should be, and whether we should just print warnings, or whether we should actually fail the tests.

## Your thoughts?

@james-d-mitchell @mtorpey what are your opinions on the lint checking that this PR proposes?