### PR TITLE
WIP: Translations and translational hulls

### DIFF
--- a/doc/semigroups.bib
+++ b/doc/semigroups.bib
@@ -380,8 +380,7 @@
  doi = {10.1109/SFCS.1978.21},
  acmid = {1382581},
  publisher = {IEEE Computer Society},
- address = {Washington, DC, USA},
-}
+ address = {Washington, DC, USA},}
 
 @article{Johnson1975aa,
   Author = {D.B. Johnson},
@@ -390,3 +389,12 @@
   Title = {Finding all the elementary circuits of a directed graph},
   Volume = {4},
   Year = {1975}}
+
+@article{Petrich1968a,
+  Author = {Petrich, M.},
+  Journal = {Glasgow Math, J,},
+  Number = {1},
+  Pages = {1--11},
+  Title = {The translational hull of a completely 0-simple semigroup},
+  Volume = {9},
+  Year = {1968}}

--- a/doc/translat.xml
+++ b/doc/translat.xml
@@ -1,8 +1,10 @@
 <#GAPDoc Label="XTranslations">
   <ManSection>
-    <Attr Name="LeftTranslations" Arg="sgrp" 
+    <Attr Name="LeftTranslations" Arg="sgrp" Label="for a finite semigroup"/>
+    <Attr Name="RightTranslations" Arg="sgrp" Label="for a finite semigroup"/>
+    <Func Name="LeftTranslationsSemigroup" Arg="sgrp" 
           Label="for a finite semigroup"/>
-    <Attr Name="RightTranslations" Arg="sgrp" 
+    <Func Name="RightTranslationsSemigroup" Arg="sgrp" 
           Label="for a finite semigroup"/>
     <Returns>The semigroup of X translations of the given semigroup</Returns>
     <Description>
@@ -12,6 +14,9 @@
       rectangular bands <A>S</A> generating sets and sizes of the translations
       semigroups are known. 
       It is not currently possible to calculate this for arbitrary semigroups.
+      <C>LeftTranslationsSemigroup</C> and <C>RightTranslationsSemigroup</C> do
+      the same thing except that they do not attempt to calculate the elements
+      of the translations semigroup.
       <Example><![CDATA[
 gap> S := RectangularBand(3,4);;
 gap> L := LeftTranslationsSemigroup(S);
@@ -31,6 +36,7 @@ gap> GeneratorsOfSemigroup(L);
     </Description>
   </ManSection>
 <#/GAPDoc>
+
 
 <#GAPDoc Label="XTranslation">
   <ManSection>
@@ -66,14 +72,17 @@ Transformation( [ 1, 2, 1, 1, 5, 5, 5, 5 ] )
 
 <#GAPDoc Label="TranslationalHull">
   <ManSection>
-    <Attr Name="TranslationalHull" Arg="sgrp" 
+    <Attr Name="TranslationalHull" Arg="sgrp" Label="for a finite semigroup">    
+    <Func Name="TranslationalHullSemigroup" Arg="sgrp" 
           Label="for a finite semigroup">
     <Returns>The translational hull of the given semigroup</Returns>
     <Description>
-      Returns the translational hull of the given semigroup. For finite 0-simple
-      semigroups and rectangular bands, explicit generating sets are known. For
-      small arbitrary semigroups, it may be possible to calculate the
-      translational hull.
+      <C>TranslationalHull</C><A>S</A>returns the translational hull of 
+      <A>S</A>. For finite 0-simple semigroups and rectangular bands, explicit 
+      generating sets are known. For small arbitrary semigroups, it may be 
+      possible to calculate the elements of the translational hull. 
+      <C>TranslationalHullSemigroup</C> does the same thing except that it does
+      not attepmt to calculate the elements of the translational hull.
       <Example><![CDATA[
 ]]>
       </Example>
@@ -97,10 +106,10 @@ gap> H := ShallowCopy(AsList(G));;
 gap> Add(H, 0);;
 gap> mat:=List([1..5], x-> List([1..5], y-> Random(H)));;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
-gap> L := LeftTranslations(S);;
-gap> R := RightTranslations(S);;
-gap> l := Representative(TranslationalElements(L));;
-gap> r := Representative(TranslationalElements(R));;
+gap> L := LeftTranslationsSemigroup(S);;
+gap> R := RightTranslationsSemigroup(S);;
+gap> l := Representative(L);;
+gap> r := Representative(R);;
 gap> H := TranslationalHull(S);;
 gap> x := TranslationalHullElement(H, l, r);
 <linked pair of translations on <0-simple regular semigroup of size 101, with 
@@ -125,7 +134,7 @@ gap> x = x * x;
       Bookname="ref">.
       <Example> <![CDATA[
 gap> S := RectangularBand(3,4);;
-gap> l := Representative(TranslationalElements(LeftTranslations(S)));
+gap> l := Representative(LeftTranslations(S));
 <left translation on <simple transformation semigroup of size 12, degree 8 
  with 4 generators>>
 gap> IsTranslationsSemigroupElement(l);
@@ -154,8 +163,8 @@ gap> mat:=List([1..5], x-> List([1..5], y-> Random(H)));;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
 gap> L := LeftTranslations(S);;
 gap> R := RightTranslations(S);;
-gap> l := Representative(TranslationalElements(L));;
-gap> r := Representative(TranslationalElements(R));;
+gap> l := Representative(L);;
+gap> r := Representative(R);;
 gap> H := TranslationalHull(S);;
 gap> x := TranslationalHullElement(H, l, r);;
 gap> IsTranslationalHullElement(x);
@@ -204,6 +213,7 @@ gap> H := TranslationalHull(S);;
 gap> IsTranslationalHull(H);
 true
 gap> IsTranslationalHull(S);
+false
 ]]>   </Example>
     </Description>
   </ManSection>
@@ -286,29 +296,5 @@ true
     </Description>
   </ManSection>
 <#/GAPDoc> 
-
-<#GAPDoc Label="TranslationalElements">
-  <ManSection>
-    <Attr Name="TranslationalElements" Arg="S">
-    <Returns>The elements of <A>S</A></Returns>
-    <Description>
-      For <A>S</A> the whole semigroup of left or right translations of a
-      semigroup, or the translational hull of a semigroup, 
-      <C>TranslationalElements</C>(<A>S</A>) returns the calculated semigroup
-      of elements of <A>S</A>, so that <A>S</A> can be manipulated as more than
-      an abstract object.
-      <Example><![CDATA[
-gap> S := RectangularBand(3,3);;
-gap> H := TranslationalHull(S);;
-gap> TranslationalElements(H);
-Semigroup( ... )
-]]>   </Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc>
     
- 
- 
- 
- 
-      
+#EOF      

--- a/doc/translat.xml
+++ b/doc/translat.xml
@@ -18,19 +18,18 @@
       <Example><![CDATA[
 gap> S := RectangularBand(3,4);;
 gap> L := LeftTranslationsSemigroup(S);
-<the semigroup of left translations of <regular transformation semigroup 
- of size 12, degree 8 with 4 generators>>
+<the semigroup of left translations of <regular transformation 
+ semigroup of size 12, degree 8 with 4 generators>>
 gap> Size(L);
 27
 gap> GeneratorsOfSemigroup(L);
-[ <left translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>>, 
-  <left translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>>, 
-  <left translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>> ]
-]]>
-      </Example>
+[ <left translation on <simple transformation semigroup of size 12, 
+     degree 8 with 4 generators>>, 
+  <left translation on <simple transformation semigroup of size 12, 
+     degree 8 with 4 generators>>, 
+  <left translation on <simple transformation semigroup of size 12, 
+     degree 8 with 4 generators>> ]
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -54,12 +53,11 @@ gap> f := function(x)
 > end;;
 gap> map := MappingByFunction(S, S, f);;
 gap> l := LeftTranslation(L, map);
-<left translation on <regular transformation semigroup of size 12, degree 8 
- with 4 generators>>
+<left translation on <regular transformation semigroup of size 12, 
+ degree 8 with 4 generators>>
 gap> s^l;
-Transformation( [ 1, 2, 1, 1, 5, 5, 5, 5 ] ) 
-]]> 
-      </Example>
+Transformation( [ 1, 2, 1, 1, 5, 5, 5, 5 ] )
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -84,10 +82,9 @@ gap> mat := [[a, 0, b],
 > [0, a, b]];;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
 gap> H := TranslationalHull(S);
-<translational hull over <0-simple regular semigroup of size 55, with 6 
- generators>>
-]]>
-      </Example>
+<translational hull over <0-simple regular semigroup of size 55, with 
+ 6 generators>>
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -103,20 +100,19 @@ gap> H := TranslationalHull(S);
       <A>H</A>.
       <Example> <![CDATA[
 gap> G := SmallGroup(4,2);;
-gap> H := ShallowCopy(AsList(G));;
-gap> Add(H, 0);;
-gap> mat:=List([1..5], x-> List([1..5], y-> Random(H)));;
+gap> A := AsList(G);;
+gap> mat := [ [A[1], 0],
+> [A[2], A[2]] ];;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
 gap> L := LeftTranslationsSemigroup(S);;
 gap> R := RightTranslationsSemigroup(S);;
-gap> l := Representative(L);;
-gap> r := Representative(R);;
+gap> l := LeftTranslation(L, MappingByFunction(S, S, s -> S.1 * s));;
+gap> r := RightTranslation(R, MappingByFunction(S, S, s -> s * S.1));;
 gap> H := TranslationalHull(S);;
 gap> x := TranslationalHullElement(H, l, r);
-<linked pair of translations on <0-simple regular semigroup of size 101, with 
- 10 generators>>
-gap> x = x * x;
-]]>   </Example>
+<linked pair of translations on <0-simple regular semigroup 
+ of size 17, with 4 generators>>
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -135,15 +131,15 @@ gap> x = x * x;
       <Example> <![CDATA[
 gap> S := RectangularBand(3,4);;
 gap> l := Representative(LeftTranslations(S));
-<left translation on <simple transformation semigroup of size 12, degree 8 
- with 4 generators>>
+<left translation on <simple transformation semigroup of size 12, 
+ degree 8 with 4 generators>>
 gap> IsTranslationsSemigroupElement(l);
 true
 gap> IsLeftTranslationsSemigroupElement(l);
 true
 gap> IsRightTranslationsSemigroupElement(l);
 false
-]]>   </Example>
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -157,22 +153,21 @@ false
       <Ref Filt="IsAssociativeElement" BookName="ref"/>.
       <Example> <![CDATA[
 gap> G := SmallGroup(4,2);;
-gap> H := ShallowCopy(AsList(G));;
-gap> Add(H, 0);;
-gap> mat:=List([1..5], x-> List([1..5], y-> Random(H)));;
+gap> A := AsList(G);;
+gap> mat := [ [A[1], 0, A[1]],
+> [A[2], A[2], A[4]]];;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
 gap> L := LeftTranslations(S);;
 gap> R := RightTranslations(S);;
-gap> l := Representative(L);;
-gap> r := Representative(R);;
+gap> l := OneOp(Representative(L));;
+gap> r := OneOp(Representative(R));;
 gap> H := TranslationalHull(S);;
 gap> x := TranslationalHullElement(H, l, r);;
 gap> IsTranslationalHullElement(x);
 true
 gap> IsTranslationsSemigroupElement(x);
 false
-
-]]>   </Example>
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -196,7 +191,7 @@ gap> IsTranslationsSemigroup(L);
 true
 gap> IsRightTranslationsSemigroup(L);
 false
-]]>   </Example>
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -214,7 +209,7 @@ gap> IsTranslationalHull(H);
 true
 gap> IsTranslationalHull(S);
 false
-]]>   </Example>
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -230,7 +225,7 @@ false
 gap> H := TranslationalHull(S);;
 gap> UnderlyingSemigroup(H) = S;
 true
-]]>   </Example>
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -251,7 +246,7 @@ gap> L := LeftTranslations(S);;
 gap> l := Representative(L);;
 gap> LeftTranslationsSemigroupOfFamily(FamilyObj(l)) = L;
 true
-]]>   </Example>
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -267,34 +262,13 @@ true
       which contains the objects of family <A>fam</A>
       <Example><![CDATA[
 gap> S := RectangularBand(3,3);;
-gap> H := LeftTranslations(S);;
+gap> H := TranslationalHull(S);;
 gap> h := Representative(H);;
 gap> TranslationalHullOfFamily(FamilyObj(h)) = H;
 true
-]]>   </Example>
+]]></Example>
     </Description>
   </ManSection>
-<#/GAPDoc> 
-
-<#GAPDoc Label="TypeXTranslationsSemigroupElements">
-  <ManSection>
-    <Attr Name="TypeLeftTranslationsSemigroupElements" Arg="L"/>
-    <Attr Name="TypeRightTranslationsSemigroupElements" Arg="R"/>
-    <Returns>The type of the elements of the given
-    XTranslationsSemigroup</Returns>
-    <Description>
-      For a semigroup of X translations <A>X</A>, 
-      <C>TypeXTranslationsSemigroup</C>(<A>X</A>) returns the type of the
-      elements of that semigroup.
-      <Example><![CDATA[
-gap> S := RectangularBand(3,3);;
-gap> L := LeftTranslations(S);;
-gap> l := Representative(L);;
-gap> TypeLeftTranslationsSemigroupElements(L) = TypeObj(l);
-true
-]]>   </Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc> 
+<#/GAPDoc>
     
 #EOF

--- a/doc/translat.xml
+++ b/doc/translat.xml
@@ -1,0 +1,125 @@
+<#GAPDoc Label="XTranslations">
+  <ManSection>
+    <Attr Name="LeftTranslations" Arg="sgrp" 
+          Label="for a finite semigroup"/>
+    <Attr Name="RightTranslations" Arg="sgrp" 
+          Label="for a finite semigroup"/>
+    <Returns>The semigroup of X translations of the given semigroup</Returns>
+    <Description>
+      <C>LeftTranslations(<A>S</A>)</C> returns the semigroup of left 
+      translations of <A>S</A>, and similarly for 
+      <C>RightTranslations(<A>S</A>)</C>. For finite 0-simple semigroups and 
+      rectangular bands <A>S</A> generating sets and sizes of the translations
+      semigroups are known. 
+      For small arbitrary semigroups, it may be possible to explicitly calculate
+      the translations semigroups..
+      <Example><![CDATA[
+gap> S := RectangularBand(3,4);;
+gap> L := LeftTranslationsSemigroup(S);
+<the semigroup of left translations of <regular transformation semigroup 
+ of size 12, degree 8 with 4 generators>>
+gap> Size(L);
+27
+gap> GeneratorsOfSemigroup(L);
+[ <left translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>>, 
+  <left translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>>, 
+  <left translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>> ]
+]]>
+      </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="XTranslation">
+  <ManSection>
+    <Func Name="LeftTranslation" Arg="L, map">
+    <Func Name="RightTranslation" Arg="R, map">
+    <Returns>An X translation.</Returns>
+    <Description>
+      For the semigroup of X translations and a Mapping on the underlying 
+      semigroup, XTranslation returns the corresponding translation. 
+      
+      XTranslation uses the function <Ref Oper="AsList" Bookname="ref"/> to
+      determine the indices of elements.
+      
+      Note that XTranslation does not check whether the map given defines a 
+      valid translation.
+      <Example><![CDATA[
+gap> S := RectangularBand(3,4);;
+gap> L := LeftTranslationsSemigroup(S);;
+gap> s := AsList(S)[1];;
+gap> f := function(x)
+> return s * x;
+> end;;
+gap> map := MappingByFunction(S, S, f);;
+gap> l := LeftTranslation(L, map);
+<left translation on <regular transformation semigroup of size 12, degree 8 
+ with 4 generators>>
+gap> s^l;
+Transformation( [ 1, 2, 1, 1, 5, 5, 5, 5 ] ) 
+]]> 
+    </Example>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="TranslationalHull">
+  <ManSection>
+    <Attr Name="TranslationalHull" Arg="sgrp" 
+          Label="for a finite semigroup">
+    <Returns>The translational hull of the given semigroup</Returns>
+    <Description>
+      Returns the translational hull of the given semigroup. For finite 0-simple
+      semigroups and rectangular bands, explicit generating sets are known. For
+      small arbitrary semigroups, it may be possible to calculate the
+      translational hull.
+      <Example><![CDATA[
+]]>
+      </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="TranslationalHullElement">
+  <ManSection>
+    <Attr Name="TranslationalHullElement" Arg="H, l, r"
+          Label="for a given translational hull, left translation, and right
+                translation">
+    <Returns>The element of the translational hull corresponding to the given 
+              left and right translations</Returns>
+    <Description>
+      <C>TranslationalHullElement(<A>H, l, r</A>) returns the linked pair 
+      (<A>l, r</A>) of translations.
+      <Example> <![CDATA[
+      
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+      

--- a/doc/translat.xml
+++ b/doc/translat.xml
@@ -1,18 +1,16 @@
 <#GAPDoc Label="XTranslations">
   <ManSection>
-    <Attr Name="LeftTranslations" Arg="sgrp" Label="for a finite semigroup"/>
-    <Attr Name="RightTranslations" Arg="sgrp" Label="for a finite semigroup"/>
-    <Func Name="LeftTranslationsSemigroup" Arg="sgrp" 
-          Label="for a finite semigroup"/>
-    <Func Name="RightTranslationsSemigroup" Arg="sgrp" 
-          Label="for a finite semigroup"/>
-    <Returns>The semigroup of X translations of the given semigroup</Returns>
+    <Func Name="LeftTranslations" Arg="sgrp"/>
+    <Func Name="RightTranslations" Arg="sgrp"/>
+    <Func Name="LeftTranslationsSemigroup" Arg="sgrp"/>
+    <Func Name="RightTranslationsSemigroup" Arg="sgrp"/>
+    <Returns>The semigroup of left or right translations of the given semigroup</Returns>
     <Description>
       <C>LeftTranslations(<A>S</A>)</C> returns the semigroup of left 
       translations of <A>S</A>, and similarly for 
       <C>RightTranslations(<A>S</A>)</C>. For finite 0-simple semigroups and 
       rectangular bands <A>S</A> generating sets and sizes of the translations
-      semigroups are known. 
+      semigroups are known.
       It is not currently possible to calculate this for arbitrary semigroups.
       <C>LeftTranslationsSemigroup</C> and <C>RightTranslationsSemigroup</C> do
       the same thing except that they do not attempt to calculate the elements
@@ -40,18 +38,13 @@ gap> GeneratorsOfSemigroup(L);
 
 <#GAPDoc Label="XTranslation">
   <ManSection>
-    <Func Name="LeftTranslation" Arg="L, map">
-    <Func Name="RightTranslation" Arg="R, map">
+    <Func Name="LeftTranslation" Arg="L, map"/>
+    <Func Name="RightTranslation" Arg="R, map"/>
     <Returns>An X translation.</Returns>
     <Description>
-      For the semigroup of X translations and a Mapping on the underlying 
-      semigroup, XTranslation returns the corresponding translation. 
-      
-      XTranslation uses the function <Ref Oper="AsList" Bookname="ref"/> to
-      determine the indices of elements.
-      
-      Note that XTranslation does not check whether the map given defines a 
-      valid translation.
+      For the semigroup of left of right translations and a Mapping on the 
+      underlying semigroup, LeftTranslation and RightTranslation return 
+      the corresponding translations. 
       <Example><![CDATA[
 gap> S := RectangularBand(3,4);;
 gap> L := LeftTranslationsSemigroup(S);;
@@ -66,24 +59,33 @@ gap> l := LeftTranslation(L, map);
 gap> s^l;
 Transformation( [ 1, 2, 1, 1, 5, 5, 5, 5 ] ) 
 ]]> 
-    </Example>
+      </Example>
+    </Description>
   </ManSection>
 <#/GAPDoc>
 
 <#GAPDoc Label="TranslationalHull">
   <ManSection>
-    <Attr Name="TranslationalHull" Arg="sgrp" Label="for a finite semigroup">    
-    <Func Name="TranslationalHullSemigroup" Arg="sgrp" 
-          Label="for a finite semigroup">
+    <Attr Name="TranslationalHull" Arg="sgrp"/>    
+    <Func Name="TranslationalHullSemigroup" Arg="sgrp"/>
     <Returns>The translational hull of the given semigroup</Returns>
     <Description>
-      <C>TranslationalHull</C><A>S</A>returns the translational hull of 
+      <C>TranslationalHull</C>(<A>S</A>)returns the translational hull of 
       <A>S</A>. For finite 0-simple semigroups and rectangular bands, explicit 
       generating sets are known. For small arbitrary semigroups, it may be 
       possible to calculate the elements of the translational hull. 
       <C>TranslationalHullSemigroup</C> does the same thing except that it does
-      not attepmt to calculate the elements of the translational hull.
+      not attempt to calculate the elements of the translational hull.
       <Example><![CDATA[
+gap> G := SmallGroup(6, 1);;
+gap> a := G.1;; b := G.2;;
+gap> mat := [[a, 0, b],
+> [b, a, 0],
+> [0, a, b]];;
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> H := TranslationalHull(S);
+<translational hull over <0-simple regular semigroup of size 55, with 6 
+ generators>>
 ]]>
       </Example>
     </Description>
@@ -92,14 +94,13 @@ Transformation( [ 1, 2, 1, 1, 5, 5, 5, 5 ] )
 
 <#GAPDoc Label="TranslationalHullElement">
   <ManSection>
-    <Attr Name="TranslationalHullElement" Arg="H, l, r"
-          Label="for a given translational hull, left translation, and right
-                translation">
+    <Attr Name="TranslationalHullElement" Arg="H, l, r"/>
     <Returns>The element of the translational hull corresponding to the given 
               left and right translations</Returns>
     <Description>
-      <C>TranslationalHullElement(<A>H, l, r</A>) returns the linked pair 
-      (<A>l, r</A>) of translations.
+      <C>TranslationalHullElement</C>(<A>H, l, r</A>) returns the linked pair 
+      (<A>l, r</A>) of translations, belonging to the translational hull 
+      <A>H</A>.
       <Example> <![CDATA[
 gap> G := SmallGroup(4,2);;
 gap> H := ShallowCopy(AsList(G));;
@@ -122,16 +123,15 @@ gap> x = x * x;
 
 <#GAPDoc Label="IsXTranslationsSemigroupElement">
   <ManSection>
-    <Filt Name = "IsTranslationsSemigroupElement" Type="Category">
-    <Filt Name = "IsLeftTranslationsSemigroupElement" Type="Category">
-    <Filt Name = "IsRightTranslationsSemigroupElement" Type="Category">
+    <Filt Name = "IsTranslationsSemigroupElement" Type="Category"/>
+    <Filt Name = "IsLeftTranslationsSemigroupElement" Type="Category"/>
+    <Filt Name = "IsRightTranslationsSemigroupElement" Type="Category"/>
     <Description>
       All, and only, left [right] translations belong to 
       <C>IsLeftTranslationsSemigroupElement</C> 
-      [<C>IsRightTranslationsSemigroupElement</C>]. 
-      These are both subcategories of <C>IsTranslationsSemigroupElement</C>,
-      which itself is a subcategory of <Ref Filt="IsAssociativeElement"
-      Bookname="ref">.
+      [<C>IsRightTranslationsSemigroupElement</C>]. These are both subcategories
+      of <C>IsTranslationsSemigroupElement</C>,
+      which itself is a subcategory of <C>IsAssociativeElement</C>.
       <Example> <![CDATA[
 gap> S := RectangularBand(3,4);;
 gap> l := Representative(LeftTranslations(S));
@@ -150,11 +150,11 @@ false
 
 <#GAPDoc Label="IsTranslationalHullElement">
   <ManSection>
-    <Filt Name="IsTranslationalHullElement" Type="Category">
+    <Filt Name="IsTranslationalHullElement" Type="Category"/>
     <Description>
       All, and only, translational hull elements belong to 
       <C>IsTranslationalHullElement</C>. This is a subcategory of 
-      <Ref Filt="IsAssociativeElement" Bookname="ref">.
+      <Ref Filt="IsAssociativeElement" BookName="ref"/>.
       <Example> <![CDATA[
 gap> G := SmallGroup(4,2);;
 gap> H := ShallowCopy(AsList(G));;
@@ -179,13 +179,13 @@ false
 
 <#GAPDoc Label="IsXTranslationsSemigroup">
   <ManSection>
-    <Filt Name="IsTranslationsSemigroup" Type="Synonym">
-    <Filt Name="IsLeftTranslationsSemigroup" Type="Synonym">
-    <Filt Name="IsRightTranslationsSemigroup" Type="Synonym">
+    <Filt Name="IsTranslationsSemigroup" Type="Synonym"/>
+    <Filt Name="IsLeftTranslationsSemigroup" Type="Synonym"/>
+    <Filt Name="IsRightTranslationsSemigroup" Type="Synonym"/>
     <Description>
       <C>IsXTranslationsSemigroup(</C> is a synonym for 
       <C>IsXTranslationsSemigroupElementCollection</C> and
-      <C>IsSemigroup<C>.
+      <C>IsSemigroup</C>.
       <Example><![CDATA[
 gap> S := RectangularBand(3,4);;
 gap> L := LeftTranslations(S);;
@@ -203,10 +203,10 @@ false
   
 <#GAPDoc Label="IsTranslationalHull">
   <ManSection>
-    <Filt Name="IsTranslationalHull" Type="synonym">
+    <Filt Name="IsTranslationalHull" Type="synonym"/>
     <Description>
       <C>IsTranslationalHull</C> is a synonym for <C>IsSemigroup</C> and
-      <Ref Filt="IsTranslationalHullElementCollection">
+      <Ref Filt="IsTranslationalHullElementCollection"/>
       <Example><![CDATA[
 gap> S := RectangularBand(3,3);;
 gap> H := TranslationalHull(S);;
@@ -221,9 +221,9 @@ false
 
 <#GAPDoc Label="UnderlyingSemigroup">
   <ManSection>
-    <Attr Name="UnderlyingSemigroup" Arg="S">
+    <Attr Name="UnderlyingSemigroup" Arg="S"/>
     <Description>
-      <C>UnderlyingSemigroup(<A>S</A>)</C>, for <A>S<A> a semigroup of left or 
+      <C>UnderlyingSemigroup(<A>S</A>)</C>, for <A>S</A> a semigroup of left or 
       right translations or a translational hull, returns the semigroup which 
       elements of <A>S</A> act on.
       <Example><![CDATA[
@@ -237,13 +237,13 @@ true
 
 <#GAPDoc Label="XTranslationsSemigroupOfFamily">
   <ManSection>
-    <Attr Name="LeftTranslationsSemigroupOfFamily" Arg="fam">
-    <Attr Name="RightTranslationsSemigroupOfFamily" Arg="fam">
+    <Attr Name="LeftTranslationsSemigroupOfFamily" Arg="fam"/>
+    <Attr Name="RightTranslationsSemigroupOfFamily" Arg="fam"/>
     <Returns>The XTranslationsSemigroup used to create objects in the given
     family </Returns>
     <Description>
       When <A>fam</A> is a family of left or right translations,
-      <C>XTranslationsSemigroupOfFamily<C>(<A>fam</A>) returns the left or right
+      <C>XTranslationsSemigroupOfFamily</C>(<A>fam</A>) returns the left or right
       translations semigroup which contains the objects of family <A>fam</A>
       <Example><![CDATA[
 gap> S := RectangularBand(3,3);;
@@ -258,12 +258,12 @@ true
  
 <#GAPDoc Label="TranslationalHullOfFamily">
   <ManSection>
-    <Attr Name="TranslationalHullOfFamily" Arg="fam">
+    <Attr Name="TranslationalHullOfFamily" Arg="fam"/>
     <Returns>The translational hull used to create objects in the given
     family </Returns>
     <Description>
       When <A>fam</A> is a family of translational hull elements,
-      <C>TranslationalHullOfFamily<C>(<A>fam</A>) returns the translational hull
+      <C>TranslationalHullOfFamily</C>(<A>fam</A>) returns the translational hull
       which contains the objects of family <A>fam</A>
       <Example><![CDATA[
 gap> S := RectangularBand(3,3);;
@@ -278,8 +278,8 @@ true
 
 <#GAPDoc Label="TypeXTranslationsSemigroupElements">
   <ManSection>
-    <Attr Name="TypeLeftTranslationsSemigroupElements" Arg="L">
-    <Attr Name="TypeRightTranslationsSemigroupElements" Arg="R">
+    <Attr Name="TypeLeftTranslationsSemigroupElements" Arg="L"/>
+    <Attr Name="TypeRightTranslationsSemigroupElements" Arg="R"/>
     <Returns>The type of the elements of the given
     XTranslationsSemigroup</Returns>
     <Description>
@@ -297,4 +297,4 @@ true
   </ManSection>
 <#/GAPDoc> 
     
-#EOF      
+#EOF

--- a/doc/translat.xml
+++ b/doc/translat.xml
@@ -270,5 +270,66 @@ true
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="InnerXTranslations">
+  <ManSection>
+    <Attr Name="InnerLeftTranslations" Arg="sgrp"/>
+    <Attr Name="InnerRightTranslations" Arg="sgrp"/>
+    <Returns>The monoid of inner left or right translations of a semigroup.
+    </Returns>
+    <Description>
+      For a finite semigroup <A>S</A>, <C>InnerLeftTranslations</C><A>S</A> 
+      returns the inner left translations of S. These are the translations 
+      defined by left multiplication by a fixed element of <A>S</A>.
+      <C>InnerRightTranslations</C><A>S</A> returns the inner right translations
+      of <A>S</A>. These are the translations defined by right multiplication by
+      a fixed element of <A>S</A>.
+      <Example><![CDATA[
+gap> S := Semigroup([Transformation([2,2,3,1]), 
+> Transformation([1,4,3,3])]);;
+gap> L := InnerLeftTranslations(S);
+Monoid( 
+[ <left translation on <transformation semigroup of size 24, degree 4 
+     with 2 generators>>, 
+  <left translation on <transformation semigroup of size 24, degree 4 
+     with 2 generators>> ] )
+gap> R := InnerRightTranslations(S);
+Monoid( 
+[ <right translation on <transformation semigroup of size 24, 
+     degree 4 with 2 generators>>, 
+  <right translation on <transformation semigroup of size 24, 
+     degree 4 with 2 generators>> ] )
+gap> Size(L) = Size(S);
+true
+gap> Size(L) = Size(R);
+true
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="InnerTranslationalHull">
+  <ManSection>
+    <Attr Name="InnerTranslationalHull" Arg="sgrp"/>
+    <Returns>The monoid of linked inner left/right translations of a semigroup
+    </Returns>
+    <Description>
+      For a finite semigroup <A>S</A>, <C>InnerTranslationalHull</C><A>S</A> 
+      returns the inner bitranslations of S. These are the pairs of left and  
+      right translations defined respectively by left multiplication 
+      and right multiplication by the same fixed element of <A>S</A>.
+      <Example><![CDATA[
+gap> S := Semigroup([Transformation([2,2,3,1]), 
+> Transformation([1,4,3,3])]);;
+gap> InnerTranslationalHull(S);
+Monoid( 
+[ <linked pair of translations on <transformation semigroup 
+     of size 24, degree 4 with 2 generators>>, 
+  <linked pair of translations on <transformation semigroup 
+     of size 24, degree 4 with 2 generators>> ] )
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
     
 #EOF

--- a/doc/translat.xml
+++ b/doc/translat.xml
@@ -11,8 +11,7 @@
       <C>RightTranslations(<A>S</A>)</C>. For finite 0-simple semigroups and 
       rectangular bands <A>S</A> generating sets and sizes of the translations
       semigroups are known. 
-      For small arbitrary semigroups, it may be possible to explicitly calculate
-      the translations semigroups..
+      It is not currently possible to calculate this for arbitrary semigroups.
       <Example><![CDATA[
 gap> S := RectangularBand(3,4);;
 gap> L := LeftTranslationsSemigroup(S);
@@ -93,31 +92,221 @@ Transformation( [ 1, 2, 1, 1, 5, 5, 5, 5 ] )
       <C>TranslationalHullElement(<A>H, l, r</A>) returns the linked pair 
       (<A>l, r</A>) of translations.
       <Example> <![CDATA[
-      
+gap> G := SmallGroup(4,2);;
+gap> H := ShallowCopy(AsList(G));;
+gap> Add(H, 0);;
+gap> mat:=List([1..5], x-> List([1..5], y-> Random(H)));;
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> L := LeftTranslations(S);;
+gap> R := RightTranslations(S);;
+gap> l := Representative(TranslationalElements(L));;
+gap> r := Representative(TranslationalElements(R));;
+gap> H := TranslationalHull(S);;
+gap> x := TranslationalHullElement(H, l, r);
+<linked pair of translations on <0-simple regular semigroup of size 101, with 
+ 10 generators>>
+gap> x = x * x;
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsXTranslationsSemigroupElement">
+  <ManSection>
+    <Filt Name = "IsTranslationsSemigroupElement" Type="Category">
+    <Filt Name = "IsLeftTranslationsSemigroupElement" Type="Category">
+    <Filt Name = "IsRightTranslationsSemigroupElement" Type="Category">
+    <Description>
+      All, and only, left [right] translations belong to 
+      <C>IsLeftTranslationsSemigroupElement</C> 
+      [<C>IsRightTranslationsSemigroupElement</C>]. 
+      These are both subcategories of <C>IsTranslationsSemigroupElement</C>,
+      which itself is a subcategory of <Ref Filt="IsAssociativeElement"
+      Bookname="ref">.
+      <Example> <![CDATA[
+gap> S := RectangularBand(3,4);;
+gap> l := Representative(TranslationalElements(LeftTranslations(S)));
+<left translation on <simple transformation semigroup of size 12, degree 8 
+ with 4 generators>>
+gap> IsTranslationsSemigroupElement(l);
+true
+gap> IsLeftTranslationsSemigroupElement(l);
+true
+gap> IsRightTranslationsSemigroupElement(l);
+false
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsTranslationalHullElement">
+  <ManSection>
+    <Filt Name="IsTranslationalHullElement" Type="Category">
+    <Description>
+      All, and only, translational hull elements belong to 
+      <C>IsTranslationalHullElement</C>. This is a subcategory of 
+      <Ref Filt="IsAssociativeElement" Bookname="ref">.
+      <Example> <![CDATA[
+gap> G := SmallGroup(4,2);;
+gap> H := ShallowCopy(AsList(G));;
+gap> Add(H, 0);;
+gap> mat:=List([1..5], x-> List([1..5], y-> Random(H)));;
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> L := LeftTranslations(S);;
+gap> R := RightTranslations(S);;
+gap> l := Representative(TranslationalElements(L));;
+gap> r := Representative(TranslationalElements(R));;
+gap> H := TranslationalHull(S);;
+gap> x := TranslationalHullElement(H, l, r);;
+gap> IsTranslationalHullElement(x);
+true
+gap> IsTranslationsSemigroupElement(x);
+false
+
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsXTranslationsSemigroup">
+  <ManSection>
+    <Filt Name="IsTranslationsSemigroup" Type="Synonym">
+    <Filt Name="IsLeftTranslationsSemigroup" Type="Synonym">
+    <Filt Name="IsRightTranslationsSemigroup" Type="Synonym">
+    <Description>
+      <C>IsXTranslationsSemigroup(</C> is a synonym for 
+      <C>IsXTranslationsSemigroupElementCollection</C> and
+      <C>IsSemigroup<C>.
+      <Example><![CDATA[
+gap> S := RectangularBand(3,4);;
+gap> L := LeftTranslations(S);;
+gap> R := RightTranslations(S);;
+gap> IsLeftTranslationsSemigroup(L);
+true
+gap> IsTranslationsSemigroup(L);
+true
+gap> IsRightTranslationsSemigroup(L);
+false
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+  
+<#GAPDoc Label="IsTranslationalHull">
+  <ManSection>
+    <Filt Name="IsTranslationalHull" Type="synonym">
+    <Description>
+      <C>IsTranslationalHull</C> is a synonym for <C>IsSemigroup</C> and
+      <Ref Filt="IsTranslationalHullElementCollection">
+      <Example><![CDATA[
+gap> S := RectangularBand(3,3);;
+gap> H := TranslationalHull(S);;
+gap> IsTranslationalHull(H);
+true
+gap> IsTranslationalHull(S);
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="UnderlyingSemigroup">
+  <ManSection>
+    <Attr Name="UnderlyingSemigroup" Arg="S">
+    <Description>
+      <C>UnderlyingSemigroup(<A>S</A>)</C>, for <A>S<A> a semigroup of left or 
+      right translations or a translational hull, returns the semigroup which 
+      elements of <A>S</A> act on.
+      <Example><![CDATA[
+gap> H := TranslationalHull(S);;
+gap> UnderlyingSemigroup(H) = S;
+true
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="XTranslationsSemigroupOfFamily">
+  <ManSection>
+    <Attr Name="LeftTranslationsSemigroupOfFamily" Arg="fam">
+    <Attr Name="RightTranslationsSemigroupOfFamily" Arg="fam">
+    <Returns>The XTranslationsSemigroup used to create objects in the given
+    family </Returns>
+    <Description>
+      When <A>fam</A> is a family of left or right translations,
+      <C>XTranslationsSemigroupOfFamily<C>(<A>fam</A>) returns the left or right
+      translations semigroup which contains the objects of family <A>fam</A>
+      <Example><![CDATA[
+gap> S := RectangularBand(3,3);;
+gap> L := LeftTranslations(S);;
+gap> l := Representative(L);;
+gap> LeftTranslationsSemigroupOfFamily(FamilyObj(l)) = L;
+true
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
  
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
+<#GAPDoc Label="TranslationalHullOfFamily">
+  <ManSection>
+    <Attr Name="TranslationalHullOfFamily" Arg="fam">
+    <Returns>The translational hull used to create objects in the given
+    family </Returns>
+    <Description>
+      When <A>fam</A> is a family of translational hull elements,
+      <C>TranslationalHullOfFamily<C>(<A>fam</A>) returns the translational hull
+      which contains the objects of family <A>fam</A>
+      <Example><![CDATA[
+gap> S := RectangularBand(3,3);;
+gap> H := LeftTranslations(S);;
+gap> h := Representative(H);;
+gap> TranslationalHullOfFamily(FamilyObj(h)) = H;
+true
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc> 
+
+<#GAPDoc Label="TypeXTranslationsSemigroupElements">
+  <ManSection>
+    <Attr Name="TypeLeftTranslationsSemigroupElements" Arg="L">
+    <Attr Name="TypeRightTranslationsSemigroupElements" Arg="R">
+    <Returns>The type of the elements of the given
+    XTranslationsSemigroup</Returns>
+    <Description>
+      For a semigroup of X translations <A>X</A>, 
+      <C>TypeXTranslationsSemigroup</C>(<A>X</A>) returns the type of the
+      elements of that semigroup.
+      <Example><![CDATA[
+gap> S := RectangularBand(3,3);;
+gap> L := LeftTranslations(S);;
+gap> l := Representative(L);;
+gap> TypeLeftTranslationsSemigroupElements(L) = TypeObj(l);
+true
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc> 
+
+<#GAPDoc Label="TranslationalElements">
+  <ManSection>
+    <Attr Name="TranslationalElements" Arg="S">
+    <Returns>The elements of <A>S</A></Returns>
+    <Description>
+      For <A>S</A> the whole semigroup of left or right translations of a
+      semigroup, or the translational hull of a semigroup, 
+      <C>TranslationalElements</C>(<A>S</A>) returns the calculated semigroup
+      of elements of <A>S</A>, so that <A>S</A> can be manipulated as more than
+      an abstract object.
+      <Example><![CDATA[
+gap> S := RectangularBand(3,3);;
+gap> H := TranslationalHull(S);;
+gap> TranslationalElements(H);
+Semigroup( ... )
+]]>   </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+    
  
  
  

--- a/doc/translat.xml
+++ b/doc/translat.xml
@@ -40,7 +40,7 @@ gap> GeneratorsOfSemigroup(L);
   <ManSection>
     <Func Name="LeftTranslation" Arg="L, map"/>
     <Func Name="RightTranslation" Arg="R, map"/>
-    <Returns>An X translation.</Returns>
+    <Returns>A left or right translation.</Returns>
     <Description>
       For the semigroup of left of right translations and a Mapping on the 
       underlying semigroup, LeftTranslation and RightTranslation return 

--- a/doc/z-chap15.xml
+++ b/doc/z-chap15.xml
@@ -238,8 +238,10 @@
     All methods in this section are only applicable to finite semigroups.
     <#Include Label = "XTranslations">
     <#Include Label = "XTranslation">
+    <#Include Label = "InnerXTranslations">
     <#Include Label = "TranslationalHull">
     <#Include Label = "TranslationalHullElement">
+    <#Include Label = "InnerTranslationalHull">
     <#Include Label = "IsXTranslationsSemigroupElement">
     <#Include Label = "IsTranslationalHullElement">
     <#Include Label = "IsXTranslationsSemigroup">

--- a/doc/z-chap15.xml
+++ b/doc/z-chap15.xml
@@ -231,4 +231,27 @@
   <!--**********************************************************************-->
   <!--**********************************************************************-->
 
+  <Section>
+    <Heading>
+      Translations and translational hulls
+    </Heading>
+    All methods in this section are only applicable to finite semigroups.
+    <#Include Label = "XTranslations">
+    <#Include Label = "XTranslation">
+    <#Include Label = "TranslationalHull">
+    <#Include Label = "TranslationalHullElement">
+    <#Include Label = "IsXTranslationsSemigroupElement">
+    <#Include Label = "IsTranslationalHullElement">
+    <#Include Label = "IsXTranslationsSemigroup">
+    <#Include Label = "IsTranslationalHull">
+    <#Include Label = "UnderlyingSemigroup">
+    <#Include Label = "XTranslationsSemigroupOfFamily">
+    <#Include Label = "TranslationalHullOfFamily">
+    <#Include Label = "TypeXTranslationsSemigroupElements">
+    
+  </Section>
+
+  <!--**********************************************************************-->
+  <!--**********************************************************************-->
+
 </Chapter>

--- a/doc/z-chap15.xml
+++ b/doc/z-chap15.xml
@@ -247,7 +247,6 @@
     <#Include Label = "UnderlyingSemigroup">
     <#Include Label = "XTranslationsSemigroupOfFamily">
     <#Include Label = "TranslationalHullOfFamily">
-    <#Include Label = "TypeXTranslationsSemigroupElements">
     
   </Section>
 

--- a/gap/attributes/rms-translat.gi
+++ b/gap/attributes/rms-translat.gi
@@ -20,6 +20,32 @@
 ##
 #############################################################################
 
+# For RZMS, don't calculate AsList when LeftTranslations is called
+# Just get generators
+InstallMethod(LeftTranslations, "for a RZMS semigroup",
+[IsSemigroup and IsFinite and IsZeroSimpleSemigroup],
+function(S) 
+  local L;
+  
+  L := LeftTranslationsSemigroup(S);
+  GeneratorsOfSemigroup(L);
+  
+  return L;
+end);
+
+# For RZMS, don't calculate AsList when RightTranslations is called
+# Just get generators
+InstallMethod(RightTranslations, "for a RZMS semigroup",
+[IsSemigroup and IsFinite and IsZeroSimpleSemigroup],
+function(S) 
+  local R;
+  
+  R := RightTranslationsSemigroup(S);
+  GeneratorsOfSemigroup(R);
+  
+  return R;
+end);
+
 # The generators are generators of partial transformation monoid to act on the
 # index sets, together with functions to the generators of the group.
 InstallMethod(GeneratorsOfSemigroup, "for the semigroup of left/right translations of a finite 0-simple semigroup",

--- a/gap/attributes/rms-translat.gi
+++ b/gap/attributes/rms-translat.gi
@@ -351,7 +351,6 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponen
   cc := DigraphConnectedComponents(digraph);
   
   #only deal with enough elements to hit each relation
-  #TODO: check safe to assume components ordered?
   relpoints := [];
   for i in cc.comps do
     if Length(i) > 1 then 

--- a/gap/attributes/rms-translat.gi
+++ b/gap/attributes/rms-translat.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  rms-translat.gi
-#Y  Copyright (C) 2016                                            Finn Smith
+#Y  Copyright (C) 2016-17                                         Finn Smith
 ##
 ##  Licensing information can be found in the README file of this package.
 ##

--- a/gap/attributes/rms-translat.gi
+++ b/gap/attributes/rms-translat.gi
@@ -436,24 +436,26 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponen
   foundfuncs := [];
   iterator := IteratorOfCartesianProduct(List(relpoints, i -> [1..gpsize]));
   
-  #TODO: prove you only need to check the relations once
-  #for all choices of x{relpoints}
-  #i.e., the only possible problem is an inconsistency 
-  #which if it exists will always occur
-  #True for commutative groups
-  
+  # If S is a commutative group and fails on one choice of relpointvals,
+  # it will fail on all of them.
   if IsDoneIterator(iterator) then
     return [];
   else
     funcs := funcsfromrelpointvals(NextIterator(iterator));
     if not relssatisfied(funcs) then
-      return [0, Set(failedcomps), t1, t2];
+      if not IsCommutative(S) then
+        return [0, Set(failedcomps), t1, t2];
+      fi;
+    else
+      Add(foundfuncs, funcs);
     fi;
-    Add(foundfuncs, funcs);
   fi;
   
   while not IsDoneIterator(iterator) do
-    Add(foundfuncs, funcsfromrelpointvals(NextIterator(iterator)));
+    funcs := funcsfromrelpointvals(NextIterator(iterator));
+    if relssatisfied(funcs) then
+      Add(foundfuncs, funcs);
+    fi;
   od;
   
   return foundfuncs;
@@ -478,8 +480,8 @@ SEMIGROUPS.TranslationalHullOfZeroSimpleElements := function(H)
   nrrows := Length(Matrix(reesmatsemi));
   nrcols := Length(Matrix(reesmatsemi)[1]);
   zero := MultiplicativeZero(reesmatsemi);
-  L := LeftTranslations(S);
-  R := RightTranslations(S);
+  L := LeftTranslationsSemigroup(S);
+  R := RightTranslationsSemigroup(S);
   tt := SEMIGROUPS.FindTranslationTransformations(S);
   failedcomponents := [];
   linkedpairs := [];
@@ -556,6 +558,5 @@ SEMIGROUPS.TranslationalHullOfZeroSimpleElements := function(H)
     od;
   od;
   
-  return Semigroup(Set(linkedpairs));
+  return Set(linkedpairs);
 end;
-

--- a/gap/attributes/rms-translat.gi
+++ b/gap/attributes/rms-translat.gi
@@ -1,0 +1,541 @@
+InstallMethod(TranslationalElements, "for the semigroup of left/right translations of a finite 0-simple semigroup",
+[IsTranslationsSemigroup and IsWholeFamily], 2,
+function(T)
+  if not (IsFinite(UnderlyingSemigroup(T)) and 
+         IsZeroSimpleSemigroup(UnderlyingSemigroup(T))) then
+     TryNextMethod();
+  fi;
+  return Semigroup(GeneratorsOfSemigroup(T));
+end);
+
+InstallMethod(GeneratorsOfSemigroup, "for the semigroup of left/right translations of a finite 0-simple semigroup",
+[IsTranslationsSemigroup and IsWholeFamily],
+function(T)
+  local S, L, n, iso, inv, reesMatSemi, semiList, gens, t, f, groupGens,
+        e, a, fa, G, zero;
+        
+  S := UnderlyingSemigroup(T);
+  if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
+    TryNextMethod();
+  fi;
+  
+  semiList := AsList(S);
+  iso := IsomorphismReesZeroMatrixSemigroup(S);
+  inv := InverseGeneralMapping(iso);
+  reesMatSemi := Range(iso);
+  zero := MultiplicativeZero(reesMatSemi);
+  L := IsLeftTranslationsSemigroup(T);
+  if L then
+    n := Length(Rows(reesMatSemi));
+  else
+    n := Length(Columns(reesMatSemi));
+  fi;
+  
+  gens := [];
+  G := UnderlyingSemigroup(reesMatSemi);
+  groupGens := GeneratorsOfGroup(G);
+  
+  for t in GeneratorsOfMonoid(PartialTransformationMonoid(n)) do
+    if L then
+      f := function(x)
+        if (x = zero or x[1]^t = n+1) then 
+          return zero;
+        fi;
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
+            x[2], x[3]);
+      end;
+      Add(gens, LeftTranslation(T, CompositionMapping(
+        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    else
+      f := function(x)
+        if (x = zero or x[3]^t = n+1) then 
+          return zero;
+        fi;
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+          x[2], x[3]^t); 
+      end;
+      Add(gens, RightTranslation(T, CompositionMapping(
+        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    fi;
+  od;
+  
+  for a in groupGens do
+    fa := function(x)
+      if x = 1 then
+        return a;
+      fi; 
+      return MultiplicativeNeutralElement(G);
+    end;
+    if L then
+      f := function(x)
+        if x = zero then 
+          return zero;
+        fi;
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+            fa(x[1])*x[2], x[3]);
+      end;
+      Add(gens, LeftTranslation(T, CompositionMapping(
+        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    else
+      f := function(x)
+        if x = zero then 
+          return zero;
+        fi;
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+          x[2]*fa(x[3]), x[3]); 
+      end;
+      Add(gens, RightTranslation(T, CompositionMapping(
+        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    fi;
+  od;
+  return gens;
+end);
+
+InstallMethod(Size, "for the semigroup of left or right translations of a completely 0-simple semigroup",
+[IsTranslationsSemigroup and IsWholeFamily], 1,
+function(T)
+  local S, G, reesMatSemi, n;
+  S := UnderlyingSemigroup(T);
+  if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
+    TryNextMethod();
+  fi;
+  reesMatSemi := Range(IsomorphismReesZeroMatrixSemigroup(S));
+  G := UnderlyingSemigroup(reesMatSemi);
+  if IsLeftTranslationsSemigroup(T) then
+    n := Length(Rows(reesMatSemi));
+  else
+    n := Length(Columns(reesMatSemi));
+  fi;
+  return (n * Size(G) + 1)^n;
+end);
+
+#Finds the transformations on the indices of a finite 0-simple semigroup
+#which are candidates for translations, when combined with a function from
+#the index sets to the group.
+#TODO: swap rows/columns if more convenient.
+SEMIGROUPS.FindTranslationTransformations := function(S)
+  local iso, reesMatSemi, mat, simpleRows, simpleColumns, nrRows, nrCols,
+    transList, partColumns, partColumn, pc, linkedTransList, col, cols, 
+    possibleCols, t, q, w, c, x, k, v, f, i, j,
+    isPartialSuccess, extend, reject, bt;
+  iso := IsomorphismReesZeroMatrixSemigroup(S);
+  reesMatSemi := Range(iso);
+  mat := Matrix(reesMatSemi);
+  simpleRows := List(mat, ShallowCopy);
+  nrRows := Length(simpleRows);
+  nrCols := Length(simpleRows[1]);
+  transList := [];
+  for i in [1..Length(simpleRows)] do
+    for j in [1..Length(simpleRows[i])] do
+      if simpleRows[i][j] <> 0 then
+        simpleRows[i][j] := 1;
+      fi;
+    od;
+  od;
+  #TODO: just use transpose
+  simpleColumns := [];
+  for i in [1..Length(simpleRows[1])] do
+    c := [];
+    for j in [1..Length(simpleRows)] do
+      c[j] := simpleRows[j][i];
+    od;
+    Add(simpleColumns, c);
+  od;
+  
+  #TODO: keep track of the partial columns in the extend/reject functions
+  isPartialSuccess := function(x)
+    partColumns := [];
+    for i in [1..Length(simpleRows[1])] do
+      partColumn := [];
+      for j in [1..Length(x)] do
+        if x[j] = nrRows + 1 then
+          #treat rows not in the domain like a row of zeros
+          partColumn[j] := 0;
+        else
+          partColumn[j] := simpleRows[x[j]][i];
+        fi;
+      od;
+      Add(partColumns, partColumn);
+    od;
+    
+    for pc in partColumns do
+      #only check the columns which contain a 1
+      #all-zero column can be made by column not in domain of transformation
+      #no ones in one partial matrix but not in the other...
+      if 1 in pc and ForAll(simpleColumns, c -> 1 in c{[1..Length(pc)]} + pc) then
+        return false;
+      fi;
+    od;
+    return true;
+  end;
+  
+  extend := function(w)
+    Add(w, 1);
+    return w;
+  end;
+  
+  reject := function(q)
+    q := ShallowCopy(q);
+    k := Length(q);
+    if q[k] <= nrRows then
+      q[k] := q[k] + 1;
+    elif k > 1 then
+      q := reject(q{[1..k-1]});
+    else return 0;
+    fi;
+    return q;
+  end;
+  
+  bt := function(x)
+    if x = 0 then
+      return 0;
+    fi;
+    if not isPartialSuccess(x) then
+      x := reject(x);  
+    elif Length(x) = nrRows then
+      return x;
+    else 
+      x := extend(x);
+    fi;
+    return bt(x);
+  end;
+  
+  v := 1;
+  transList := [bt([1])];
+  while transList[v] <> 0 do
+    v := v + 1;
+    transList[v] := bt(reject(transList[v-1]));
+  od;
+  
+  linkedTransList := [];
+  #last element of transList will be 0, ignore
+  for k in [1..Length(transList) - 1] do
+    t := transList[k];
+    cols := [];
+    for i in [1..Length(simpleRows[1])] do
+      col := [];
+      for j in [1..nrRows] do
+        if t[j] = nrRows + 1 then
+          col[j] := 0;
+        else 
+          col[j] := simpleRows[t[j]][i];
+        fi;
+      od;
+      Add(cols, col);
+    od;
+    possibleCols := [];
+    for i in [1..nrCols] do
+      possibleCols[i] := [];
+      for j in [1..nrCols] do  
+        if not 1 in cols[i] + simpleColumns[j] then
+          Add(possibleCols[i], j);
+        fi;
+        if not 1 in cols[i] then 
+          Add(possibleCols[i], nrCols+1);
+        fi;
+      od;
+    od;
+    linkedTransList[k] := IteratorOfCartesianProduct(possibleCols);
+  od;
+  
+  return [transList{[1..Length(transList) - 1]}, linkedTransList];
+end;
+
+#TODO: sort out where the failedComponents is going
+#For a pair of transformations on the indices of a completely 0-simple semigroup
+#determine the functions to the group associated with the RMS representation
+#which will form translations when combined with the transformations
+SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponents)
+  local reesmatsemi, mat, gplist, gpsize, nrrows, nrcols, invmat,
+        rowtransformedmat, zerorow, zerocol, pos, satisfied,
+        rels, edges, rowrels, relpoints, rel, i, j, k, l, x, y, r, n, q, c,
+        funcs, digraph, cc, comp, iterator, foundfuncs, failedcomps, vals,
+        failedtocomplete, relpointvals,
+        relssatisfied, funcsfromrelpointvals, fillin;
+  reesmatsemi := Range(IsomorphismReesZeroMatrixSemigroup(S));
+  mat := Matrix(reesmatsemi);
+  gplist := AsList(UnderlyingSemigroup(reesmatsemi));
+  gpsize := Size(gplist);
+  nrrows := Length(mat);
+  nrcols := Length(mat[1]);
+  invmat := List(mat, ShallowCopy);
+  for i in [1..nrrows] do
+    for j in [1..nrcols] do
+      invmat[i][j] := Inverse(invmat[i][j]);
+    od;
+  od; 
+  rowtransformedmat := [];
+  zerorow := [];
+  zerocol := [];
+  for i in [1..nrcols] do
+    zerorow[i] := 0;
+  od;
+  for i in [1..nrrows] do
+    zerocol[i] := 0;
+  od;
+  for i in [1..nrrows] do
+    if t1[i] <> nrrows + 1 then 
+      rowtransformedmat[i] := mat[t1[i]];
+    else
+      rowtransformedmat[i] := zerorow;
+    fi;
+  od;
+
+  #for ease of checking the constraints, set up lists of linked indices
+  rels := [];
+  for i in [1..nrrows] do
+    for j in [1..nrcols] do
+      if rowtransformedmat[i][j] <> 0 then
+        Add(rels, [i,j]);
+      fi;
+    od;
+  od;
+  rowrels := [];
+  for i in [1..nrrows] do
+    rowrels[i] := [];
+    for j in [1..nrrows] do
+      for k in [1..nrcols] do
+        if [i,k] in rels and [j,k] in rels then
+          rowrels[i][j] := k;
+          break;
+        fi;
+      od;
+    od;
+  od;
+  
+  #get connected components
+  edges := List(rels, r -> [r[1], r[2] + nrrows]);
+  digraph := DigraphByEdges(edges, nrrows + nrcols);
+  cc := DigraphConnectedComponents(digraph);
+  
+  #only deal with enough elements to hit each relation
+  #TODO: check safe to assume components ordered?
+  relpoints := [];
+  for i in cc.comps do
+    if Length(i) > 1 then 
+      Add(relpoints, i[1]);
+    fi;
+  od;
+  
+  #check whether these connected components have already been found to fail
+  for i in [1..Length(failedcomponents)] do
+    for j in [1..Length(failedcomponents[i][1])] do
+      c := failedcomponents[i][1][j];
+      if ForAny(cc.comps, comp -> IsSubset(comp, c)) then
+        vals := [[],[]];
+        for k in c do
+          if k <= nrrows then
+            Add(vals[1], k);
+          else
+            Add(vals[2], k - nrrows);
+          fi;
+        od;
+        if t1{vals[1]} = failedcomponents[i][2]{vals[1]} 
+          and t2{vals[2]} = failedcomponents[i][3]{vals[2]} then
+          return [];
+        fi;
+      fi;
+    od;
+  od;
+  
+  #given a choice of relpoints, fill in everything else possible
+  fillin := function(funcs)
+    x := ShallowCopy(funcs[1]);
+    y := ShallowCopy(funcs[2]);
+    for r in relpoints do
+      comp := cc.comps[cc.id[r]];
+      failedtocomplete := false;
+      for n in [2..Length(comp)] do
+        j := comp[n];
+        if j <= nrrows then
+          for q in comp do
+            if IsBound(rowrels[q][j]) and not IsBound(x[j]) then
+              k := rowrels[q][j];
+              x[j] := mat[j][t2[k]] * invmat[q][t2[k]] * x[q] *
+                      rowtransformedmat[q][k] * invmat[t1[j]][k];
+              break;
+            fi;
+          od;
+        if not IsBound(x[j]) then
+          failedtocomplete := true;
+        fi;
+        else
+          j := j - nrrows;
+          if not IsBound(y[j]) then
+            for rel in rels do
+              if rel[1] in comp and rel[2] = j then
+                i := rel[1];
+                y[j] := invmat[i][t2[j]] * x[i] * rowtransformedmat[i][j];
+                break;
+              fi;
+            od;
+          fi;
+        fi;
+      od;
+      if failedtocomplete then
+        funcs := fillin([x,y]);
+        x := funcs[1];
+        y := funcs[2];
+      fi;
+    od;
+    return [x,y];
+  end;
+  
+  relssatisfied := function(funcs)
+    failedcomps := [];
+    satisfied := true;
+    x := funcs[1];
+    y := funcs[2];
+    for rel in rels do
+      i := rel[1];
+      j := rel[2];
+      if IsBound(x[i]) and IsBound(y[j]) and not 
+          x[i] * rowtransformedmat[i][j] = mat[i][t2[j]] * y[j] then
+          Add(failedcomps, cc.comps[cc.id[i]]);
+          satisfied := false;
+      fi;
+    od;
+    return satisfied;
+  end;
+  
+  funcsfromrelpointvals := function(relpointvals)
+    x := [1..nrrows];
+    y := [1..nrcols];
+    
+    for i in [1..nrrows] do
+      Unbind(x[i]);
+    od;
+    for i in [1..nrcols] do
+      Unbind(y[i]);
+    od;
+    for i in [1..Length(relpoints)] do
+      x[relpoints[i]] := gplist[relpointvals[i]];
+    od;
+    return fillin([x,y]);
+  end;
+  
+  foundfuncs := [];
+  iterator := IteratorOfCartesianProduct(List(relpoints, i -> [1..gpsize]));
+  
+  #TODO: prove you only need to check the relations once
+  #for all choices of x{relpoints}
+  #i.e., the only possible problem is an inconsistency 
+  #which if it exists will always occur
+  
+  if IsDoneIterator(iterator) then
+    return [];
+  else
+    funcs := funcsfromrelpointvals(NextIterator(iterator));
+    if not relssatisfied(funcs) then
+      return [0, Set(failedcomps), t1, t2];
+    fi;
+    Add(foundfuncs, funcs);
+  fi;
+  
+  while not IsDoneIterator(iterator) do
+    Add(foundfuncs, funcsfromrelpointvals(NextIterator(iterator)));
+  od;
+  
+  return foundfuncs;
+end;
+
+InstallMethod(TranslationalElements, "for the translational hull of a finite 0-simple semigroup",
+[IsTranslationalHull and IsWholeFamily], 1,
+function(H)
+  local S, tt, failedcomponents, iterator, transfuncs, unboundpositions, gplist,
+        L, R, linkedpairs, i, j, c, linkedpairfromfuncs, iso, inv, nrrows,
+        nrcols, reesmatsemi, zero, fl, fr, l, r, t1, t2, funcs, fx, fy,
+        partialfunciterator, funcvals;
+  
+  S := UnderlyingSemigroup(H);
+  if not IsFinite(S) and IsZeroSimpleSemigroup(S) then
+    TryNextMethod();
+  fi;
+  iso := IsomorphismReesZeroMatrixSemigroup(S);
+  inv := InverseGeneralMapping(iso);
+  reesmatsemi := Range(iso);
+  gplist := AsList(UnderlyingSemigroup(reesmatsemi));
+  nrrows := Length(Matrix(reesmatsemi));
+  nrcols := Length(Matrix(reesmatsemi)[1]);
+  zero := MultiplicativeZero(reesmatsemi);
+  L := SEMIGROUPS.LeftTranslationsSemigroup(S);
+  R := SEMIGROUPS.RightTranslationsSemigroup(S);
+  tt := SEMIGROUPS.FindTranslationTransformations(S);
+  failedcomponents := [];
+  linkedpairs := [];
+  
+  linkedpairfromfuncs := function(t1, t2, fx, fy)
+    fl := function(x)
+      if x = zero then
+        return zero;
+      fi;
+      if t2[x[1]] <> nrcols + 1 then
+        return RMSElement(reesmatsemi, t2[x[1]], fy[x[1]] * x[2], x[3]);
+      else
+        return zero;
+      fi;
+    end;
+    
+    fr := function(x)
+      if x = zero then
+        return zero;
+      fi;
+      if t1[x[3]] <> nrrows + 1 then
+        return RMSElement(reesmatsemi, x[1], x[2] * fx[x[3]], t1[x[3]]);
+      else
+        return zero;
+      fi;
+    end;
+    
+    l := LeftTranslation(L, CompositionMapping(inv, MappingByFunction(
+      reesmatsemi, reesmatsemi, fl), iso));
+    
+    r := RightTranslation(R, CompositionMapping(inv, MappingByFunction(
+      reesmatsemi, reesmatsemi, fr), iso));
+    
+    return TranslationalHullElement(H, l, r);
+  end;
+  
+  
+  for i in [1..Length(tt[1])] do
+    t1 := tt[1][i];
+    iterator := tt[2][i];
+    while not IsDoneIterator(iterator) do
+      t2 := NextIterator(iterator);
+      transfuncs := SEMIGROUPS.FindTranslationFunctionsToGroup(S, t1, t2, 
+                                                              failedcomponents);
+      if not IsEmpty(transfuncs) then
+        if not transfuncs[1] = 0 then
+          for funcs in transfuncs do
+            fx := funcs[1];
+            fy := funcs[2];
+            unboundpositions := [];
+            for j in [1..nrcols] do
+              if not IsBound(fy[j]) then 
+                Add(unboundpositions, j);
+              fi;
+            od;
+            if Length(unboundpositions) > 0 then
+              c := List([1..Length(unboundpositions)], i -> [1..Length(gplist)]);
+              partialfunciterator := IteratorOfCartesianProduct(c);
+              while not IsDoneIterator(partialfunciterator) do
+                funcvals := NextIterator(partialfunciterator);
+                for j in [1..Length(unboundpositions)] do
+                  fy[unboundpositions[j]] := gplist[funcvals[j]];
+                od;
+                Add(linkedpairs, linkedpairfromfuncs(t1, t2, fx, fy));
+              od;
+            else
+              Add(linkedpairs, linkedpairfromfuncs(t1, t2, fx, fy));
+            fi;
+          od;
+        else
+          Add(failedcomponents, transfuncs{[2,3,4]}); 
+        fi;
+      fi;
+    od;
+  od;
+  
+  return Semigroup(Set(linkedpairs));
+end);
+

--- a/gap/attributes/rms-translat.gi
+++ b/gap/attributes/rms-translat.gi
@@ -448,7 +448,7 @@ function(H)
         partialfunciterator, funcvals;
   
   S := UnderlyingSemigroup(H);
-  if not IsFinite(S) and IsZeroSimpleSemigroup(S) then
+  if not (IsFinite(S) and IsZeroSimpleSemigroup(S)) then
     TryNextMethod();
   fi;
   iso := IsomorphismReesZeroMatrixSemigroup(S);

--- a/gap/attributes/rms-translat.gi
+++ b/gap/attributes/rms-translat.gi
@@ -488,7 +488,7 @@ end;
 
 # Combine the previous methods to form the translational hull
 # Performance suffers greatly as the size of the group increases.
-SEMIGROUPS.TranslationalHullOfZeroSimpleElements := function(H)
+SEMIGROUPS.TranslationalHullElementsOfZeroSimple := function(H)
   local S, tt, failedcomponents, iterator, transfuncs, unboundpositions, gplist,
         L, R, linkedpairs, i, j, c, linkedpairfromfuncs, iso, inv, nrrows,
         nrcols, reesmatsemi, zero, fl, fr, l, r, t1, t2, funcs, fx, fy,

--- a/gap/attributes/rms-translat.gi
+++ b/gap/attributes/rms-translat.gi
@@ -1,13 +1,27 @@
-InstallMethod(TranslationalElements, "for the semigroup of left/right translations of a finite 0-simple semigroup",
-[IsTranslationsSemigroup and IsWholeFamily], 2,
-function(T)
-  if not (IsFinite(UnderlyingSemigroup(T)) and 
-         IsZeroSimpleSemigroup(UnderlyingSemigroup(T))) then
-     TryNextMethod();
-  fi;
-  return Semigroup(GeneratorsOfSemigroup(T));
-end);
+#############################################################################
+##
+#W  rms-translat.gi
+#Y  Copyright (C) 2016                                            Finn Smith
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
 
+#############################################################################
+## This file contains special methods for translations semigroups and 
+## translational hulls of completely 0-simple seimgroups.
+## 
+## These methods are based on the constructions given in 
+## Petrich, M. (1968) 
+## ‘The translational hull of a completely 0-simple semigroup’,
+## Glasgow Mathematical Journal, 9(01), p. 1. 
+## doi: 10.1017/s0017089500000239
+##
+#############################################################################
+
+# The generators are generators of partial transformation monoid to act on the
+# index sets, together with functions to the generators of the group.
 InstallMethod(GeneratorsOfSemigroup, "for the semigroup of left/right translations of a finite 0-simple semigroup",
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
@@ -109,10 +123,10 @@ function(T)
   return (n * Size(G) + 1)^n;
 end);
 
-#Finds the transformations on the indices of a finite 0-simple semigroup
-#which are candidates for translations, when combined with a function from
-#the index sets to the group.
-#TODO: swap rows/columns if more convenient.
+# Finds the transformations on the indices of a finite 0-simple semigroup
+# which are candidates for translations, when combined with a function from
+# the index sets to the group.
+# TODO: swap rows/columns if more convenient.
 SEMIGROUPS.FindTranslationTransformations := function(S)
   local iso, reesMatSemi, mat, simpleRows, simpleColumns, nrRows, nrCols,
     transList, partColumns, partColumn, pc, linkedTransList, col, cols, 
@@ -159,9 +173,9 @@ SEMIGROUPS.FindTranslationTransformations := function(S)
     od;
     
     for pc in partColumns do
-      #only check the columns which contain a 1
-      #all-zero column can be made by column not in domain of transformation
-      #no ones in one partial matrix but not in the other...
+      #Only check the columns which contain a 1 since
+      #all-zero column can be made by column not in domain of transformation.
+      #No ones in one partial matrix but not in the other...
       if 1 in pc and ForAll(simpleColumns, c -> 1 in c{[1..Length(pc)]} + pc) then
         return false;
       fi;
@@ -180,7 +194,7 @@ SEMIGROUPS.FindTranslationTransformations := function(S)
     if q[k] <= nrRows then
       q[k] := q[k] + 1;
     elif k > 1 then
-      q := reject(q{[1..k-1]});
+      q := reject(q{[1 .. k - 1]});
     else return 0;
     fi;
     return q;
@@ -208,13 +222,14 @@ SEMIGROUPS.FindTranslationTransformations := function(S)
   od;
   
   linkedTransList := [];
-  #last element of transList will be 0, ignore
-  for k in [1..Length(transList) - 1] do
+  # Given each row transformation, look for matching column transformations.
+  # Last element of transList will be 0, ignore.
+  for k in [1 .. Length(transList) - 1] do
     t := transList[k];
     cols := [];
-    for i in [1..Length(simpleRows[1])] do
+    for i in [1 .. Length(simpleRows[1])] do
       col := [];
-      for j in [1..nrRows] do
+      for j in [1 .. nrRows] do
         if t[j] = nrRows + 1 then
           col[j] := 0;
         else 
@@ -238,13 +253,14 @@ SEMIGROUPS.FindTranslationTransformations := function(S)
     linkedTransList[k] := IteratorOfCartesianProduct(possibleCols);
   od;
   
-  return [transList{[1..Length(transList) - 1]}, linkedTransList];
+  return [transList{[1 .. Length(transList) - 1]}, linkedTransList];
 end;
 
-#TODO: sort out where the failedComponents is going
-#For a pair of transformations on the indices of a completely 0-simple semigroup
-#determine the functions to the group associated with the RMS representation
-#which will form translations when combined with the transformations
+# For a pair of transformations on the indices of a completely 0-simple semigroup
+# determine the functions to the group associated with the RMS representation
+# which will form translations when combined with the transformations.
+# Connected components here means points in the domains which are related
+# through the linked pair condition given by Petrich.
 SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponents)
   local reesmatsemi, mat, gplist, gpsize, nrrows, nrcols, invmat,
         rowtransformedmat, zerorow, zerocol, pos, satisfied,
@@ -317,7 +333,8 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponen
     fi;
   od;
   
-  #check whether these connected components have already been found to fail
+  # Check whether these connected components have already been found to fail
+  # (on the same values).
   for i in [1..Length(failedcomponents)] do
     for j in [1..Length(failedcomponents[i][1])] do
       c := failedcomponents[i][1][j];
@@ -372,6 +389,8 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponen
           fi;
         fi;
       od;
+      # Might need several passes to fill in everything, since the filling in
+      # propagates through the connected components.
       if failedtocomplete then
         funcs := fillin([x,y]);
         x := funcs[1];
@@ -421,6 +440,7 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponen
   #for all choices of x{relpoints}
   #i.e., the only possible problem is an inconsistency 
   #which if it exists will always occur
+  #True for commutative groups
   
   if IsDoneIterator(iterator) then
     return [];
@@ -439,9 +459,9 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponen
   return foundfuncs;
 end;
 
-InstallMethod(TranslationalElements, "for the translational hull of a finite 0-simple semigroup",
-[IsTranslationalHull and IsWholeFamily], 1,
-function(H)
+# Combine the previous methods to form the translational hull
+# Performance suffers greatly as the size of the group increases.
+SEMIGROUPS.TranslationalHullOfZeroSimpleElements := function(H)
   local S, tt, failedcomponents, iterator, transfuncs, unboundpositions, gplist,
         L, R, linkedpairs, i, j, c, linkedpairfromfuncs, iso, inv, nrrows,
         nrcols, reesmatsemi, zero, fl, fr, l, r, t1, t2, funcs, fx, fy,
@@ -458,8 +478,8 @@ function(H)
   nrrows := Length(Matrix(reesmatsemi));
   nrcols := Length(Matrix(reesmatsemi)[1]);
   zero := MultiplicativeZero(reesmatsemi);
-  L := SEMIGROUPS.LeftTranslationsSemigroup(S);
-  R := SEMIGROUPS.RightTranslationsSemigroup(S);
+  L := LeftTranslations(S);
+  R := RightTranslations(S);
   tt := SEMIGROUPS.FindTranslationTransformations(S);
   failedcomponents := [];
   linkedpairs := [];
@@ -537,5 +557,5 @@ function(H)
   od;
   
   return Semigroup(Set(linkedpairs));
-end);
+end;
 

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -1,7 +1,7 @@
 ############################################################################
 ##
 #W  translat.gd
-#Y  Copyright (C) 2015                                  James D. Mitchell
+#Y  Copyright (C) 2015-17                      James D. Mitchell, Finn Smith
 ##
 ##  Licensing information can be found in the README file of this package.
 ##

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -25,7 +25,9 @@ DeclareGlobalFunction("LeftTranslationNC");
 DeclareGlobalFunction("RightTranslation");
 DeclareGlobalFunction("RightTranslationNC");
 DeclareGlobalFunction("TranslationalHullElement");
-
+DeclareGlobalFunction("LeftTranslationsSemigroup");
+DeclareGlobalFunction("RightTranslationsSemigroup");
+DeclareGlobalFunction("TranslationalHullSemigroup");
 
 DeclareSynonym("IsLeftTranslationsSemigroup", IsSemigroup and
                   IsLeftTranslationsSemigroupElementCollection);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -25,6 +25,7 @@ DeclareGlobalFunction("LeftTranslationNC");
 DeclareGlobalFunction("RightTranslation");
 DeclareGlobalFunction("RightTranslationNC");
 DeclareGlobalFunction("TranslationalHullElement");
+DeclareGlobalFunction("TranslationalHullElementNC");
 DeclareGlobalFunction("LeftTranslationsSemigroup");
 DeclareGlobalFunction("RightTranslationsSemigroup");
 DeclareGlobalFunction("TranslationalHullSemigroup");

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -58,5 +58,5 @@ DeclareAttribute("TypeTranslationalHullElements",
 
 DeclareAttribute("LeftTranslations", IsSemigroup);
 DeclareAttribute("RightTranslations", IsSemigroup);
-DeclareAttribute("TranslationalHull", IsSemigroup);
-DeclareAttribute("TranslationalHull2", IsRectangularBand);
+DeclareAttribute("TranslationalHullSemigroup", IsSemigroup);
+DeclareAttribute("TranslationalHull", IsZeroSimpleSemigroup and IsFinite);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -32,16 +32,10 @@ DeclareSynonymAttr("IsTranslationsSemigroup", IsSemigroup and
 	IsTranslationsSemigroupElementCollection);
 DeclareSynonymAttr("IsTranslationalHull", IsSemigroup and 
 	IsTranslationalHullElementCollection);
-
-
-DeclareSynonymAttr("IsWholeTranslationsSemigroup", IsTranslationsSemigroup and
-	IsWholeFamily);
-DeclareSynonymAttr("IsWholeTranslationalHull", IsTranslationalHull and 
-	IsWholeFamily);
 	
 
-DeclareOperation("LeftTranslationsSemigroup", [IsRectangularBand]);
-DeclareOperation("RightTranslationsSemigroup", [IsRectangularBand]);
+DeclareOperation("LeftTranslationsSemigroup", [IsSemigroup]);
+DeclareOperation("RightTranslationsSemigroup", [IsSemigroup]);
 
 
 DeclareAttribute("UnderlyingSemigroup", IsTranslationsSemigroup);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -15,29 +15,26 @@ DeclareCategory( "IsRightTranslationsSemigroupElement",
                 IsTranslationsSemigroupElement);
 DeclareCategory( "IsTranslationalHullElement", IsAssociativeElement);
 
-
 DeclareCategoryCollections( "IsTranslationsSemigroupElement");
 DeclareCategoryCollections( "IsLeftTranslationsSemigroupElement");
 DeclareCategoryCollections( "IsRightTranslationsSemigroupElement");
 DeclareCategoryCollections( "IsTranslationalHullElement" );
 
 DeclareGlobalFunction("LeftTranslation");
+DeclareGlobalFunction("LeftTranslationNC");
 DeclareGlobalFunction("RightTranslation");
+DeclareGlobalFunction("RightTranslationNC");
 DeclareGlobalFunction("TranslationalHullElement");
 
 
-DeclareSynonymAttr("IsLeftTranslationsSemigroup", IsSemigroup and
+DeclareSynonym("IsLeftTranslationsSemigroup", IsSemigroup and
                   IsLeftTranslationsSemigroupElementCollection);
-DeclareSynonymAttr("IsRightTranslationsSemigroup", IsSemigroup and
+DeclareSynonym("IsRightTranslationsSemigroup", IsSemigroup and
                   IsRightTranslationsSemigroupElementCollection);
-DeclareSynonymAttr("IsTranslationsSemigroup", IsSemigroup and
+DeclareSynonym("IsTranslationsSemigroup", IsSemigroup and
                   IsTranslationsSemigroupElementCollection);
-DeclareSynonymAttr("IsTranslationalHull", IsSemigroup and 
+DeclareSynonym("IsTranslationalHull", IsSemigroup and 
                   IsTranslationalHullElementCollection);
-  
-
-DeclareOperation("LeftTranslationsSemigroup", [IsSemigroup]);
-DeclareOperation("RightTranslationsSemigroup", [IsSemigroup]);
 
 DeclareAttribute("UnderlyingSemigroup", IsTranslationsSemigroup);
 DeclareAttribute("UnderlyingSemigroup", IsTranslationalHull);
@@ -55,8 +52,8 @@ DeclareAttribute("TypeTranslationalHullElements",
                  IsTranslationalHull);
 
 
-
 DeclareAttribute("LeftTranslations", IsSemigroup);
 DeclareAttribute("RightTranslations", IsSemigroup);
-DeclareAttribute("TranslationalHullSemigroup", IsSemigroup);
-DeclareAttribute("TranslationalHull", IsZeroSimpleSemigroup and IsFinite);
+DeclareAttribute("TranslationalHull", IsSemigroup and IsFinite);
+DeclareAttribute("TranslationalElements", IsTranslationsSemigroup and IsWholeFamily);
+DeclareAttribute("TranslationalElements", IsTranslationalHull and IsWholeFamily);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -8,17 +8,19 @@
 #############################################################################
 ##
 
-DeclareCategory( "IsTranslationsSemigroupElement", IsAssociativeElement);
-DeclareCategory( "IsLeftTranslationsSemigroupElement",
+DeclareCategory("IsTranslationsSemigroupElement", IsAssociativeElement and
+                  IsMultiplicativeElementWithOne);
+DeclareCategory("IsLeftTranslationsSemigroupElement",
                 IsTranslationsSemigroupElement);
-DeclareCategory( "IsRightTranslationsSemigroupElement",
+DeclareCategory("IsRightTranslationsSemigroupElement",
                 IsTranslationsSemigroupElement);
-DeclareCategory( "IsTranslationalHullElement", IsAssociativeElement);
+DeclareCategory("IsTranslationalHullElement", IsAssociativeElement and
+                  IsMultiplicativeElementWithOne);
 
-DeclareCategoryCollections( "IsTranslationsSemigroupElement");
-DeclareCategoryCollections( "IsLeftTranslationsSemigroupElement");
-DeclareCategoryCollections( "IsRightTranslationsSemigroupElement");
-DeclareCategoryCollections( "IsTranslationalHullElement" );
+DeclareCategoryCollections("IsTranslationsSemigroupElement");
+DeclareCategoryCollections("IsLeftTranslationsSemigroupElement");
+DeclareCategoryCollections("IsRightTranslationsSemigroupElement");
+DeclareCategoryCollections("IsTranslationalHullElement" );
 
 DeclareGlobalFunction("LeftTranslation");
 DeclareGlobalFunction("LeftTranslationNC");
@@ -46,7 +48,6 @@ DeclareAttribute("LeftTranslationsSemigroupOfFamily", IsFamily);
 DeclareAttribute("RightTranslationsSemigroupOfFamily", IsFamily);
 DeclareAttribute("TranslationalHullOfFamily", IsFamily);
 
-
 DeclareAttribute("TypeLeftTranslationsSemigroupElements",
                  IsLeftTranslationsSemigroup);
 DeclareAttribute("TypeRightTranslationsSemigroupElements", 
@@ -55,8 +56,9 @@ DeclareAttribute("TypeTranslationalHullElements",
                  IsTranslationalHull);
 
 
-DeclareAttribute("LeftTranslations", IsSemigroup);
-DeclareAttribute("RightTranslations", IsSemigroup);
+DeclareAttribute("LeftTranslations", IsSemigroup and IsFinite);
+DeclareAttribute("RightTranslations", IsSemigroup and IsFinite);
 DeclareAttribute("TranslationalHull", IsSemigroup and IsFinite);
+DeclareAttribute("InnerTranslationalHull", IsSemigroup and IsFinite);
 DeclareAttribute("TranslationalElements", IsTranslationsSemigroup and IsWholeFamily);
 DeclareAttribute("TranslationalElements", IsTranslationalHull and IsWholeFamily);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -9,8 +9,10 @@
 ##
 
 DeclareCategory( "IsTranslationsSemigroupElement", IsAssociativeElement);
-DeclareCategory( "IsLeftTranslationsSemigroupElement", IsTranslationsSemigroupElement);
-DeclareCategory( "IsRightTranslationsSemigroupElement", IsTranslationsSemigroupElement);
+DeclareCategory( "IsLeftTranslationsSemigroupElement",
+                IsTranslationsSemigroupElement);
+DeclareCategory( "IsRightTranslationsSemigroupElement",
+                IsTranslationsSemigroupElement);
 DeclareCategory( "IsTranslationalHullElement", IsAssociativeElement);
 
 
@@ -25,18 +27,17 @@ DeclareGlobalFunction("TranslationalHullElement");
 
 
 DeclareSynonymAttr("IsLeftTranslationsSemigroup", IsSemigroup and
-	IsLeftTranslationsSemigroupElementCollection);
+                  IsLeftTranslationsSemigroupElementCollection);
 DeclareSynonymAttr("IsRightTranslationsSemigroup", IsSemigroup and
-	IsRightTranslationsSemigroupElementCollection);
+                  IsRightTranslationsSemigroupElementCollection);
 DeclareSynonymAttr("IsTranslationsSemigroup", IsSemigroup and
-	IsTranslationsSemigroupElementCollection);
+                  IsTranslationsSemigroupElementCollection);
 DeclareSynonymAttr("IsTranslationalHull", IsSemigroup and 
-	IsTranslationalHullElementCollection);
-	
+                  IsTranslationalHullElementCollection);
+  
 
 DeclareOperation("LeftTranslationsSemigroup", [IsSemigroup]);
 DeclareOperation("RightTranslationsSemigroup", [IsSemigroup]);
-
 
 DeclareAttribute("UnderlyingSemigroup", IsTranslationsSemigroup);
 DeclareAttribute("UnderlyingSemigroup", IsTranslationalHull);
@@ -47,11 +48,11 @@ DeclareAttribute("TranslationalHullOfFamily", IsFamily);
 
 
 DeclareAttribute("TypeLeftTranslationsSemigroupElements",
-	IsLeftTranslationsSemigroup);
+                 IsLeftTranslationsSemigroup);
 DeclareAttribute("TypeRightTranslationsSemigroupElements", 
-	IsRightTranslationsSemigroup);
+                 IsRightTranslationsSemigroup);
 DeclareAttribute("TypeTranslationalHullElements",
-	IsTranslationalHull);
+                 IsTranslationalHull);
 
 
 

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -57,7 +57,9 @@ DeclareAttribute("TypeTranslationalHullElements",
 
 
 DeclareAttribute("LeftTranslations", IsSemigroup and IsFinite);
+DeclareAttribute("InnerLeftTranslations", IsSemigroup and IsFinite);
 DeclareAttribute("RightTranslations", IsSemigroup and IsFinite);
+DeclareAttribute("InnerRightTranslations", IsSemigroup and IsFinite);
 DeclareAttribute("TranslationalHull", IsSemigroup and IsFinite);
 DeclareAttribute("InnerTranslationalHull", IsSemigroup and IsFinite);
 DeclareAttribute("TranslationalElements", IsTranslationsSemigroup and IsWholeFamily);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -36,15 +36,16 @@ DeclareSynonymAttr("IsTranslationalHull", IsSemigroup and
 
 DeclareSynonymAttr("IsWholeTranslationsSemigroup", IsTranslationsSemigroup and
 	IsWholeFamily);
-	
+DeclareSynonymAttr("IsWholeTranslationalHull", IsTranslationalHull and 
+	IsWholeFamily);
 	
 
 DeclareOperation("LeftTranslationsSemigroup", [IsRectangularBand]);
 DeclareOperation("RightTranslationsSemigroup", [IsRectangularBand]);
 
 
-DeclareAttribute("UnderlyingSemigroup", IsLeftTranslationsSemigroup);
-DeclareAttribute("UnderlyingSemigroup", IsRightTranslationsSemigroup);
+DeclareAttribute("UnderlyingSemigroup", IsTranslationsSemigroup);
+DeclareAttribute("UnderlyingSemigroup", IsTranslationalHull);
 
 DeclareAttribute("LeftTranslationsSemigroupOfFamily", IsFamily);
 DeclareAttribute("RightTranslationsSemigroupOfFamily", IsFamily);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -9,4 +9,6 @@
 ##
 
 DeclareAttribute("LeftTranslations", IsSemigroup);
+DeclareAttribute("LeftTranslationsNew", IsSemigroup);
 DeclareAttribute("RightTranslations", IsSemigroup);
+DeclareAttribute("TranslationalHull", IsRectangularBand);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -8,6 +8,59 @@
 #############################################################################
 ##
 
+DeclareCategory( "IsTranslationsSemigroupElement", IsAssociativeElement);
+DeclareCategory( "IsLeftTranslationsSemigroupElement", IsTranslationsSemigroupElement);
+DeclareCategory( "IsRightTranslationsSemigroupElement", IsTranslationsSemigroupElement);
+DeclareCategory( "IsTranslationalHullElement", IsAssociativeElement);
+
+
+DeclareCategoryCollections( "IsTranslationsSemigroupElement");
+DeclareCategoryCollections( "IsLeftTranslationsSemigroupElement");
+DeclareCategoryCollections( "IsRightTranslationsSemigroupElement");
+DeclareCategoryCollections( "IsTranslationalHullElement" );
+
+DeclareGlobalFunction("LeftTranslation");
+DeclareGlobalFunction("RightTranslation");
+DeclareGlobalFunction("TranslationalHullElement");
+
+
+DeclareSynonymAttr("IsLeftTranslationsSemigroup", IsSemigroup and
+	IsLeftTranslationsSemigroupElementCollection);
+DeclareSynonymAttr("IsRightTranslationsSemigroup", IsSemigroup and
+	IsRightTranslationsSemigroupElementCollection);
+DeclareSynonymAttr("IsTranslationsSemigroup", IsSemigroup and
+	IsTranslationsSemigroupElementCollection);
+DeclareSynonymAttr("IsTranslationalHull", IsSemigroup and 
+	IsTranslationalHullElementCollection);
+
+
+DeclareSynonymAttr("IsWholeTranslationsSemigroup", IsTranslationsSemigroup and
+	IsWholeFamily);
+	
+	
+
+DeclareOperation("LeftTranslationsSemigroup", [IsRectangularBand]);
+DeclareOperation("RightTranslationsSemigroup", [IsRectangularBand]);
+
+
+DeclareAttribute("UnderlyingSemigroup", IsLeftTranslationsSemigroup);
+DeclareAttribute("UnderlyingSemigroup", IsRightTranslationsSemigroup);
+
+DeclareAttribute("LeftTranslationsSemigroupOfFamily", IsFamily);
+DeclareAttribute("RightTranslationsSemigroupOfFamily", IsFamily);
+DeclareAttribute("TranslationalHullOfFamily", IsFamily);
+
+
+DeclareAttribute("TypeLeftTranslationsSemigroupElements",
+	IsLeftTranslationsSemigroup);
+DeclareAttribute("TypeRightTranslationsSemigroupElements", 
+	IsRightTranslationsSemigroup);
+DeclareAttribute("TypeTranslationalHullElements",
+	IsTranslationalHull);
+
+
+
 DeclareAttribute("LeftTranslations", IsSemigroup);
 DeclareAttribute("RightTranslations", IsSemigroup);
-DeclareAttribute("TranslationalHull", IsRectangularBand);
+DeclareAttribute("TranslationalHull", IsSemigroup);
+DeclareAttribute("TranslationalHull2", IsRectangularBand);

--- a/gap/attributes/translat.gd
+++ b/gap/attributes/translat.gd
@@ -9,6 +9,5 @@
 ##
 
 DeclareAttribute("LeftTranslations", IsSemigroup);
-DeclareAttribute("LeftTranslationsNew", IsSemigroup);
 DeclareAttribute("RightTranslations", IsSemigroup);
 DeclareAttribute("TranslationalHull", IsRectangularBand);

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -1210,3 +1210,19 @@ function(h)
   r := RightTranslation(R, MappingByFunction(S, S, x -> x));
   return TranslationalHullElement(H, l, r);
 end);
+
+InstallMethod(OneOp, "for a semigroup of translations",
+[IsTranslationsSemigroupElement],
+function(t)
+  local T, S, l, r;
+  if IsLeftTranslationsSemigroupElement(t) then
+    T := LeftTranslationsSemigroupOfFamily(FamilyObj(t));
+    S := UnderlyingSemigroup(T);
+    return LeftTranslation(T, MappingByFunction(S, S, x -> x));
+  else
+    T := RightTranslationsSemigroupOfFamily(FamilyObj(t));
+    S := UnderlyingSemigroup(T);
+    return RightTranslation(T, MappingByFunction(S, S, x -> x));
+  fi;
+end);
+

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -833,16 +833,6 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2)
       rowtransformedmat[i] := zerorow;
     fi;
   od;
-  #TODO: avoid transposing matrices, it's taking a long time
-  coltransformedmat := [];
-  for i in [1..nrcols] do
-    if t2[i] <> nrcols + 1 then
-      coltransformedmat[i] := TransposedMat(mat)[t2[i]];
-    else
-      coltransformedmat[i] := zerocol;
-    fi;
-  od;
-  coltransformedmat := TransposedMat(coltransformedmat);
 
   #for ease of checking the constraints, set up lists of linked indices
   rels := [];
@@ -895,10 +885,10 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2)
         j := comp[n];
         if j <= nrrows then
           k := rowrels[r][j];
-          x[j] := coltransformedmat[j][k] * invmat[r][t2[k]] * x[r] *
+          x[j] := mat[j][t2[k]] * invmat[r][t2[k]] * x[r] *
                     rowtransformedmat[r][k] * invmat[t1[j]][k];
         else
-          j := j-nrrows;
+          j := j - nrrows;
           for rel in rels do
             if rel[1] in comp and rel[2] = j then
               i := rel[1];
@@ -919,7 +909,7 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2)
       i := rel[1];
       j := rel[2];
       if IsBound(x[i]) and IsBound(y[j]) and not 
-          x[i] * rowtransformedmat[i][j] = coltransformedmat[i][j] * y[j] then
+          x[i] * rowtransformedmat[i][j] = mat[i][t2[j]] * y[j] then
         return false;
       fi;
     od;

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -59,9 +59,9 @@ SEMIGROUPS.TranslationsSemigroupElements := function(T)
     return Semigroup(GeneratorsOfSemigroup(T));
   elif HasGeneratorsOfSemigroup(S) then
     if IsLeftTranslationsSemigroup(T) then
-      return SEMIGROUPS.LeftTranslationsSemigroupWithGeneratorsElements(T);
+      return SEMIGROUPS.LeftTranslationsSemigroupElementsByGenerators(T);
     else 
-      return SEMIGROUPS.RightTranslationsSemigroupWithGeneratorsElements(T); 
+      return SEMIGROUPS.RightTranslationsSemigroupElementsByGenerators(T); 
     fi;
   fi;
   Error("Semigroups: TranslationsSemigroupElements: \n",
@@ -75,15 +75,15 @@ SEMIGROUPS.TranslationalHullElements := function(H)
   if IsRectangularBand(S) then
     return Semigroup(GeneratorsOfSemigroup(H));
   elif IsZeroSimpleSemigroup(S) then
-    return SEMIGROUPS.TranslationalHullOfZeroSimpleElements(H);
+    return SEMIGROUPS.TranslationalHullElementsOfZeroSimple(H);
   else
-    return SEMIGROUPS.TranslationalHullOfArbitraryElements(H);
+    return SEMIGROUPS.TranslationalHullElementsGeneric(H);
   fi;
 end;
     
 # Left translations are the same as edge-label preserving endomorphisms of the
 # right cayley graph
-SEMIGROUPS.LeftTranslationsSemigroupWithGeneratorsElements := function(L)
+SEMIGROUPS.LeftTranslationsSemigroupElementsByGenerators := function(L)
   local S, digraph, n, nrgens, out, colors, gens, i, j;
   
   S := UnderlyingSemigroup(L);
@@ -109,7 +109,7 @@ SEMIGROUPS.LeftTranslationsSemigroupWithGeneratorsElements := function(L)
 end;
 
 # Dual for right translations.
-SEMIGROUPS.RightTranslationsSemigroupWithGeneratorsElements := function(R)
+SEMIGROUPS.RightTranslationsSemigroupElementsByGenerators := function(R)
   local S, digraph, n, nrgens, out, colors, gens, i, j;
 
   S := UnderlyingSemigroup(R);
@@ -142,7 +142,7 @@ end;
 # s*a_i f(a_k) = (s*a_i)g a_k and a_k f(a_i * s) = (a_k)g a_i * s,
 # as well as restriction by the translation condition if Sa_i intersect Sa_k is
 # non-empty or a_i S intersect a_k S is non-empty.
-SEMIGROUPS.TranslationalHullOfArbitraryElements := function(H)
+SEMIGROUPS.TranslationalHullElementsGeneric := function(H)
   local S, reps, repspos, dclasses, lclasses, rclasses,
         d, f, g, i, j, k, m, n, p, r, s, slist, fposrepk, gposrepk,
         possiblefrepvals, possiblegrepvals, whenboundfvals, whenboundgvals, pos,

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -553,42 +553,42 @@ function(H)
 end);
 
 
-InstallMethod(\*, "for translations of a semigroup",
+InstallMethod(\*, "for left translations of a semigroup",
 IsIdenticalObj,
 [IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
 function(x, y)
-  return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
+  return Objectify(FamilyObj(x)!.type, [y![1]*x![1]]);
 end);
 
-InstallMethod(\=, "for translations of a semigroup",
+InstallMethod(\=, "for left translations of a semigroup",
 IsIdenticalObj,
 [IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
 function(x, y) 
   return x![1] = y![1];
 end);
 
-InstallMethod(\<, "for translations of a semigroup",
+InstallMethod(\<, "for left translations of a semigroup",
 IsIdenticalObj,
 [IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
 function(x, y) 
   return x![1] < y![1];
 end);
 
-InstallMethod(\*, "for translations of a semigroup",
+InstallMethod(\*, "for right translations of a semigroup",
 IsIdenticalObj,
 [IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
 function(x, y)
   return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
 end);
 
-InstallMethod(\=, "for translations of a semigroup",
+InstallMethod(\=, "for right translations of a semigroup",
 IsIdenticalObj,
 [IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
 function(x, y) 
   return x![1] = y![1];
 end);
 
-InstallMethod(\<, "for translations of a semigroup",
+InstallMethod(\<, "for right translations of a semigroup",
 IsIdenticalObj,
 [IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
 function(x, y) 
@@ -821,7 +821,7 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponen
         rowtransformedmat, zerorow, zerocol, pos, satisfied,
         rels, edges, rowrels, relpoints, rel, i, j, k, l, x, y, r, n, q, c,
         funcs, digraph, cc, comp, iterator, foundfuncs, failedcomps, vals,
-        failedtocomplete, relpointvals, 
+        failedtocomplete, relpointvals,
         relssatisfied, funcsfromrelpointvals, fillin;
   reesmatsemi := Range(IsomorphismReesZeroMatrixSemigroup(S));
   mat := Matrix(reesmatsemi);
@@ -995,8 +995,12 @@ SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponen
   
   if IsDoneIterator(iterator) then
     return [];
-  elif not relssatisfied(funcsfromrelpointvals(NextIterator(iterator))) then
-    return [0, Set(failedcomps), t1, t2];
+  else
+    funcs := funcsfromrelpointvals(NextIterator(iterator));
+    if not relssatisfied(funcs) then
+      return [0, Set(failedcomps), t1, t2];
+    fi;
+    Add(foundfuncs, funcs);
   fi;
   
   while not IsDoneIterator(iterator) do
@@ -1033,8 +1037,8 @@ function(S)
       if x = zero then
         return zero;
       fi;
-      if t1[x[1]] <> nrrows + 1 then
-        return RMSElement(reesmatsemi, t1[x[1]], fx[x[1]] * x[2], x[3]);
+      if t2[x[1]] <> nrcols + 1 then
+        return RMSElement(reesmatsemi, t2[x[1]], fy[x[1]] * x[2], x[3]);
       else
         return zero;
       fi;
@@ -1044,8 +1048,8 @@ function(S)
       if x = zero then
         return zero;
       fi;
-      if t2[x[3]] <> nrcols + 1 then
-        return RMSElement(reesmatsemi, x[1], x[2] * fy[x[3]], t2[x[3]]);
+      if t1[x[3]] <> nrrows + 1 then
+        return RMSElement(reesmatsemi, x[1], x[2] * fx[x[3]], t1[x[3]]);
       else
         return zero;
       fi;
@@ -1100,7 +1104,7 @@ function(S)
     od;
   od;
   
-  return linkedpairs;
+  return Set(linkedpairs);
 end);
 
 InstallMethod(LeftTranslations, "for a semigroup with known generators",

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -164,42 +164,12 @@ SEMIGROUPS.TranslationalHullElementsGeneric := function(H)
     sortinglist[i] := Position(undosortinglist, i);
   od;
   
-  # TODO: for now, choose the reps by L/R classes - but better to choose 
-  # minimal set A such that SA = AS = S.
-  dclasses := DClasses(S);
-  reps := [];
+  reps := GeneratorsOfSemigroup(S);
   repspos := [];
-  
-  # choose diagonally through the D classes for now
-  for d in dclasses do
-    lclasses := ShallowCopy(LClasses(d));
-    rclasses := ShallowCopy(RClasses(d));
-    for i in [1 .. Minimum(Size(lclasses), Size(rclasses)) - 1] do
-      r := Representative(Intersection(lclasses[1], rclasses[1]));
-      Add(reps, r);
-      Add(repspos, Position(slist, r));
-      Remove(lclasses, 1);
-      Remove(rclasses, 1);
-    od;
-    if Size(lclasses) > Size(rclasses) then
-      #Size(rclasses) = 1
-      for j in [1 .. Size(lclasses)] do
-        r := Representative(Intersection(lclasses[1], rclasses[1]));
-        Add(reps, r);
-        Add(repspos, Position(slist, r));
-        Remove(lclasses, 1);
-      od;
-    else
-      #Size(lclasses) = 1
-      for j in [1 .. Size(rclasses)] do
-        r := Representative(Intersection(lclasses[1], rclasses[1]));
-        Add(reps, r);
-        Add(repspos, Position(slist, r));
-        Remove(rclasses, 1);
-      od;
-    fi;
-  od;
   m := Size(reps);
+  for i in [1 .. m] do
+    repspos[i] := Position(slist, reps[i]);
+  od;
 
   #store which elements of the semigroups multiply each given element to form
   #another given element

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -7,6 +7,7 @@
 ##
 #############################################################################
 ##
+
 # (a * b) f = (a) f * b
 
 InstallMethod(TranslationalHull, "for a rectangular band",
@@ -59,56 +60,6 @@ function(S)
 	hull := DirectProduct(Semigroup(leftHullGens), Semigroup(rightHullGens));
 	return hull;
 
-end);
-
-InstallMethod(LeftTranslationsNew, "for a semigroup with known generators",
-[IsSemigroup and HasGeneratorsOfSemigroup],
-function(S)
-  local digraph, n, nrgens, nrgraphs, out, colors, gens, i, tempi, revbinbitsi, 
-  j, k;
-
-  digraph  := RightCayleyGraphSemigroup(S);
-  n        := Length(digraph);
-  nrgens   := Length(digraph[1]);
-  nrgraphs := LogInt(nrgens,2) + 1;
-  out      := [];
-  colors   := [];
-
-
-  for i in [1 .. nrgraphs] do
-  	for j in [1 .. n] do
-  	  out[n * (i - 1) + j]    := [];
-  	    for k in [1 .. nrgraphs] do
-  	      if i <> k  then
-  	      	Add(out[n * (i - 1) + j], n * (k - 1) + j);
-  	      fi;
-  	    colors[n * (i - 1) + j] := i;
-  	    od;
-  	od;
-  od;
-  
-  		
-  for i in [1 .. nrgens] do
-  	tempi       := i;
-  	revbinbitsi := [];
-  	while tempi > 0 do
-  		revbinbitsi[LogInt(tempi,2)+1] := 1;
-  		tempi := tempi - 2^LogInt(tempi,2);
-    od;
-    for j in [1 .. nrgraphs] do
-      if IsBound(revbinbitsi[j]) then
-        for k in [1 .. n] do
-        	Add(out[n * (j - 1) + k], n * (j - 1) + digraph[k][i]);
-  		od;
-  	  fi;
-  	od;
-  od;
-  	
-  gens := GeneratorsOfEndomorphismMonoid(Digraph(out), colors);
-  Apply(gens, x -> RestrictedTransformation(x, [1 .. n]));
-  return Semigroup(gens, rec(small := true));
-  #DOESN'T PRESERVE ENDOMORPHISMS
-  #DOES PRESERVE AUTOMORPHISMS? TODO: Prove
 end);
 
 InstallMethod(RightTranslations, "for a semigroup with known generators",

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -9,13 +9,13 @@
 ##
 # (a * b) f = (a) f * b
 
-InstallMethod(LeftTranslationsSemigroup, "for a rectangular band", 
+InstallMethod(LeftTranslationsSemigroup, "for a semigroup", 
 [IsRectangularBand], 
 function(S) 
 	local fam, type, L;
 	
 	fam := NewFamily( "LeftTranslationsSemigroupElementsFamily",
-					IsTranslationsSemigroupElement);
+					IsLeftTranslationsSemigroupElement);
 	
 	#create the semigroup of left translations
 	L := Objectify(NewType(CollectionsFamily(fam), IsLeftTranslationsSemigroup
@@ -57,13 +57,13 @@ function(L, f)
 		[Transformation(mapAsTransList)]);
 end);
 
-InstallMethod(RightTranslationsSemigroup, "for a rectangular band", 
+InstallMethod(RightTranslationsSemigroup, "for a semigroup", 
 [IsRectangularBand], 
 function(S) 
 	local fam, type, R;
 	
 	fam := NewFamily( "RightTranslationsSemigroupElementsFamily",
-					IsTranslationsSemigroupElement);
+					IsRightTranslationsSemigroupElement);
 	
 	#create the semigroup of right translations
 	R := Objectify(NewType(CollectionsFamily(fam), IsRightTranslationsSemigroup 
@@ -227,7 +227,7 @@ InstallMethod(ViewObj, "for a translational hull",
 [IsTranslationalHull], PrintObj);
 
 InstallMethod(PrintObj, "for a translational hull",
-[IsTranslationalHull],
+[IsTranslationalHull and IsWholeFamily],
 function(H)
 	Print("<translational hull over ", UnderlyingSemigroup(H), ">");
 end);
@@ -263,7 +263,7 @@ function(T)
 end);
 
 InstallMethod(Size, "for the translational hull of a rectangular band",
-[IsTranslationalHull],
+[IsWholeTranslationalHull],
 function(H)
 	local S, L, R;
 	S := UnderlyingSemigroup(H);
@@ -375,21 +375,42 @@ end);
 
 InstallMethod(\*, "for translations of a semigroup",
 IsIdenticalObj,
-[IsTranslationsSemigroupElement, IsTranslationsSemigroupElement],
+[IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
 function(x, y)
 	return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
 end);
 
 InstallMethod(\=, "for translations of a semigroup",
 IsIdenticalObj,
-[IsTranslationsSemigroupElement, IsTranslationsSemigroupElement],
+[IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
 function(x, y) 
 	return x![1] = y![1];
 end);
 
 InstallMethod(\<, "for translations of a semigroup",
 IsIdenticalObj,
-[IsTranslationsSemigroupElement, IsTranslationsSemigroupElement],
+[IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
+function(x, y) 
+	return x![1] < y![1];
+end);
+
+InstallMethod(\*, "for translations of a semigroup",
+IsIdenticalObj,
+[IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
+function(x, y)
+	return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
+end);
+
+InstallMethod(\=, "for translations of a semigroup",
+IsIdenticalObj,
+[IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
+function(x, y) 
+	return x![1] = y![1];
+end);
+
+InstallMethod(\<, "for translations of a semigroup",
+IsIdenticalObj,
+[IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
 function(x, y) 
 	return x![1] < y![1];
 end);
@@ -426,11 +447,30 @@ function(T)
 	fi;
 end);
 
+InstallMethod(IsWholeFamily, "for a subsemigroup of the translational hull of a rectangular band",
+[IsTranslationalHull],
+function(H) 
+	return Size(H) = Size(TranslationalHullOfFamily(ElementsFamily(FamilyObj(H))));
+end);
 
+InstallMethod(UnderlyingSemigroup, "for a semigroup of left or right translations",
+[IsTranslationsSemigroup],
+function(T)
+	if IsLeftTranslationsSemigroup(T) then
+		return UnderlyingSemigroup(LeftTranslationsSemigroupOfFamily(ElementsFamily(
+			FamilyObj(T))));
+	else 
+		return UnderlyingSemigroup(RightTranslationsSemigroupOfFamily(ElementsFamily(
+			FamilyObj(T))));
+	fi;
+end);
 
-
-
-
+InstallMethod(UnderlyingSemigroup, "for a subsemigroup of the translational hull",
+[IsTranslationalHull],
+function(H)
+		return UnderlyingSemigroup(TranslationalHullOfFamily(FamilyObj(
+			Enumerator(H)[1])));
+end);
 
 
 

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -9,6 +9,7 @@
 ##
 
 # TODO: Left/right translations of a monoid are all left/right multiplications
+# TODO: Translational hull of monoid is inner translational hull
 
 #############################################################################
 ## This file contains methods for dealing with left and right translation
@@ -149,7 +150,7 @@ SEMIGROUPS.TranslationalHullOfArbitraryElements := function(H)
         possrepsk, possgrepsk, undosortinglist, sortinglist, p1, p2, L, R,
         fvalsi, gvalsi, ftransrestrictionatstage, gtransrestrictionatstage, 
         flinkedrestrictionatstage, glinkedrestrictionatstage, 
-        extendf, extendg, reject, propagatef, propagateg, restrictfromf,
+        extendf, reject, propagatef, propagateg, restrictfromf,
         restrictfromg, bt, unrestrict, linkedpairs, linkedpairsunsorted;
 
   S := UnderlyingSemigroup(H);

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -15,181 +15,188 @@
 InstallMethod(LeftTranslationsSemigroup, "for a semigroup", 
 [IsSemigroup], 
 function(S) 
-	local fam, type, L;
-	
-	fam := NewFamily( "LeftTranslationsSemigroupElementsFamily",
-					IsLeftTranslationsSemigroupElement);
-	
-	#create the semigroup of left translations
-	L := Objectify(NewType(CollectionsFamily(fam), IsLeftTranslationsSemigroup
-	 and IsWholeFamily and IsAttributeStoringRep), rec());
-		
-	#store the type of the elements in the semigroup
-	type := NewType(fam, IsLeftTranslationsSemigroupElement);
-	
-	fam!.type := type;
-	SetTypeLeftTranslationsSemigroupElements(L, type);
-	SetLeftTranslationsSemigroupOfFamily(fam, L); 
-	
-	SetUnderlyingSemigroup(L, S);
-	return L;
+  local fam, type, L;
+  
+  fam := NewFamily("LeftTranslationsSemigroupElementsFamily",
+                    IsLeftTranslationsSemigroupElement);
+  
+  #create the semigroup of left translations
+  L := Objectify(NewType(CollectionsFamily(fam), IsLeftTranslationsSemigroup
+                         and IsWholeFamily and IsAttributeStoringRep), rec());
+    
+  #store the type of the elements in the semigroup
+  type := NewType(fam, IsLeftTranslationsSemigroupElement);
+  
+  fam!.type := type;
+  SetTypeLeftTranslationsSemigroupElements(L, type);
+  SetLeftTranslationsSemigroupOfFamily(fam, L); 
+  
+  SetUnderlyingSemigroup(L, S);
+  return L;
 end);
 
 
 InstallGlobalFunction(LeftTranslation,
 #why not filters? And should it be checked that this really is a translation?
 function(L, f)
-	local semiList, mapAsTransList, i;
-	if not (IsLeftTranslationsSemigroup(L)) then
-		Error("usage: the first argument must be a semigroup of left translations");
-		return;
-	fi;
-	
-	if not (UnderlyingSemigroup(L) = Source(f) and Source(f) = Range(f)) then
-		Error("usage: the second argument must be a function from the underlying ",
-		 "semigroup of the semigroup of left translations to itself");
-	fi;
-	
-	#TODO: this is a bit dodgy - what about infinite underlying semigroups?
-	semiList:=AsList(UnderlyingSemigroup(L));
-	mapAsTransList := [];
-	for i in [1..Length(semiList)] do
-		mapAsTransList[i] := Position(semiList, semiList[i]^f);
-	od;
-	
-	return Objectify(TypeLeftTranslationsSemigroupElements(L), 						
-		[Transformation(mapAsTransList)]);
+  local semiList, mapAsTransList, i;
+  if not (IsLeftTranslationsSemigroup(L)) then
+    Error("Semigroups: LeftTranslation: \n",
+          "the first argument must be a semigroup of left translations");
+    return;
+  fi;
+  
+  if not (UnderlyingSemigroup(L) = Source(f) and Source(f) = Range(f)) then
+    Error("Semigroups: LeftTranslation: \n",
+          "the second argument must be a function from the underlying ",
+          "semigroup of the semigroup of left translations to itself");
+  fi;
+  
+  #TODO: this is a bit dodgy - what about infinite underlying semigroups?
+  semiList:=AsList(UnderlyingSemigroup(L));
+  mapAsTransList := [];
+  for i in [1..Length(semiList)] do
+    mapAsTransList[i] := Position(semiList, semiList[i]^f);
+  od;
+  
+  return Objectify(TypeLeftTranslationsSemigroupElements(L),             
+    [Transformation(mapAsTransList)]);
 end);
 
 InstallMethod(RightTranslationsSemigroup, "for a semigroup", 
 [IsSemigroup], 
 function(S) 
-	local fam, type, R;
-	
-	fam := NewFamily( "RightTranslationsSemigroupElementsFamily",
-					IsRightTranslationsSemigroupElement);
-	
-	#create the semigroup of right translations
-	R := Objectify(NewType(CollectionsFamily(fam), IsRightTranslationsSemigroup 
-		and IsWholeFamily and IsAttributeStoringRep ), rec() );
-		
-	#store the type of the elements in the semigroup
-	type := NewType(fam, IsRightTranslationsSemigroupElement);
-	
-	fam!.type := type;
-	SetTypeRightTranslationsSemigroupElements(R, type);
-	SetRightTranslationsSemigroupOfFamily(fam, R); 
-	
-	SetUnderlyingSemigroup(R, S);
-	return R;
+  local fam, type, R;
+  
+  fam := NewFamily( "RightTranslationsSemigroupElementsFamily",
+          IsRightTranslationsSemigroupElement);
+  
+  #create the semigroup of right translations
+  R := Objectify(NewType(CollectionsFamily(fam), IsRightTranslationsSemigroup 
+    and IsWholeFamily and IsAttributeStoringRep ), rec() );
+    
+  #store the type of the elements in the semigroup
+  type := NewType(fam, IsRightTranslationsSemigroupElement);
+  
+  fam!.type := type;
+  SetTypeRightTranslationsSemigroupElements(R, type);
+  SetRightTranslationsSemigroupOfFamily(fam, R); 
+  
+  SetUnderlyingSemigroup(R, S);
+  return R;
 end);
 
 
 InstallGlobalFunction(RightTranslation,
 #why not filters? And should it be checked that this really is a translation?
 function(R, f)
-	local semiList, mapAsTransList, i;
-	if not (IsRightTranslationsSemigroup(R)) then
-		Error("usage: the first argument must be a semigroup of right translations");
-		return;
-	fi;
-	
-	if not (UnderlyingSemigroup(R) = Source(f) and Source(f) = Range(f)) then
-		Error("usage: the second argument must be a function from the underlying semigroup",
-		" of the semigroup of right translations to itself");
-	fi;
-	
-	#this is a bit dodgy
-	semiList:=AsList(UnderlyingSemigroup(R));
-	mapAsTransList := [];
-	for i in [1..Length(semiList)] do
-		mapAsTransList[i] := Position(semiList, semiList[i]^f);
-	od;
-	
-	return Objectify(TypeRightTranslationsSemigroupElements(R), 
-	[Transformation(mapAsTransList)]);
+  local semiList, mapAsTransList, i;
+  if not (IsRightTranslationsSemigroup(R)) then
+    Error("Semigroups: RightTranslation: \n",
+          "the first argument must be a semigroup of right translations");
+    return;
+  fi;
+  
+  if not (UnderlyingSemigroup(R) = Source(f) and Source(f) = Range(f)) then
+    Error("Semigroups: RightTranslation: \n",
+          "the second argument must be a function from the underlying ",
+          "semigroup of the semigroup of left translations to itself");
+  fi;
+  
+  #this is a bit dodgy
+  semiList:=AsList(UnderlyingSemigroup(R));
+  mapAsTransList := [];
+  for i in [1..Length(semiList)] do
+    mapAsTransList[i] := Position(semiList, semiList[i]^f);
+  od;
+  
+  return Objectify(TypeRightTranslationsSemigroupElements(R), 
+  [Transformation(mapAsTransList)]);
 end);
 
 InstallMethod(TranslationalHull, "for a semigroup",
 [IsSemigroup],
 function(S)
-	local fam, type, H;
-	
-	fam := NewFamily( "TranslationalHullElementsFamily", 
-					IsTranslationalHullElement);
-	
-	#create the translational hull
- 	H := Objectify ( NewType ( CollectionsFamily( fam ), IsTranslationalHull and
- 		IsWholeFamily and IsAttributeStoringRep ), rec() );
- 	
- 	type := NewType(fam, IsTranslationalHullElement);
- 	
- 	fam!.type := type;
- 	SetTypeTranslationalHullElements(H, type);
- 	SetTranslationalHullOfFamily(fam, H);
-	SetUnderlyingSemigroup(H, S);
-	
-	return H;
+  local fam, type, H;
+  
+  fam := NewFamily( "TranslationalHullElementsFamily", 
+          IsTranslationalHullElement);
+  
+  #create the translational hull
+   H := Objectify ( NewType ( CollectionsFamily( fam ), IsTranslationalHull and
+     IsWholeFamily and IsAttributeStoringRep ), rec() );
+   
+   type := NewType(fam, IsTranslationalHullElement);
+   
+   fam!.type := type;
+   SetTypeTranslationalHullElements(H, type);
+   SetTranslationalHullOfFamily(fam, H);
+  SetUnderlyingSemigroup(H, S);
+  
+  return H;
 end);
 
 InstallGlobalFunction(TranslationalHullElement, 
 function(H, l, r) 
-	local S, L, R;
-	
-	if not IsTranslationalHull(H) then 
-		Error("usage: the first argument must be a translational hull");
-	fi;
-	
-	if not (IsLeftTranslationsSemigroupElement(l) and 
-						IsRightTranslationsSemigroupElement(r)) then
-		Error("usage: the second argument must be a left translation",
-			" and the third argument must be a right translation");
-		return;
-	fi;
-	
-	L := LeftTranslationsSemigroupOfFamily(FamilyObj(l));
-	R := RightTranslationsSemigroupOfFamily(FamilyObj(r));
-	
-	if not UnderlyingSemigroup(L) = UnderlyingSemigroup(R) then
-			Error("usage: each argument must have the same underlying semigroup");
-	fi;
-	
-	return Objectify(TypeTranslationalHullElements(H), [l, r]);
+  local S, L, R;
+  
+  if not IsTranslationalHull(H) then 
+    Error("Semigroups: TranslationalHullElement: \n",
+          "the first argument must be a translational hull");
+  fi;
+  
+  if not (IsLeftTranslationsSemigroupElement(l) and 
+            IsRightTranslationsSemigroupElement(r)) then
+    Error("Semigroups: TranslationalHullElement: \n",
+          "the second argument must be a left translation",
+          " and the third argument must be a right translation");
+    return;
+  fi;
+  
+  L := LeftTranslationsSemigroupOfFamily(FamilyObj(l));
+  R := RightTranslationsSemigroupOfFamily(FamilyObj(r));
+  
+  if not UnderlyingSemigroup(L) = UnderlyingSemigroup(R) then
+      Error("Semigroups: TranslationalHullElement: \n",
+            "each argument must have the same underlying semigroup");
+  fi;
+  
+  return Objectify(TypeTranslationalHullElements(H), [l, r]);
 end);
 
 
 InstallMethod(ViewObj, "for the semigroup of left or right translations of a rectangular band", 
 [IsTranslationsSemigroup and IsWholeFamily], 
 function(T)
-	local S;
-	S:=UnderlyingSemigroup(T);
-	if not IsRectangularBand(S) then 
-		TryNextMethod(); 
-	fi;
-	
-	Print("<the semigroup of");
-	if IsLeftTranslationsSemigroup(T) then Print(" left");
-	else Print(" right"); fi;
-	Print(" translations of a ", NrRClasses(S), "x", NrLClasses(S));
-	Print(" rectangular band>"); 
+  local S;
+  S:=UnderlyingSemigroup(T);
+  if not IsRectangularBand(S) then 
+    TryNextMethod(); 
+  fi;
+  
+  Print("<the semigroup of");
+  if IsLeftTranslationsSemigroup(T) then Print(" left");
+  else Print(" right"); fi;
+  Print(" translations of a ", NrRClasses(S), "x", NrLClasses(S));
+  Print(" rectangular band>"); 
 
 end);
 
 InstallMethod(PrintObj, "for the semigroup of left or right translations of a rectangular band",
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
-	local S;
-	S:=UnderlyingSemigroup(T);
-	if not IsRectangularBand(S) then 
-		TryNextMethod();
+  local S;
+  S:=UnderlyingSemigroup(T);
+  if not IsRectangularBand(S) then 
+    TryNextMethod();
   fi;
-	
-	Print("<the semigroup of");
-	if IsLeftTranslationsSemigroup(T) then Print(" left");
-	else Print(" right"); fi;
-	Print(" translations of ", S);
-	Print(">");
-	return;
+  
+  Print("<the semigroup of");
+  if IsLeftTranslationsSemigroup(T) then Print(" left");
+  else Print(" right"); fi;
+  Print(" translations of ", S);
+  Print(">");
+  return;
 end);
 
 InstallMethod(ViewObj, "for a semigroup of translations", 
@@ -198,18 +205,18 @@ InstallMethod(ViewObj, "for a semigroup of translations",
 InstallMethod(PrintObj, "for a semigroup of translations",
 [IsTranslationsSemigroup and HasGeneratorsOfSemigroup],
 function(T)
-	Print("<semigroup of ");
-	if IsLeftTranslationsSemigroup(T) then Print("left ");
-	else Print("right ");
-	fi;
-	Print("translations of ", UnderlyingSemigroup(T), " with ",
-		Length(GeneratorsOfSemigroup(T)),
-		" generators");
-	if Length(GeneratorsOfSemigroup(T)) > 1 then
-		Print("s");
-	fi;
-	Print(">");
-	return;
+  Print("<semigroup of ");
+  if IsLeftTranslationsSemigroup(T) then Print("left ");
+  else Print("right ");
+  fi;
+  Print("translations of ", UnderlyingSemigroup(T), " with ",
+    Length(GeneratorsOfSemigroup(T)),
+    " generators");
+  if Length(GeneratorsOfSemigroup(T)) > 1 then
+    Print("s");
+  fi;
+  Print(">");
+  return;
 end);
 
 InstallMethod(ViewObj, "for a translation", 
@@ -218,17 +225,17 @@ InstallMethod(ViewObj, "for a translation",
 InstallMethod(PrintObj, "for a translation",
 [IsTranslationsSemigroupElement],
 function(t)
-	local L, S;
-	L := IsLeftTranslationsSemigroupElement(t); 
-	if L then 
-		S := UnderlyingSemigroup(LeftTranslationsSemigroupOfFamily(FamilyObj(t)));
-		Print("<left ");
-	else 
-		S := UnderlyingSemigroup(RightTranslationsSemigroupOfFamily(FamilyObj(t)));
-		Print("<right ");
-	fi;
-	
-	Print("translation on ", ViewString(S), ">");
+  local L, S;
+  L := IsLeftTranslationsSemigroupElement(t); 
+  if L then 
+    S := UnderlyingSemigroup(LeftTranslationsSemigroupOfFamily(FamilyObj(t)));
+    Print("<left ");
+  else 
+    S := UnderlyingSemigroup(RightTranslationsSemigroupOfFamily(FamilyObj(t)));
+    Print("<right ");
+  fi;
+  
+  Print("translation on ", ViewString(S), ">");
 end);
 
 InstallMethod(ViewObj, "for a translational hull", 
@@ -237,7 +244,7 @@ InstallMethod(ViewObj, "for a translational hull",
 InstallMethod(PrintObj, "for a translational hull",
 [IsTranslationalHull and IsWholeFamily],
 function(H)
-	Print("<translational hull over ", ViewString(UnderlyingSemigroup(H)), ">");
+  Print("<translational hull over ", ViewString(UnderlyingSemigroup(H)), ">");
 end);
 
 InstallMethod(ViewObj, "for a translational hull element", 
@@ -246,9 +253,9 @@ InstallMethod(ViewObj, "for a translational hull element",
 InstallMethod(PrintObj, "for a translational hull element",
 [IsTranslationalHullElement],
 function(t)
-	local H;
-	H := TranslationalHullOfFamily(FamilyObj(t));
-	Print("<linked pair of translations on ", ViewString(UnderlyingSemigroup(H)), ">");
+  local H;
+  H := TranslationalHullOfFamily(FamilyObj(t));
+  Print("<linked pair of translations on ", ViewString(UnderlyingSemigroup(H)), ">");
 end);
 
 
@@ -257,292 +264,292 @@ end);
 InstallMethod(Size, "for the semigroup of left or right translations of a rectangular band", 
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
-	local S, n;
-	S := UnderlyingSemigroup(T);
-	if not IsRectangularBand(S) then
-		TryNextMethod();
-	fi;
-	if IsLeftTranslationsSemigroup(T) then
-		n := NrRClasses(S);
-	else n := NrLClasses(S);
-	fi;
-	
-	return n^n;
+  local S, n;
+  S := UnderlyingSemigroup(T);
+  if not IsRectangularBand(S) then
+    TryNextMethod();
+  fi;
+  if IsLeftTranslationsSemigroup(T) then
+    n := NrRClasses(S);
+  else n := NrLClasses(S);
+  fi;
+  
+  return n^n;
 end);
 
 InstallMethod(Size, "for the semigroup of left or right translations of a completely 0-simple semigroup",
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
-	local S, G, reesMatSemi, n;
-	S := UnderlyingSemigroup(T);
-	if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
-		TryNextMethod();
-	fi;
-	reesMatSemi := Range(IsomorphismReesZeroMatrixSemigroup(S));
-	G := UnderlyingSemigroup(reesMatSemi);
-	if IsLeftTranslationsSemigroup(T) then
-		n := Length(Rows(reesMatSemi));
-	else
-		n := Length(Columns(reesMatSemi));
-	fi;
-	return (n * Size(G) + 1)^n;
+  local S, G, reesMatSemi, n;
+  S := UnderlyingSemigroup(T);
+  if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
+    TryNextMethod();
+  fi;
+  reesMatSemi := Range(IsomorphismReesZeroMatrixSemigroup(S));
+  G := UnderlyingSemigroup(reesMatSemi);
+  if IsLeftTranslationsSemigroup(T) then
+    n := Length(Rows(reesMatSemi));
+  else
+    n := Length(Columns(reesMatSemi));
+  fi;
+  return (n * Size(G) + 1)^n;
 end);
 
 InstallMethod(Size, "for the translational hull of a rectangular band",
 [IsTranslationalHull and IsWholeFamily],
 function(H)
-	local S, L, R;
-	S := UnderlyingSemigroup(H);
-	L := LeftTranslationsSemigroup(S);
-	R := RightTranslationsSemigroup(S);
-	return Size(L) * Size(R);
+  local S, L, R;
+  S := UnderlyingSemigroup(H);
+  L := LeftTranslationsSemigroup(S);
+  R := RightTranslationsSemigroup(S);
+  return Size(L) * Size(R);
 end);
-	
+  
 InstallMethod(Enumerator, "for the semigroup of left or right translations of a rectangular band", 
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
-	local S, semiList, iso, inv, reesMatSemi, L, size, 
-		i, r, s, mapAsReesTransList, f;
+  local S, semiList, iso, inv, reesMatSemi, L, size, 
+    i, r, s, mapAsReesTransList, f;
 
-	if not IsRectangularBand(UnderlyingSemigroup(T)) then
-		TryNextMethod();
-	fi;
-	
-	S := UnderlyingSemigroup(T);
-	semiList := AsList(S);
-	iso := IsomorphismReesMatrixSemigroup(S);
-	inv := InverseGeneralMapping(iso);
-	reesMatSemi := Range(iso);
-	L := IsLeftTranslationsSemigroup(T);
-	if L then
-		size := Length(Rows(reesMatSemi));
-	else
-		size := Length(Columns(reesMatSemi));
-	fi;
-	
-	return EnumeratorByFunctions(T, rec(
-		enum := Enumerator(FullTransformationMonoid(size)),
-		
-		#TODO: find a better way of doing this - can probably use generators
-		NumberElement := function(enum, x)
-			mapAsReesTransList := [];
-			if L then
-				for i in [1..size] do
-					r := RMSElement(S, i, (), 1);
-					s := semiList[Position(semiList, (r^inv))^x![1]]^iso;
-					mapAsReesTransList[i] := s[1];
-				od;
-			else 
-				for i in [1..size] do
-					r := RMSElement(S, 1, (), i);
-					s := semiList[Position(semiList, (r^inv))^x![1]]^iso;
-					mapAsReesTransList[i] := s[3];
-				od;
-			fi;
-			return Position(enum!.enum, Transformation(mapAsReesTransList));
-		end,
-		
-		ElementNumber := function(enum, n)
-			if L then
-				f := function(x)
-					return ReesMatrixSemigroupElement(reesMatSemi, x[1]^enum!.enum[n], 
-						(), x[3]);
-				end;
-				return LeftTranslation(T, CompositionMapping(inv, 
-					MappingByFunction(reesMatSemi, reesMatSemi, f), iso));
-			else 
-				f := function(x)
-					return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-						(), x[3]^enum!.enum[n]);
-				end;
-				return RightTranslation(T, CompositionMapping(inv, 
-					MappingByFunction(reesMatSemi, reesMatSemi, f), iso));
-			fi;
-		end,
-		
-		Length := enum -> Length(enum!.enum),
-		
-		PrintObj := function(enum)
-			Print("<enumerator of translations of a rectangular band>");
-			return;
-		end));
+  if not IsRectangularBand(UnderlyingSemigroup(T)) then
+    TryNextMethod();
+  fi;
+  
+  S := UnderlyingSemigroup(T);
+  semiList := AsList(S);
+  iso := IsomorphismReesMatrixSemigroup(S);
+  inv := InverseGeneralMapping(iso);
+  reesMatSemi := Range(iso);
+  L := IsLeftTranslationsSemigroup(T);
+  if L then
+    size := Length(Rows(reesMatSemi));
+  else
+    size := Length(Columns(reesMatSemi));
+  fi;
+  
+  return EnumeratorByFunctions(T, rec(
+    enum := Enumerator(FullTransformationMonoid(size)),
+    
+    #TODO: find a better way of doing this - can probably use generators
+    NumberElement := function(enum, x)
+      mapAsReesTransList := [];
+      if L then
+        for i in [1..size] do
+          r := RMSElement(S, i, (), 1);
+          s := semiList[Position(semiList, (r^inv))^x![1]]^iso;
+          mapAsReesTransList[i] := s[1];
+        od;
+      else 
+        for i in [1..size] do
+          r := RMSElement(S, 1, (), i);
+          s := semiList[Position(semiList, (r^inv))^x![1]]^iso;
+          mapAsReesTransList[i] := s[3];
+        od;
+      fi;
+      return Position(enum!.enum, Transformation(mapAsReesTransList));
+    end,
+    
+    ElementNumber := function(enum, n)
+      if L then
+        f := function(x)
+          return ReesMatrixSemigroupElement(reesMatSemi, x[1]^enum!.enum[n], 
+            (), x[3]);
+        end;
+        return LeftTranslation(T, CompositionMapping(inv, 
+          MappingByFunction(reesMatSemi, reesMatSemi, f), iso));
+      else 
+        f := function(x)
+          return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+            (), x[3]^enum!.enum[n]);
+        end;
+        return RightTranslation(T, CompositionMapping(inv, 
+          MappingByFunction(reesMatSemi, reesMatSemi, f), iso));
+      fi;
+    end,
+    
+    Length := enum -> Length(enum!.enum),
+    
+    PrintObj := function(enum)
+      Print("<enumerator of translations of a rectangular band>");
+      return;
+    end));
 end); 
 
 InstallMethod(Enumerator, "for the translational hull of a rectangular band",
 [IsTranslationalHull], 
 function(H)
-	local S;
-	S := UnderlyingSemigroup(H);
-	if not IsRectangularBand(S) then
-		TryNextMethod();
-	fi;
-	
-	return EnumeratorByFunctions(H, rec(
-		
-		enum:=EnumeratorOfCartesianProduct(Enumerator(LeftTranslationsSemigroup(S)),
-			Enumerator(RightTranslationsSemigroup(S))),
-			
-		NumberElement := function(enum, x)
-			return Position(enum!.enum, [x![1], x![2]]);
-		end,
-		
-		ElementNumber := function(enum, n)
-			return Objectify(TypeTranslationalHullElements(H), enum!.enum[n]);
-		end,
-		
-		Length := enum -> Length(enum!.enum),
-		
-		PrintObj := function(enum)
-			Print("<enumerator of translational hull>");
-			return;
-		end));
+  local S;
+  S := UnderlyingSemigroup(H);
+  if not IsRectangularBand(S) then
+    TryNextMethod();
+  fi;
+  
+  return EnumeratorByFunctions(H, rec(
+    
+    enum:=EnumeratorOfCartesianProduct(Enumerator(LeftTranslationsSemigroup(S)),
+      Enumerator(RightTranslationsSemigroup(S))),
+      
+    NumberElement := function(enum, x)
+      return Position(enum!.enum, [x![1], x![2]]);
+    end,
+    
+    ElementNumber := function(enum, n)
+      return Objectify(TypeTranslationalHullElements(H), enum!.enum[n]);
+    end,
+    
+    Length := enum -> Length(enum!.enum),
+    
+    PrintObj := function(enum)
+      Print("<enumerator of translational hull>");
+      return;
+    end));
 end);
 
 InstallMethod(GeneratorsOfSemigroup, "for the semigroup of left or right translations of a rectangular band",
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
-	local S, L, n, iso, inv, reesMatSemi, semiList, gens, t, f;
-	S := UnderlyingSemigroup(T);
-	if not IsRectangularBand(S) then
-		TryNextMethod();
-	fi;
+  local S, L, n, iso, inv, reesMatSemi, semiList, gens, t, f;
+  S := UnderlyingSemigroup(T);
+  if not IsRectangularBand(S) then
+    TryNextMethod();
+  fi;
 
-	semiList := AsList(S);
-	iso := IsomorphismReesMatrixSemigroup(S);
-	inv := InverseGeneralMapping(iso);
-	reesMatSemi := Range(iso);
-	L := IsLeftTranslationsSemigroup(T);
-	if L then
-		n := Length(Rows(reesMatSemi));
-	else
-		n := Length(Columns(reesMatSemi));
-	fi;
-	
-	gens := [];
-	for t in GeneratorsOfMonoid(FullTransformationMonoid(n)) do
-		if L then
-				f := function(x)
-					return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
-						(), x[3]);
-				end;
-				Add(gens, LeftTranslation(T, CompositionMapping(inv, 
-				MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-		else 
-				f := function(x)
-					return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-						(), x[3]^t);
-				end;
-				Add(gens, RightTranslation(T, CompositionMapping(inv, 
-					MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-		fi;
-	od;
-	return gens;
-end);			
+  semiList := AsList(S);
+  iso := IsomorphismReesMatrixSemigroup(S);
+  inv := InverseGeneralMapping(iso);
+  reesMatSemi := Range(iso);
+  L := IsLeftTranslationsSemigroup(T);
+  if L then
+    n := Length(Rows(reesMatSemi));
+  else
+    n := Length(Columns(reesMatSemi));
+  fi;
+  
+  gens := [];
+  for t in GeneratorsOfMonoid(FullTransformationMonoid(n)) do
+    if L then
+        f := function(x)
+          return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
+            (), x[3]);
+        end;
+        Add(gens, LeftTranslation(T, CompositionMapping(inv, 
+        MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    else 
+        f := function(x)
+          return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+            (), x[3]^t);
+        end;
+        Add(gens, RightTranslation(T, CompositionMapping(inv, 
+          MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    fi;
+  od;
+  return gens;
+end);      
 
 InstallMethod(GeneratorsOfSemigroup, "for the left/right translations of a finite 0-simple semigroup",
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
-	local S, L, n, iso, inv, reesMatSemi, semiList, gens, t, f, groupGens,
-				e, a, fa, G, zero;
-				
-	S := UnderlyingSemigroup(T);
-	if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
-		TryNextMethod();
-	fi;
-	
-	semiList := AsList(S);
-	iso := IsomorphismReesZeroMatrixSemigroup(S);
-	inv := InverseGeneralMapping(iso);
-	reesMatSemi := Range(iso);
-	zero := MultiplicativeZero(reesMatSemi);
-	L := IsLeftTranslationsSemigroup(T);
-	if L then
-		n := Length(Rows(reesMatSemi));
-	else
-		n := Length(Columns(reesMatSemi));
-	fi;
-	
-	gens := [];
-	G := UnderlyingSemigroup(reesMatSemi);
-	groupGens := GeneratorsOfGroup(G);
-	
-	for t in GeneratorsOfMonoid(PartialTransformationMonoid(n)) do
-		if L then
-			f := function(x)
-				if (x = zero or x[1]^t = n+1) then 
-					return zero;
-				fi;
-				return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
-						x[2], x[3]);
-			end;
-			Add(gens, LeftTranslation(T, CompositionMapping(
-				inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-		else
-			f := function(x)
-				if (x = zero or x[3]^t = n+1) then 
-					return zero;
-				fi;
-				return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-					x[2], x[3]^t); 
-			end;
-			Add(gens, RightTranslation(T, CompositionMapping(
-				inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-		fi;
-	od;
-	
-	for a in groupGens do
-		fa := function(x)
-			if x = 1 then
-				return a;
-			fi; 
-			return MultiplicativeNeutralElement(G);
-		end;
-		if L then
-			f := function(x)
-				if x = zero then 
-					return zero;
-				fi;
-				return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-						fa(x[1])*x[2], x[3]);
-			end;
-			Add(gens, LeftTranslation(T, CompositionMapping(
-				inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-		else
-			f := function(x)
-				if x = zero then 
-					return zero;
-				fi;
-				return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-					x[2]*fa(x[3]), x[3]); 
-			end;
-			Add(gens, RightTranslation(T, CompositionMapping(
-				inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-		fi;
-	od;
-	return gens;
+  local S, L, n, iso, inv, reesMatSemi, semiList, gens, t, f, groupGens,
+        e, a, fa, G, zero;
+        
+  S := UnderlyingSemigroup(T);
+  if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
+    TryNextMethod();
+  fi;
+  
+  semiList := AsList(S);
+  iso := IsomorphismReesZeroMatrixSemigroup(S);
+  inv := InverseGeneralMapping(iso);
+  reesMatSemi := Range(iso);
+  zero := MultiplicativeZero(reesMatSemi);
+  L := IsLeftTranslationsSemigroup(T);
+  if L then
+    n := Length(Rows(reesMatSemi));
+  else
+    n := Length(Columns(reesMatSemi));
+  fi;
+  
+  gens := [];
+  G := UnderlyingSemigroup(reesMatSemi);
+  groupGens := GeneratorsOfGroup(G);
+  
+  for t in GeneratorsOfMonoid(PartialTransformationMonoid(n)) do
+    if L then
+      f := function(x)
+        if (x = zero or x[1]^t = n+1) then 
+          return zero;
+        fi;
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
+            x[2], x[3]);
+      end;
+      Add(gens, LeftTranslation(T, CompositionMapping(
+        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    else
+      f := function(x)
+        if (x = zero or x[3]^t = n+1) then 
+          return zero;
+        fi;
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+          x[2], x[3]^t); 
+      end;
+      Add(gens, RightTranslation(T, CompositionMapping(
+        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    fi;
+  od;
+  
+  for a in groupGens do
+    fa := function(x)
+      if x = 1 then
+        return a;
+      fi; 
+      return MultiplicativeNeutralElement(G);
+    end;
+    if L then
+      f := function(x)
+        if x = zero then 
+          return zero;
+        fi;
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+            fa(x[1])*x[2], x[3]);
+      end;
+      Add(gens, LeftTranslation(T, CompositionMapping(
+        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    else
+      f := function(x)
+        if x = zero then 
+          return zero;
+        fi;
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+          x[2]*fa(x[3]), x[3]); 
+      end;
+      Add(gens, RightTranslation(T, CompositionMapping(
+        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+    fi;
+  od;
+  return gens;
 end);
 
 InstallMethod(GeneratorsOfSemigroup, "for the translational hull of a rectangular band", 
 [IsTranslationalHull],
 function(H)
-	local S, leftGens, rightGens, l, r, gens;
-	
-	S := UnderlyingSemigroup(H);
-	if not IsRectangularBand(S) then
-		TryNextMethod();
-	fi;
+  local S, leftGens, rightGens, l, r, gens;
+  
+  S := UnderlyingSemigroup(H);
+  if not IsRectangularBand(S) then
+    TryNextMethod();
+  fi;
 
-	leftGens := GeneratorsOfSemigroup(LeftTranslationsSemigroup(S));
-	rightGens := GeneratorsOfSemigroup(RightTranslationsSemigroup(S));
-	gens := [];
-	
-	for l in leftGens do
-		for r in rightGens do
-			Add(gens, TranslationalHullElement(H, l, r));
-		od;
-	od;
-	
-	return gens;
+  leftGens := GeneratorsOfSemigroup(LeftTranslationsSemigroup(S));
+  rightGens := GeneratorsOfSemigroup(RightTranslationsSemigroup(S));
+  gens := [];
+  
+  for l in leftGens do
+    for r in rightGens do
+      Add(gens, TranslationalHullElement(H, l, r));
+    od;
+  od;
+  
+  return gens;
 end);
 
 
@@ -550,104 +557,104 @@ InstallMethod(\*, "for translations of a semigroup",
 IsIdenticalObj,
 [IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
 function(x, y)
-	return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
+  return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
 end);
 
 InstallMethod(\=, "for translations of a semigroup",
 IsIdenticalObj,
 [IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
 function(x, y) 
-	return x![1] = y![1];
+  return x![1] = y![1];
 end);
 
 InstallMethod(\<, "for translations of a semigroup",
 IsIdenticalObj,
 [IsLeftTranslationsSemigroupElement, IsLeftTranslationsSemigroupElement],
 function(x, y) 
-	return x![1] < y![1];
+  return x![1] < y![1];
 end);
 
 InstallMethod(\*, "for translations of a semigroup",
 IsIdenticalObj,
 [IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
 function(x, y)
-	return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
+  return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
 end);
 
 InstallMethod(\=, "for translations of a semigroup",
 IsIdenticalObj,
 [IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
 function(x, y) 
-	return x![1] = y![1];
+  return x![1] = y![1];
 end);
 
 InstallMethod(\<, "for translations of a semigroup",
 IsIdenticalObj,
 [IsRightTranslationsSemigroupElement, IsRightTranslationsSemigroupElement],
 function(x, y) 
-	return x![1] < y![1];
+  return x![1] < y![1];
 end);
 
 InstallMethod(\*, "for translation hull elements (linked pairs)",
 IsIdenticalObj,
 [IsTranslationalHullElement, IsTranslationalHullElement],
 function(x, y)
-	return Objectify(FamilyObj(x)!.type, [x![1]*y![1], x![2]*y![2]]);
+  return Objectify(FamilyObj(x)!.type, [x![1]*y![1], x![2]*y![2]]);
 end);
 
 InstallMethod(\=, "for translational hull elements (linked pairs)",
 IsIdenticalObj,
 [IsTranslationalHullElement, IsTranslationalHullElement],
 function(x, y)
-	return x![1] = y![1] and x![2] = y![2];
+  return x![1] = y![1] and x![2] = y![2];
 end);
 
 InstallMethod(\<, "for translational hull elements (linked pairs)",
 IsIdenticalObj,
 [IsTranslationalHullElement, IsTranslationalHullElement],
 function(x, y)
-	return x![1] < y![1] or (x![1] = y![1] and x![2] < y![2]);
+  return x![1] < y![1] or (x![1] = y![1] and x![2] < y![2]);
 end);
 
 InstallMethod(IsWholeFamily, "for a semigroup of translations of a rectangular band",
 [IsTranslationsSemigroup],
 function(T)
-	if IsLeftTranslationsSemigroup(T) then	
-		return Size(T)=Size(LeftTranslationsSemigroupOfFamily(ElementsFamily(
-			FamilyObj(T))));
-	else return Size(T)=Size(RightTranslationsSemigroupOfFamily(ElementsFamily(
-			FamilyObj(T)))); 
-	fi;
+  if IsLeftTranslationsSemigroup(T) then  
+    return Size(T)=Size(LeftTranslationsSemigroupOfFamily(ElementsFamily(
+      FamilyObj(T))));
+  else return Size(T)=Size(RightTranslationsSemigroupOfFamily(ElementsFamily(
+      FamilyObj(T)))); 
+  fi;
 end);
 
 InstallMethod(IsWholeFamily, "for a subsemigroup of the translational hull of a rectangular band",
 [IsTranslationalHull],
 function(H) 
-	return Size(H) = Size(TranslationalHullOfFamily(ElementsFamily(FamilyObj(H))));
+  return Size(H) = Size(TranslationalHullOfFamily(ElementsFamily(FamilyObj(H))));
 end);
 
 InstallMethod(UnderlyingSemigroup, "for a semigroup of left or right translations",
 [IsTranslationsSemigroup],
 function(T)
-	if IsLeftTranslationsSemigroup(T) then
-		return UnderlyingSemigroup(LeftTranslationsSemigroupOfFamily(ElementsFamily(
-			FamilyObj(T))));
-	else 
-		return UnderlyingSemigroup(RightTranslationsSemigroupOfFamily(ElementsFamily(
-			FamilyObj(T))));
-	fi;
+  if IsLeftTranslationsSemigroup(T) then
+    return UnderlyingSemigroup(LeftTranslationsSemigroupOfFamily(ElementsFamily(
+      FamilyObj(T))));
+  else 
+    return UnderlyingSemigroup(RightTranslationsSemigroupOfFamily(ElementsFamily(
+      FamilyObj(T))));
+  fi;
 end);
 
 InstallMethod(UnderlyingSemigroup, "for a subsemigroup of the translational hull",
 [IsTranslationalHull],
 function(H)
-		return UnderlyingSemigroup(TranslationalHullOfFamily(FamilyObj(
-			Enumerator(H)[1])));
+    return UnderlyingSemigroup(TranslationalHullOfFamily(FamilyObj(
+      Enumerator(H)[1])));
 end);
 
 SEMIGROUPS.HashFunctionForTranslationalHullElements := function(x, data)
-		return (ORB_HashFunctionForTransformations(x![1]![1], data)
-			+ ORB_HashFunctionForTransformations(x![2]![1], data)) mod data + 1;
+    return (ORB_HashFunctionForTransformations(x![1]![1], data)
+      + ORB_HashFunctionForTransformations(x![2]![1], data)) mod data + 1;
 end;
 
 InstallMethod(ChooseHashFunction, "for a translational hull element and int",
@@ -657,64 +664,189 @@ function(x, hashlen)
              data := hashlen);
 end);
 
+#Finds the transformations on the indices of a completely 0-simple semigroup
+#which are candidates for translations, when combined with a function from
+#the index sets to the group.
 
-
-
-
-
-
+SEMIGROUPS.FindTranslationTransformations := function(S)
+  local iso, reesMatSemi, mat, simpleRows, simpleColumns, nrRows, nrCols,
+    transList, partColumns, partColumn, pc, linkedTransList, col, cols, 
+    possibleCols, t, q, w, c, x, k, v, f, i, j,
+    isPartialSuccess, extend, reject, bt;
+  iso := IsomorphismReesZeroMatrixSemigroup(S);
+  reesMatSemi := Range(iso);
+  mat := Matrix(reesMatSemi);
+  simpleRows := List(mat, ShallowCopy);
+  nrRows := Length(simpleRows);
+  nrCols := Length(simpleRows[1]);
+  transList := [];
+  for i in [1..Length(simpleRows)] do
+    for j in [1..Length(simpleRows[i])] do
+      if simpleRows[i][j] <> 0 then
+        simpleRows[i][j] := 1;
+      fi;
+    od;
+  od;
+  simpleColumns := [];
+  for i in [1..Length(simpleRows[1])] do
+    c := [];
+    for j in [1..Length(simpleRows)] do
+      c[j] := simpleRows[j][i];
+    od;
+    Add(simpleColumns, c);
+  od;
+  
+  #TODO: keep track of the partial columns in the extend/reject functions
+  isPartialSuccess := function(x)
+    partColumns := [];
+    for i in [1..Length(simpleRows[1])] do
+      partColumn := [];
+      for j in [1..Length(x)] do
+        if x[j] = nrRows + 1 then
+          #treat rows not in the domain like a row of zeros
+          partColumn[j] := 0;
+        else
+          partColumn[j] := simpleRows[x[j]][i];
+        fi;
+      od;
+      Add(partColumns, partColumn);
+    od;
+    
+    for pc in partColumns do
+      #only check the columns which contain a 1
+      #all-zero column can be made by column not in domain of transformation
+      #also, no ones in one partial matrix but not in the other...
+      if 1 in pc and ForAll(simpleColumns, c -> 1 in c{[1..Length(pc)]} + pc) then
+        return false;
+      fi;
+    od;
+    return true;
+  end;
+  
+  extend := function(w)
+    Add(w, 1);
+    return w;
+  end;
+  
+  reject := function(q)
+    q := ShallowCopy(q);
+    k := Length(q);
+    if q[k] <= nrRows then
+      q[k] := q[k] + 1;
+    elif k > 1 then
+      q := reject(q{[1..k-1]});
+    else return 0;
+    fi;
+    return q;
+  end;
+  
+  bt := function(x)
+    if x = 0 then
+      return 0;
+    fi;
+    if not isPartialSuccess(x) then
+      x := reject(x);  
+    elif Length(x) = nrRows then
+      return x;
+    else 
+      x := extend(x);
+    fi;
+    return bt(x);
+  end;
+  
+  v := 1;
+  transList := [bt([1])];
+  while transList[v] <> 0 do
+    v := v + 1;
+    transList[v] := bt(reject(transList[v-1]));
+    fi;
+  od;
+  
+  linkedTransList := [];
+  #last element of transList will be 0, ignore
+  for k in [1..Length(transList) -1 ] do
+    t := transList[k];
+    cols := [];
+    for i in [1..Length(simpleRows[1])] do
+      col := [];
+      for j in [1..nrRows] do
+        if t[j] = nrRows + 1 then
+          col[j] := 0;
+        else 
+          col[j] := simpleRows[t[j]][i];
+        fi;
+      od;
+      Add(cols, col);
+    od;
+    possibleCols := [];
+    for i in [1..nrCols] do
+      possibleCols[i] := [];
+      for j in [1..nrCols] do  
+        if not 1 in cols[i] + simpleColumns[j] then
+          Add(possibleCols[i], j);
+        fi;
+        if not 1 in cols[i] then 
+          Add(possibleCols[i], nrCols+1);
+        fi;
+      od;
+    od;
+    linkedTransList[k] := IteratorOfCartesianProduct(possibleCols);
+  od;
+  
+  return [transList, linkedTransList];
+end;
 
 
 
 InstallMethod(TranslationalHull2, "for a rectangular band",
 [IsRectangularBand], 
 function(S)
-	local iso, reesMatSemi, reesMat, sizeI, sizeL, leftGens, rightGens, map,
-	 mapAsTransList, semiList, leftHullGens, rightHullGens, hull, 
-	 reesMappingFunction, i, j, k, l;
-	
-	iso := IsomorphismReesMatrixSemigroup(S);
-	reesMatSemi := Range(iso);
-	reesMat := Matrix(reesMatSemi);
-	sizeI := Length(reesMat[1]);
-	sizeL := Length(reesMat);
-	
-	leftGens := ShallowCopy(GeneratorsOfMonoid(FullTransformationMonoid(sizeI)));
-	rightGens := ShallowCopy(GeneratorsOfMonoid(FullTransformationMonoid(sizeL)));
-	Add(leftGens, IdentityTransformation);
-	Add(rightGens, IdentityTransformation);
-	
-	leftHullGens:=[];
-	semiList:= AsList(S);
-	for i in [1..Length(leftGens)] do
-		reesMappingFunction := function(x)
-			return ReesMatrixSemigroupElement(reesMatSemi, x[1]^leftGens[i], (), x[3]);
-		end;
-		map := CompositionMapping(InverseGeneralMapping(iso), MappingByFunction(
-			reesMatSemi, reesMatSemi, reesMappingFunction), iso);
-		mapAsTransList := [];
-		for l in [1..Length(semiList)] do
-			mapAsTransList[l] := Position(semiList, semiList[l]^map);
-		od;
-		Add(leftHullGens, Transformation(mapAsTransList));
-	od;	 
-	
-	rightHullGens:=[];
-	for j in [1..Length(rightGens)] do
-		reesMappingFunction := function(x)
-			return ReesMatrixSemigroupElement(reesMatSemi, x[1], (), x[3]^rightGens[j]);
-		end;
-		map := CompositionMapping(InverseGeneralMapping(iso), MappingByFunction(
-			reesMatSemi, reesMatSemi, reesMappingFunction), iso);
-		mapAsTransList := [];
-		for l in [1..Length(semiList)] do
-			mapAsTransList[l] := Position(semiList, semiList[l]^map);
-		od;
-		Add(rightHullGens, Transformation(mapAsTransList));
-	od;
-	
-	hull := DirectProduct(Semigroup(leftHullGens), Semigroup(rightHullGens));
-	return hull;
+  local iso, reesMatSemi, reesMat, sizeI, sizeL, leftGens, rightGens, map,
+   mapAsTransList, semiList, leftHullGens, rightHullGens, hull, 
+   reesMappingFunction, i, j, k, l;
+  
+  iso := IsomorphismReesMatrixSemigroup(S);
+  reesMatSemi := Range(iso);
+  reesMat := Matrix(reesMatSemi);
+  sizeI := Length(reesMat[1]);
+  sizeL := Length(reesMat);
+  
+  leftGens := ShallowCopy(GeneratorsOfMonoid(FullTransformationMonoid(sizeI)));
+  rightGens := ShallowCopy(GeneratorsOfMonoid(FullTransformationMonoid(sizeL)));
+  Add(leftGens, IdentityTransformation);
+  Add(rightGens, IdentityTransformation);
+  
+  leftHullGens:=[];
+  semiList:= AsList(S);
+  for i in [1..Length(leftGens)] do
+    reesMappingFunction := function(x)
+      return ReesMatrixSemigroupElement(reesMatSemi, x[1]^leftGens[i], (), x[3]);
+    end;
+    map := CompositionMapping(InverseGeneralMapping(iso), MappingByFunction(
+      reesMatSemi, reesMatSemi, reesMappingFunction), iso);
+    mapAsTransList := [];
+    for l in [1..Length(semiList)] do
+      mapAsTransList[l] := Position(semiList, semiList[l]^map);
+    od;
+    Add(leftHullGens, Transformation(mapAsTransList));
+  od;   
+  
+  rightHullGens:=[];
+  for j in [1..Length(rightGens)] do
+    reesMappingFunction := function(x)
+      return ReesMatrixSemigroupElement(reesMatSemi, x[1], (), x[3]^rightGens[j]);
+    end;
+    map := CompositionMapping(InverseGeneralMapping(iso), MappingByFunction(
+      reesMatSemi, reesMatSemi, reesMappingFunction), iso);
+    mapAsTransList := [];
+    for l in [1..Length(semiList)] do
+      mapAsTransList[l] := Position(semiList, semiList[l]^map);
+    od;
+    Add(rightHullGens, Transformation(mapAsTransList));
+  od;
+  
+  hull := DirectProduct(Semigroup(leftHullGens), Semigroup(rightHullGens));
+  return hull;
 
 end);
 

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -22,7 +22,6 @@
 ## incides of the underlying semigroup (determined by AsList). Hence, only 
 ## finite semigroups are supported.
 ##
-## 
 ## Much of the implementation in this file was based on the implementation of
 ## RMS in reesmatsemi.gi in the GAP library - in particular, the creation of
 ## the semigroups and their relation to their elements.
@@ -142,7 +141,6 @@ end;
 # s*a_i f(a_k) = (s*a_i)g a_k and a_k f(a_i * s) = (a_k)g a_i * s,
 # as well as restriction by the translation condition if Sa_i intersect Sa_k is
 # non-empty or a_i S intersect a_k S is non-empty.
-# TODO: make this work
 SEMIGROUPS.TranslationalHullOfArbitraryElements := function(H)
   local S, multtable, transpose, reps, repspos, dclasses, lclasses, rclasses,
         d, f, g, i, j, k, m, n, p, r, s, slist, fposrepk, gposrepk,
@@ -772,6 +770,25 @@ function(S)
   return H;
 end);
 
+# Creates the ideal of the translational hull consisting of 
+# all inner bitranslations
+InstallMethod(InnerTranslationalHull, "for a semigroup",
+[IsSemigroup and IsFinite],
+function(S)
+  local I, H, L, R, l, r, s;
+  
+  I := [];
+  H := TranslationalHullSemigroup(S);
+  for s in S do
+    L := LeftTranslationsSemigroup(S);
+    R := RightTranslationsSemigroup(S);
+    l := LeftTranslation(L, MappingByFunction(S, S, x -> s * x));
+    r := RightTranslation(R, MappingByFunction(S, S, x -> x * s));
+    Add(I, TranslationalHullElement(H, l, r));
+  od;
+  return Monoid(I);
+end);
+
 # Creates a linked pair (l, r) from a left translation l and a right
 # translation r, as an element of a translational hull H.
 InstallGlobalFunction(TranslationalHullElement, 
@@ -1179,4 +1196,17 @@ InstallMethod(ChooseHashFunction, "for a translational hull element and int",
 function(x, hashlen)
   return rec(func := SEMIGROUPS.HashFunctionForTranslationalHullElements,
              data := hashlen);
+end);
+
+InstallMethod(OneOp, "for a translational hull",
+[IsTranslationalHullElement],
+function(h)
+  local H, L, R, S, l, r;
+  H := TranslationalHullOfFamily(FamilyObj(h));
+  S := UnderlyingSemigroup(H);
+  L := LeftTranslationsSemigroup(S);
+  R := RightTranslationsSemigroup(S);
+  l := LeftTranslation(L, MappingByFunction(S, S, x -> x));
+  r := RightTranslation(R, MappingByFunction(S, S, x -> x));
+  return TranslationalHullElement(H, l, r);
 end);

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -595,6 +595,22 @@ function(x, y)
   return x![1] < y![1];
 end);
 
+InstallMethod(\^, "for a semigroup element and a translation",
+[IsAssociativeElement, IsTranslationsSemigroupElement],
+function(x, t)
+  local list;
+  if IsLeftTranslationsSemigroupElement(t) then
+    list := AsList(UnderlyingSemigroup(LeftTranslationsSemigroupOfFamily(FamilyObj(t))));
+  else
+    list := AsList(UnderlyingSemigroup(RightTranslationsSemigroupOfFamily(FamilyObj(t))));
+  fi;
+  if not x in list then
+    Error("Semigroups: ^ for a semigroup element and translation: \n",
+          "the first argument must be an element of the domain of the second");
+  fi;
+  return list[Position(list, x)^t![1]];
+end);
+
 InstallMethod(\*, "for translation hull elements (linked pairs)",
 IsIdenticalObj,
 [IsTranslationalHullElement, IsTranslationalHullElement],
@@ -1003,16 +1019,22 @@ function(S)
   
   linkedpairfromfuncs := function(t1, t2, fx, fy)
     fl := function(x)
-      if x[1]^t1 <> nrrows + 1 then
-        return RMSElement(reesmatsemi, x[1]^t1, fx[x[1]] * x[2], x[3]);
+      if x = zero then
+        return zero;
+      fi;
+      if t1[x[1]] <> nrrows + 1 then
+        return RMSElement(reesmatsemi, t1[x[1]], fx[x[1]] * x[2], x[3]);
       else
         return zero;
       fi;
     end;
     
     fr := function(x)
-      if x[3]^t2 <> nrcols + 1 then
-        return RMSElement(reesmatsemi, x[1], x[2] * fy[x[3]], x[3]^t2);
+      if x = zero then
+        return zero;
+      fi;
+      if t2[x[3]] <> nrcols + 1 then
+        return RMSElement(reesmatsemi, x[1], x[2] * fy[x[3]], t2[x[3]]);
       else
         return zero;
       fi;
@@ -1038,8 +1060,8 @@ function(S)
       if not IsEmpty(transfuncs) then
         if not transfuncs[1] = 0 then
           for funcs in transfuncs do
-            fx := transfuncs[1];
-            fy := transfuncs[2];
+            fx := funcs[1];
+            fy := funcs[2];
             unboundpositions := [];
             for j in [1..Length(transfuncs[2])] do
               if not IsBound(transfuncs[2]) then 

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -7,7 +7,8 @@
 ##
 #############################################################################
 ##
-
+#TODO Translations semigroups can currently forget their generators
+#TODO SEMIGROUPS.TranslationalHullElements can be called again after Representative
 #############################################################################
 ## This file contains methods for dealing with left and right translation
 ## semigroups, as well as translational hulls. 
@@ -1101,7 +1102,6 @@ function(H)
   return Immutable(AsList(SEMIGROUPS.TranslationalHullElements(H)));
 end);
 
-#TODO: fix this so SEMIGROUPS.TranslationsSemigroupElements is not called later
 InstallMethod(Representative, "for a semigroup of left or right translations",
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
@@ -1111,7 +1111,6 @@ function(T)
   return Representative(SEMIGROUPS.TranslationsSemigroupElements(T));
 end);
 
-#TODO: fix this so SEMIGROUPS.TranslationalHullElements is not called later
 InstallMethod(Representative, "for a translational hull",
 [IsTranslationalHull and IsWholeFamily],
 function(H)

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -9,12 +9,18 @@
 ##
 # (a * b) f = (a) f * b
 
-#TODO: deal with infinite underlying semigroups
-
-
-InstallMethod(LeftTranslationsSemigroup, "for a semigroup", 
-[IsSemigroup], 
+InstallMethod(LeftTranslations, "for a semigroup", 
+[IsSemigroup and IsFinite], 
 function(S) 
+  local L;
+  
+  L := SEMIGROUPS.LeftTranslationsSemigroup(S);
+  TranslationalElements(L);
+  
+  return L;
+end);
+
+SEMIGROUPS.LeftTranslationsSemigroup := function(S)
   local fam, type, L;
   
   fam := NewFamily("LeftTranslationsSemigroupElementsFamily",
@@ -33,11 +39,9 @@ function(S)
   
   SetUnderlyingSemigroup(L, S);
   return L;
-end);
-
+end;
 
 InstallGlobalFunction(LeftTranslation,
-#why not filters? And should it be checked that this really is a translation?
 function(L, f)
   local semiList, mapAsTransList, i;
   if not (IsLeftTranslationsSemigroup(L)) then
@@ -52,20 +56,32 @@ function(L, f)
           "semigroup of the semigroup of left translations to itself");
   fi;
   
-  #TODO: this is a bit dodgy - what about infinite underlying semigroups?
   semiList:=AsList(UnderlyingSemigroup(L));
   mapAsTransList := [];
   for i in [1..Length(semiList)] do
     mapAsTransList[i] := Position(semiList, semiList[i]^f);
   od;
   
-  return Objectify(TypeLeftTranslationsSemigroupElements(L),             
-    [Transformation(mapAsTransList)]);
+  return LeftTranslationNC(L, Transformation(mapAsTransList));
 end);
 
-InstallMethod(RightTranslationsSemigroup, "for a semigroup", 
-[IsSemigroup], 
+InstallGlobalFunction(LeftTranslationNC,
+function(L, t)
+  return Objectify(TypeLeftTranslationsSemigroupElements(L), [t]);
+end);
+
+InstallMethod(RightTranslations, "for a semigroup", 
+[IsSemigroup and IsFinite], 
 function(S) 
+  local R;
+  
+  R := SEMIGROUPS.RightTranslationsSemigroup(S);
+  TranslationalElements(R);
+  
+  return R;
+end);
+
+SEMIGROUPS.RightTranslationsSemigroup := function(S)
   local fam, type, R;
   
   fam := NewFamily( "RightTranslationsSemigroupElementsFamily",
@@ -81,14 +97,12 @@ function(S)
   fam!.type := type;
   SetTypeRightTranslationsSemigroupElements(R, type);
   SetRightTranslationsSemigroupOfFamily(fam, R); 
-  
   SetUnderlyingSemigroup(R, S);
+  
   return R;
-end);
-
+end;
 
 InstallGlobalFunction(RightTranslation,
-#why not filters? And should it be checked that this really is a translation?
 function(R, f)
   local semiList, mapAsTransList, i;
   if not (IsRightTranslationsSemigroup(R)) then
@@ -102,20 +116,23 @@ function(R, f)
           "the second argument must be a function from the underlying ",
           "semigroup of the semigroup of left translations to itself");
   fi;
-  
-  #this is a bit dodgy
+
   semiList:=AsList(UnderlyingSemigroup(R));
   mapAsTransList := [];
   for i in [1..Length(semiList)] do
     mapAsTransList[i] := Position(semiList, semiList[i]^f);
   od;
   
-  return Objectify(TypeRightTranslationsSemigroupElements(R), 
-  [Transformation(mapAsTransList)]);
+  return RightTranslationNC(R, Transformation(mapAsTransList));
 end);
 
-InstallMethod(TranslationalHullSemigroup, "for a semigroup",
-[IsSemigroup],
+InstallGlobalFunction(RightTranslationNC,
+function(R, t)
+  return Objectify(TypeRightTranslationsSemigroupElements(R), [t]);
+end);
+
+InstallMethod(TranslationalHull, "for a semigroup",
+[IsSemigroup and IsFinite],
 function(S)
   local fam, type, H;
   
@@ -123,15 +140,16 @@ function(S)
           IsTranslationalHullElement);
   
   #create the translational hull
-   H := Objectify ( NewType ( CollectionsFamily( fam ), IsTranslationalHull and
-     IsWholeFamily and IsAttributeStoringRep ), rec() );
-   
-   type := NewType(fam, IsTranslationalHullElement);
-   
-   fam!.type := type;
-   SetTypeTranslationalHullElements(H, type);
-   SetTranslationalHullOfFamily(fam, H);
+  H := Objectify ( NewType ( CollectionsFamily( fam ), IsTranslationalHull and
+    IsWholeFamily and IsAttributeStoringRep ), rec() );
+  
+  type := NewType(fam, IsTranslationalHullElement);
+  
+  fam!.type := type;
+  SetTypeTranslationalHullElements(H, type);
+  SetTranslationalHullOfFamily(fam, H);
   SetUnderlyingSemigroup(H, S);
+  TranslationalElements(H);
   
   return H;
 end);
@@ -164,40 +182,15 @@ function(H, l, r)
   return Objectify(TypeTranslationalHullElements(H), [l, r]);
 end);
 
-
-InstallMethod(ViewObj, "for the semigroup of left or right translations of a rectangular band", 
-[IsTranslationsSemigroup and IsWholeFamily], 
-function(T)
-  local S;
-  S:=UnderlyingSemigroup(T);
-  if not IsRectangularBand(S) then 
-    TryNextMethod(); 
-  fi;
-  
-  Print("<the semigroup of");
-  if IsLeftTranslationsSemigroup(T) then Print(" left");
-  else Print(" right"); fi;
-  Print(" translations of a ", NrRClasses(S), "x", NrLClasses(S));
-  Print(" rectangular band>"); 
-
-end);
-
-InstallMethod(PrintObj, "for the semigroup of left or right translations of a rectangular band",
+InstallMethod(ViewObj, "for a semigroup of left or right translations",
 [IsTranslationsSemigroup and IsWholeFamily],
 function(T)
-  local S;
-  S:=UnderlyingSemigroup(T);
-  if not IsRectangularBand(S) then 
-    TryNextMethod();
-  fi;
-  
   Print("<the semigroup of");
   if IsLeftTranslationsSemigroup(T) then Print(" left");
   else Print(" right"); fi;
-  Print(" translations of ", S);
-  Print(">");
-  return;
+  Print(" translations of ", ViewString(UnderlyingSemigroup(T)), ">");
 end);
+  
 
 InstallMethod(ViewObj, "for a semigroup of translations", 
 [IsTranslationsSemigroup], PrintObj);
@@ -209,7 +202,7 @@ function(T)
   if IsLeftTranslationsSemigroup(T) then Print("left ");
   else Print("right ");
   fi;
-  Print("translations of ", UnderlyingSemigroup(T), " with ",
+  Print("translations of ", ViewString(UnderlyingSemigroup(T)), " with ",
     Length(GeneratorsOfSemigroup(T)),
     " generators");
   if Length(GeneratorsOfSemigroup(T)) > 1 then
@@ -258,8 +251,17 @@ function(t)
   Print("<linked pair of translations on ", ViewString(UnderlyingSemigroup(H)), ">");
 end);
 
+InstallMethod(Enumerator, "for a semigroup of left or right translations",
+[IsTranslationsSemigroup],
+function(T)
+  return Enumerator(TranslationalElements(T));
+end);
 
-#do I actually need to define Size/enumerator or will it inherit it from IsSemigroup?
+InstallMethod(Enumerator, "for a semigroup of translational hull elements",
+[IsTranslationalHull],
+function(H)
+  return Enumerator(TranslationalElements(H));
+end);
 
 InstallMethod(Size, "for the semigroup of left or right translations of a rectangular band", 
 [IsTranslationsSemigroup and IsWholeFamily],
@@ -277,132 +279,29 @@ function(T)
   return n^n;
 end);
 
-InstallMethod(Size, "for the semigroup of left or right translations of a completely 0-simple semigroup",
-[IsTranslationsSemigroup and IsWholeFamily],
-function(T)
-  local S, G, reesMatSemi, n;
-  S := UnderlyingSemigroup(T);
-  if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
-    TryNextMethod();
-  fi;
-  reesMatSemi := Range(IsomorphismReesZeroMatrixSemigroup(S));
-  G := UnderlyingSemigroup(reesMatSemi);
-  if IsLeftTranslationsSemigroup(T) then
-    n := Length(Rows(reesMatSemi));
-  else
-    n := Length(Columns(reesMatSemi));
-  fi;
-  return (n * Size(G) + 1)^n;
-end);
-
 InstallMethod(Size, "for the translational hull of a rectangular band",
 [IsTranslationalHull and IsWholeFamily],
 function(H)
   local S, L, R;
   S := UnderlyingSemigroup(H);
-  L := LeftTranslationsSemigroup(S);
-  R := RightTranslationsSemigroup(S);
-  return Size(L) * Size(R);
-end);
-  
-InstallMethod(Enumerator, "for the semigroup of left or right translations of a rectangular band", 
-[IsTranslationsSemigroup and IsWholeFamily],
-function(T)
-  local S, semiList, iso, inv, reesMatSemi, L, size, 
-    i, r, s, mapAsReesTransList, f;
-
-  if not IsRectangularBand(UnderlyingSemigroup(T)) then
-    TryNextMethod();
-  fi;
-  
-  S := UnderlyingSemigroup(T);
-  semiList := AsList(S);
-  iso := IsomorphismReesMatrixSemigroup(S);
-  inv := InverseGeneralMapping(iso);
-  reesMatSemi := Range(iso);
-  L := IsLeftTranslationsSemigroup(T);
-  if L then
-    size := Length(Rows(reesMatSemi));
-  else
-    size := Length(Columns(reesMatSemi));
-  fi;
-  
-  return EnumeratorByFunctions(T, rec(
-    enum := Enumerator(FullTransformationMonoid(size)),
-    
-    #TODO: find a better way of doing this - can probably use generators
-    NumberElement := function(enum, x)
-      mapAsReesTransList := [];
-      if L then
-        for i in [1..size] do
-          r := RMSElement(S, i, (), 1);
-          s := semiList[Position(semiList, (r^inv))^x![1]]^iso;
-          mapAsReesTransList[i] := s[1];
-        od;
-      else 
-        for i in [1..size] do
-          r := RMSElement(S, 1, (), i);
-          s := semiList[Position(semiList, (r^inv))^x![1]]^iso;
-          mapAsReesTransList[i] := s[3];
-        od;
-      fi;
-      return Position(enum!.enum, Transformation(mapAsReesTransList));
-    end,
-    
-    ElementNumber := function(enum, n)
-      if L then
-        f := function(x)
-          return ReesMatrixSemigroupElement(reesMatSemi, x[1]^enum!.enum[n], 
-            (), x[3]);
-        end;
-        return LeftTranslation(T, CompositionMapping(inv, 
-          MappingByFunction(reesMatSemi, reesMatSemi, f), iso));
-      else 
-        f := function(x)
-          return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-            (), x[3]^enum!.enum[n]);
-        end;
-        return RightTranslation(T, CompositionMapping(inv, 
-          MappingByFunction(reesMatSemi, reesMatSemi, f), iso));
-      fi;
-    end,
-    
-    Length := enum -> Length(enum!.enum),
-    
-    PrintObj := function(enum)
-      Print("<enumerator of translations of a rectangular band>");
-      return;
-    end));
-end); 
-
-InstallMethod(Enumerator, "for the translational hull of a rectangular band",
-[IsTranslationalHull], 
-function(H)
-  local S;
-  S := UnderlyingSemigroup(H);
   if not IsRectangularBand(S) then
     TryNextMethod();
   fi;
-  
-  return EnumeratorByFunctions(H, rec(
-    
-    enum:=EnumeratorOfCartesianProduct(Enumerator(LeftTranslationsSemigroup(S)),
-      Enumerator(RightTranslationsSemigroup(S))),
-      
-    NumberElement := function(enum, x)
-      return Position(enum!.enum, [x![1], x![2]]);
-    end,
-    
-    ElementNumber := function(enum, n)
-      return Objectify(TypeTranslationalHullElements(H), enum!.enum[n]);
-    end,
-    
-    Length := enum -> Length(enum!.enum),
-    
-    PrintObj := function(enum)
-      Print("<enumerator of translational hull>");
-      return;
-    end));
+  L := LeftTranslations(S);
+  R := RightTranslations(S);
+  return Size(L) * Size(R);
+end);
+
+InstallMethod(Size, "for the left/right translations of a semigroup",
+[IsTranslationsSemigroup and IsWholeFamily],
+function(T)
+  return Size(TranslationalElements(T));
+end);
+
+InstallMethod(Size, "for the translational hull of a semigroup",
+[IsTranslationalHull and IsWholeFamily],
+function(T)
+  return Size(TranslationalElements(T));
 end);
 
 InstallMethod(GeneratorsOfSemigroup, "for the semigroup of left or right translations of a rectangular band",
@@ -428,106 +327,23 @@ function(T)
   gens := [];
   for t in GeneratorsOfMonoid(FullTransformationMonoid(n)) do
     if L then
-        f := function(x)
-          return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
-            (), x[3]);
-        end;
-        Add(gens, LeftTranslation(T, CompositionMapping(inv, 
-        MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+      f := function(x)
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
+          (), x[3]);
+      end;
+      Add(gens, LeftTranslation(T, CompositionMapping(inv, 
+      MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
     else 
-        f := function(x)
-          return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-            (), x[3]^t);
-        end;
-        Add(gens, RightTranslation(T, CompositionMapping(inv, 
-          MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
+      f := function(x)
+        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+          (), x[3]^t);
+      end;
+      Add(gens, RightTranslation(T, CompositionMapping(inv, 
+        MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
     fi;
   od;
   return gens;
 end);      
-
-InstallMethod(GeneratorsOfSemigroup, "for the left/right translations of a finite 0-simple semigroup",
-[IsTranslationsSemigroup and IsWholeFamily],
-function(T)
-  local S, L, n, iso, inv, reesMatSemi, semiList, gens, t, f, groupGens,
-        e, a, fa, G, zero;
-        
-  S := UnderlyingSemigroup(T);
-  if not (IsZeroSimpleSemigroup(S) and IsFinite(S)) then
-    TryNextMethod();
-  fi;
-  
-  semiList := AsList(S);
-  iso := IsomorphismReesZeroMatrixSemigroup(S);
-  inv := InverseGeneralMapping(iso);
-  reesMatSemi := Range(iso);
-  zero := MultiplicativeZero(reesMatSemi);
-  L := IsLeftTranslationsSemigroup(T);
-  if L then
-    n := Length(Rows(reesMatSemi));
-  else
-    n := Length(Columns(reesMatSemi));
-  fi;
-  
-  gens := [];
-  G := UnderlyingSemigroup(reesMatSemi);
-  groupGens := GeneratorsOfGroup(G);
-  
-  for t in GeneratorsOfMonoid(PartialTransformationMonoid(n)) do
-    if L then
-      f := function(x)
-        if (x = zero or x[1]^t = n+1) then 
-          return zero;
-        fi;
-        return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
-            x[2], x[3]);
-      end;
-      Add(gens, LeftTranslation(T, CompositionMapping(
-        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-    else
-      f := function(x)
-        if (x = zero or x[3]^t = n+1) then 
-          return zero;
-        fi;
-        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-          x[2], x[3]^t); 
-      end;
-      Add(gens, RightTranslation(T, CompositionMapping(
-        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-    fi;
-  od;
-  
-  for a in groupGens do
-    fa := function(x)
-      if x = 1 then
-        return a;
-      fi; 
-      return MultiplicativeNeutralElement(G);
-    end;
-    if L then
-      f := function(x)
-        if x = zero then 
-          return zero;
-        fi;
-        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-            fa(x[1])*x[2], x[3]);
-      end;
-      Add(gens, LeftTranslation(T, CompositionMapping(
-        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-    else
-      f := function(x)
-        if x = zero then 
-          return zero;
-        fi;
-        return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
-          x[2]*fa(x[3]), x[3]); 
-      end;
-      Add(gens, RightTranslation(T, CompositionMapping(
-        inv, MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
-    fi;
-  od;
-  return gens;
-end);
 
 InstallMethod(GeneratorsOfSemigroup, "for the translational hull of a rectangular band", 
 [IsTranslationalHull],
@@ -539,8 +355,8 @@ function(H)
     TryNextMethod();
   fi;
 
-  leftGens := GeneratorsOfSemigroup(LeftTranslationsSemigroup(S));
-  rightGens := GeneratorsOfSemigroup(RightTranslationsSemigroup(S));
+  leftGens := GeneratorsOfSemigroup(LeftTranslations(S));
+  rightGens := GeneratorsOfSemigroup(RightTranslations(S));
   gens := [];
   
   for l in leftGens do
@@ -550,6 +366,24 @@ function(H)
   od;
   
   return gens;
+end);
+
+InstallMethod(TranslationalElements, "for the semigroup of left/right translations of a rectangular band",
+[IsTranslationsSemigroup and IsWholeFamily], 1,
+function(T)
+  if not IsRectangularBand(UnderlyingSemigroup(T)) then
+    TryNextMethod();
+  fi;
+  return Semigroup(GeneratorsOfSemigroup(T));
+end);
+
+InstallMethod(TranslationalElements, "for the translational hull of a rectangular band",
+[IsTranslationalHull and IsWholeFamily], 1,
+function(H)
+  if not IsRectangularBand(UnderlyingSemigroup(H)) then
+    TryNextMethod();
+  fi;
+  return Semigroup(GeneratorsOfSemigroup(H));
 end);
 
 
@@ -636,10 +470,10 @@ InstallMethod(IsWholeFamily, "for a semigroup of translations of a rectangular b
 [IsTranslationsSemigroup],
 function(T)
   if IsLeftTranslationsSemigroup(T) then  
-    return Size(T)=Size(LeftTranslationsSemigroupOfFamily(ElementsFamily(
-      FamilyObj(T))));
-  else return Size(T)=Size(RightTranslationsSemigroupOfFamily(ElementsFamily(
-      FamilyObj(T)))); 
+    return Size(T) = Size(LeftTranslationsSemigroupOfFamily(ElementsFamily(
+                                                                FamilyObj(T))));
+  else return Size(T) = Size(RightTranslationsSemigroupOfFamily(ElementsFamily(
+                                                                FamilyObj(T)))); 
   fi;
 end);
 
@@ -654,10 +488,10 @@ InstallMethod(UnderlyingSemigroup, "for a semigroup of left or right translation
 function(T)
   if IsLeftTranslationsSemigroup(T) then
     return UnderlyingSemigroup(LeftTranslationsSemigroupOfFamily(ElementsFamily(
-      FamilyObj(T))));
+                                                                FamilyObj(T))));
   else 
     return UnderlyingSemigroup(RightTranslationsSemigroupOfFamily(ElementsFamily(
-      FamilyObj(T))));
+                                                                FamilyObj(T))));
   fi;
 end);
 
@@ -680,438 +514,16 @@ function(x, hashlen)
              data := hashlen);
 end);
 
-#Finds the transformations on the indices of a completely 0-simple semigroup
-#which are candidates for translations, when combined with a function from
-#the index sets to the group.
-#TODO: swap rows/columns if more convenient.
-SEMIGROUPS.FindTranslationTransformations := function(S)
-  local iso, reesMatSemi, mat, simpleRows, simpleColumns, nrRows, nrCols,
-    transList, partColumns, partColumn, pc, linkedTransList, col, cols, 
-    possibleCols, t, q, w, c, x, k, v, f, i, j,
-    isPartialSuccess, extend, reject, bt;
-  iso := IsomorphismReesZeroMatrixSemigroup(S);
-  reesMatSemi := Range(iso);
-  mat := Matrix(reesMatSemi);
-  simpleRows := List(mat, ShallowCopy);
-  nrRows := Length(simpleRows);
-  nrCols := Length(simpleRows[1]);
-  transList := [];
-  for i in [1..Length(simpleRows)] do
-    for j in [1..Length(simpleRows[i])] do
-      if simpleRows[i][j] <> 0 then
-        simpleRows[i][j] := 1;
-      fi;
-    od;
-  od;
-  #TODO: just use transpose
-  simpleColumns := [];
-  for i in [1..Length(simpleRows[1])] do
-    c := [];
-    for j in [1..Length(simpleRows)] do
-      c[j] := simpleRows[j][i];
-    od;
-    Add(simpleColumns, c);
-  od;
+InstallMethod(LeftTranslations, "for the left translations of a semigroup with known generators",
+[IsLeftTranslationsSemigroup and IsWholeFamily],
+function(L)
+  local S, digraph, n, nrgens, out, colors, gens, i, j;
   
-  #TODO: keep track of the partial columns in the extend/reject functions
-  isPartialSuccess := function(x)
-    partColumns := [];
-    for i in [1..Length(simpleRows[1])] do
-      partColumn := [];
-      for j in [1..Length(x)] do
-        if x[j] = nrRows + 1 then
-          #treat rows not in the domain like a row of zeros
-          partColumn[j] := 0;
-        else
-          partColumn[j] := simpleRows[x[j]][i];
-        fi;
-      od;
-      Add(partColumns, partColumn);
-    od;
-    
-    for pc in partColumns do
-      #only check the columns which contain a 1
-      #all-zero column can be made by column not in domain of transformation
-      #no ones in one partial matrix but not in the other...
-      if 1 in pc and ForAll(simpleColumns, c -> 1 in c{[1..Length(pc)]} + pc) then
-        return false;
-      fi;
-    od;
-    return true;
-  end;
-  
-  extend := function(w)
-    Add(w, 1);
-    return w;
-  end;
-  
-  reject := function(q)
-    q := ShallowCopy(q);
-    k := Length(q);
-    if q[k] <= nrRows then
-      q[k] := q[k] + 1;
-    elif k > 1 then
-      q := reject(q{[1..k-1]});
-    else return 0;
-    fi;
-    return q;
-  end;
-  
-  bt := function(x)
-    if x = 0 then
-      return 0;
-    fi;
-    if not isPartialSuccess(x) then
-      x := reject(x);  
-    elif Length(x) = nrRows then
-      return x;
-    else 
-      x := extend(x);
-    fi;
-    return bt(x);
-  end;
-  
-  v := 1;
-  transList := [bt([1])];
-  while transList[v] <> 0 do
-    v := v + 1;
-    transList[v] := bt(reject(transList[v-1]));
-  od;
-  
-  linkedTransList := [];
-  #last element of transList will be 0, ignore
-  for k in [1..Length(transList) - 1] do
-    t := transList[k];
-    cols := [];
-    for i in [1..Length(simpleRows[1])] do
-      col := [];
-      for j in [1..nrRows] do
-        if t[j] = nrRows + 1 then
-          col[j] := 0;
-        else 
-          col[j] := simpleRows[t[j]][i];
-        fi;
-      od;
-      Add(cols, col);
-    od;
-    possibleCols := [];
-    for i in [1..nrCols] do
-      possibleCols[i] := [];
-      for j in [1..nrCols] do  
-        if not 1 in cols[i] + simpleColumns[j] then
-          Add(possibleCols[i], j);
-        fi;
-        if not 1 in cols[i] then 
-          Add(possibleCols[i], nrCols+1);
-        fi;
-      od;
-    od;
-    linkedTransList[k] := IteratorOfCartesianProduct(possibleCols);
-  od;
-  
-  return [transList{[1..Length(transList) - 1]}, linkedTransList];
-end;
-
-#TODO: sort out where the failedComponents is going
-#For a pair of transformations on the indices of a completely 0-simple semigroup
-#determine the functions to the group associated with the RMS representation
-#which will form translations when combined with the transformations
-SEMIGROUPS.FindTranslationFunctionsToGroup := function(S, t1, t2, failedcomponents)
-  local reesmatsemi, mat, gplist, gpsize, nrrows, nrcols, invmat,
-        rowtransformedmat, zerorow, zerocol, pos, satisfied,
-        rels, edges, rowrels, relpoints, rel, i, j, k, l, x, y, r, n, q, c,
-        funcs, digraph, cc, comp, iterator, foundfuncs, failedcomps, vals,
-        failedtocomplete, relpointvals,
-        relssatisfied, funcsfromrelpointvals, fillin;
-  reesmatsemi := Range(IsomorphismReesZeroMatrixSemigroup(S));
-  mat := Matrix(reesmatsemi);
-  gplist := AsList(UnderlyingSemigroup(reesmatsemi));
-  gpsize := Size(gplist);
-  nrrows := Length(mat);
-  nrcols := Length(mat[1]);
-  invmat := List(mat, ShallowCopy);
-  for i in [1..nrrows] do
-    for j in [1..nrcols] do
-      invmat[i][j] := Inverse(invmat[i][j]);
-    od;
-  od; 
-  rowtransformedmat := [];
-  zerorow := [];
-  zerocol := [];
-  for i in [1..nrcols] do
-    zerorow[i] := 0;
-  od;
-  for i in [1..nrrows] do
-    zerocol[i] := 0;
-  od;
-  for i in [1..nrrows] do
-    if t1[i] <> nrrows + 1 then 
-      rowtransformedmat[i] := mat[t1[i]];
-    else
-      rowtransformedmat[i] := zerorow;
-    fi;
-  od;
-
-  #for ease of checking the constraints, set up lists of linked indices
-  rels := [];
-  for i in [1..nrrows] do
-    for j in [1..nrcols] do
-      if rowtransformedmat[i][j] <> 0 then
-        Add(rels, [i,j]);
-      fi;
-    od;
-  od;
-  rowrels := [];
-  for i in [1..nrrows] do
-    rowrels[i] := [];
-    for j in [1..nrrows] do
-      for k in [1..nrcols] do
-        if [i,k] in rels and [j,k] in rels then
-          rowrels[i][j] := k;
-          break;
-        fi;
-      od;
-    od;
-  od;
-  
-  #get connected components
-  edges := List(rels, r -> [r[1], r[2] + nrrows]);
-  digraph := DigraphByEdges(edges, nrrows + nrcols);
-  cc := DigraphConnectedComponents(digraph);
-  
-  #only deal with enough elements to hit each relation
-  #TODO: check safe to assume components ordered?
-  relpoints := [];
-  for i in cc.comps do
-    if Length(i) > 1 then 
-      Add(relpoints, i[1]);
-    fi;
-  od;
-  
-  #check whether these connected components have already been found to fail
-  for i in [1..Length(failedcomponents)] do
-    for j in [1..Length(failedcomponents[i][1])] do
-      c := failedcomponents[i][1][j];
-      if ForAny(cc.comps, comp -> IsSubset(comp, c)) then
-        vals := [[],[]];
-        for k in c do
-          if k <= nrrows then
-            Add(vals[1], k);
-          else
-            Add(vals[2], k - nrrows);
-          fi;
-        od;
-        if t1{vals[1]} = failedcomponents[i][2]{vals[1]} 
-          and t2{vals[2]} = failedcomponents[i][3]{vals[2]} then
-          return [];
-        fi;
-      fi;
-    od;
-  od;
-  
-  #given a choice of relpoints, fill in everything else possible
-  fillin := function(funcs)
-    x := ShallowCopy(funcs[1]);
-    y := ShallowCopy(funcs[2]);
-    for r in relpoints do
-      comp := cc.comps[cc.id[r]];
-      failedtocomplete := false;
-      for n in [2..Length(comp)] do
-        j := comp[n];
-        if j <= nrrows then
-          for q in comp do
-            if IsBound(rowrels[q][j]) and not IsBound(x[j]) then
-              k := rowrels[q][j];
-              x[j] := mat[j][t2[k]] * invmat[q][t2[k]] * x[q] *
-                      rowtransformedmat[q][k] * invmat[t1[j]][k];
-              break;
-            fi;
-          od;
-        if not IsBound(x[j]) then
-          failedtocomplete := true;
-        fi;
-        else
-          j := j - nrrows;
-          if not IsBound(y[j]) then
-            for rel in rels do
-              if rel[1] in comp and rel[2] = j then
-                i := rel[1];
-                y[j] := invmat[i][t2[j]] * x[i] * rowtransformedmat[i][j];
-                break;
-              fi;
-            od;
-          fi;
-        fi;
-      od;
-      if failedtocomplete then
-        funcs := fillin([x,y]);
-        x := funcs[1];
-        y := funcs[2];
-      fi;
-    od;
-    return [x,y];
-  end;
-  
-  relssatisfied := function(funcs)
-    failedcomps := [];
-    satisfied := true;
-    x := funcs[1];
-    y := funcs[2];
-    for rel in rels do
-      i := rel[1];
-      j := rel[2];
-      if IsBound(x[i]) and IsBound(y[j]) and not 
-          x[i] * rowtransformedmat[i][j] = mat[i][t2[j]] * y[j] then
-          Add(failedcomps, cc.comps[cc.id[i]]);
-          satisfied := false;
-      fi;
-    od;
-    return satisfied;
-  end;
-  
-  funcsfromrelpointvals := function(relpointvals)
-    x := [1..nrrows];
-    y := [1..nrcols];
-    
-    for i in [1..nrrows] do
-      Unbind(x[i]);
-    od;
-    for i in [1..nrcols] do
-      Unbind(y[i]);
-    od;
-    for i in [1..Length(relpoints)] do
-      x[relpoints[i]] := gplist[relpointvals[i]];
-    od;
-    return fillin([x,y]);
-  end;
-  
-  foundfuncs := [];
-  iterator := IteratorOfCartesianProduct(List(relpoints, i -> [1..gpsize]));
-  
-  #TODO: prove you only need to check the relations once
-  #for all choices of x{relpoints}
-  #i.e., the only possible problem is an inconsistency 
-  #which if it exists will always occur
-  
-  if IsDoneIterator(iterator) then
-    return [];
-  else
-    funcs := funcsfromrelpointvals(NextIterator(iterator));
-    if not relssatisfied(funcs) then
-      return [0, Set(failedcomps), t1, t2];
-    fi;
-    Add(foundfuncs, funcs);
+  S := UnderlyingSemigroup(L);
+  if not HasGeneratorsOfSemigroup(S) then
+    TryNextMethod();
   fi;
   
-  while not IsDoneIterator(iterator) do
-    Add(foundfuncs, funcsfromrelpointvals(NextIterator(iterator)));
-  od;
-  
-  return foundfuncs;
-end;
-
-InstallMethod(TranslationalHull, "for a finite 0-simple semigroup",
-[IsFinite and IsZeroSimpleSemigroup],
-function(S)
-  local tt, failedcomponents, iterator, transfuncs, unboundpositions, gplist,
-        L, R, H, linkedpairs, i, j, c, linkedpairfromfuncs, iso, inv, nrrows,
-        nrcols, reesmatsemi, zero, fl, fr, l, r, t1, t2, funcs, fx, fy,
-        partialfunciterator, funcvals;
-  
-  iso := IsomorphismReesZeroMatrixSemigroup(S);
-  inv := InverseGeneralMapping(iso);
-  reesmatsemi := Range(iso);
-  gplist := AsList(UnderlyingSemigroup(reesmatsemi));
-  nrrows := Length(Matrix(reesmatsemi));
-  nrcols := Length(Matrix(reesmatsemi)[1]);
-  zero := MultiplicativeZero(reesmatsemi);
-  L := LeftTranslationsSemigroup(S);
-  R := RightTranslationsSemigroup(S);
-  H := TranslationalHullSemigroup(S);
-  tt := SEMIGROUPS.FindTranslationTransformations(S);
-  failedcomponents := [];
-  linkedpairs := [];
-  
-  linkedpairfromfuncs := function(t1, t2, fx, fy)
-    fl := function(x)
-      if x = zero then
-        return zero;
-      fi;
-      if t2[x[1]] <> nrcols + 1 then
-        return RMSElement(reesmatsemi, t2[x[1]], fy[x[1]] * x[2], x[3]);
-      else
-        return zero;
-      fi;
-    end;
-    
-    fr := function(x)
-      if x = zero then
-        return zero;
-      fi;
-      if t1[x[3]] <> nrrows + 1 then
-        return RMSElement(reesmatsemi, x[1], x[2] * fx[x[3]], t1[x[3]]);
-      else
-        return zero;
-      fi;
-    end;
-    
-    l := LeftTranslation(L, CompositionMapping(inv, MappingByFunction(
-      reesmatsemi, reesmatsemi, fl), iso));
-    
-    r := RightTranslation(R, CompositionMapping(inv, MappingByFunction(
-      reesmatsemi, reesmatsemi, fr), iso));
-    
-    return TranslationalHullElement(H, l, r);
-  end;
-  
-  
-  for i in [1..Length(tt[1])] do
-    t1 := tt[1][i];
-    iterator := tt[2][i];
-    while not IsDoneIterator(iterator) do
-      t2 := NextIterator(iterator);
-      transfuncs := SEMIGROUPS.FindTranslationFunctionsToGroup(S, t1, t2, 
-                                                              failedcomponents);
-      if not IsEmpty(transfuncs) then
-        if not transfuncs[1] = 0 then
-          for funcs in transfuncs do
-            fx := funcs[1];
-            fy := funcs[2];
-            unboundpositions := [];
-            for j in [1..nrcols] do
-              if not IsBound(fy[j]) then 
-                Add(unboundpositions, j);
-              fi;
-            od;
-            if Length(unboundpositions) > 0 then
-              c := List([1..Length(unboundpositions)], i -> [1..Length(gplist)]);
-              partialfunciterator := IteratorOfCartesianProduct(c);
-              while not IsDoneIterator(partialfunciterator) do
-                funcvals := NextIterator(partialfunciterator);
-                for j in [1..Length(unboundpositions)] do
-                  fy[unboundpositions[j]] := gplist[funcvals[j]];
-                od;
-                Add(linkedpairs, linkedpairfromfuncs(t1, t2, fx, fy));
-              od;
-            else
-              Add(linkedpairs, linkedpairfromfuncs(t1, t2, fx, fy));
-            fi;
-          od;
-        else
-          Add(failedcomponents, transfuncs{[2,3,4]}); 
-        fi;
-      fi;
-    od;
-  od;
-  
-  return Set(linkedpairs);
-end);
-
-InstallMethod(LeftTranslations, "for a semigroup with known generators",
-[IsSemigroup and HasGeneratorsOfSemigroup],
-function(S)
-  local digraph, n, nrgens, out, colors, gens, i, j;
-
   digraph := RightCayleyGraphSemigroup(S);
   n       := Length(digraph);
   nrgens  := Length(digraph[1]);
@@ -1128,15 +540,20 @@ function(S)
     od;
   od;
   gens := GeneratorsOfEndomorphismMonoid(Digraph(out), colors);
-  Apply(gens, x -> RestrictedTransformation(x, [1 .. n]));
+  Apply(gens, x -> LeftTranslationNC(L, RestrictedTransformation(x, [1 .. n])));
   return Semigroup(gens, rec(small := true));
 end);
 
-InstallMethod(RightTranslations, "for a semigroup with known generators",
-[IsSemigroup and HasGeneratorsOfSemigroup],
-function(S)
-  local digraph, n, nrgens, out, colors, gens, i, j;
+InstallMethod(TranslationalElements, "for the right translations of a semigroup with known generators",
+[IsRightTranslationsSemigroup and IsWholeFamily],
+function(R)
+  local S, digraph, n, nrgens, out, colors, gens, i, j;
 
+  S       := UnderlyingSemigroup(R);
+  if not HasGeneratorsOfSemigroup(S) then
+    TryNextMethod();
+  fi;
+  
   digraph := LeftCayleyGraphSemigroup(S);
   n       := Length(digraph);
   nrgens  := Length(digraph[1]);
@@ -1153,6 +570,6 @@ function(S)
     od;
   od;
   gens := GeneratorsOfEndomorphismMonoid(Digraph(out), colors);
-  Apply(gens, x -> RestrictedTransformation(x, [1 .. n]));
+  Apply(gens, x -> RightTranslationNC(R,RestrictedTransformation(x, [1 .. n])));
   return Semigroup(gens, rec(small := true));
 end);

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -999,7 +999,7 @@ end;
 InstallMethod(TranslationalHull, "for a finite 0-simple semigroup",
 [IsFinite and IsZeroSimpleSemigroup],
 function(S)
-  local tt, failedcomponents, iterator, transfuncs, unboundpositions,
+  local tt, failedcomponents, iterator, transfuncs, unboundpositions, gplist,
         L, R, H, linkedpairs, i, j, c, linkedpairfromfuncs, iso, inv, nrrows,
         nrcols, reesmatsemi, zero, fl, fr, l, r, t1, t2, funcs, fx, fy,
         partialfunciterator, funcvals;
@@ -1007,6 +1007,7 @@ function(S)
   iso := IsomorphismReesZeroMatrixSemigroup(S);
   inv := InverseGeneralMapping(iso);
   reesmatsemi := Range(iso);
+  gplist := AsList(UnderlyingSemigroup(reesmatsemi));
   nrrows := Length(Matrix(reesmatsemi));
   nrcols := Length(Matrix(reesmatsemi)[1]);
   zero := MultiplicativeZero(reesmatsemi);
@@ -1063,18 +1064,18 @@ function(S)
             fx := funcs[1];
             fy := funcs[2];
             unboundpositions := [];
-            for j in [1..Length(transfuncs[2])] do
-              if not IsBound(transfuncs[2]) then 
-                Add(unboundpositions, i);
+            for j in [1..Length(fy)] do
+              if not IsBound(fy[j]) then 
+                Add(unboundpositions, j);
               fi;
             od;
-            if Length(unboundpositions) > 0 then 
-              c := List([1..Length(unboundpositions)], i -> [1..Length(fy)]);
+            if Length(unboundpositions) > 0 then
+              c := List([1..Length(unboundpositions)], i -> [1..Length(gplist)]);
               partialfunciterator := IteratorOfCartesianProduct(c);
               while not IsDoneIterator(partialfunciterator) do
                 funcvals := NextIterator(partialfunciterator);
                 for j in [1..Length(unboundpositions)] do
-                  fy[unboundpositions[j]] := funcvals[j];
+                  fy[unboundpositions[j]] := gplist[funcvals[j]];
                 od;
                 Add(linkedpairs, linkedpairfromfuncs(t1, t2, fx, fy));
               od;

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -9,12 +9,441 @@
 ##
 # (a * b) f = (a) f * b
 
-InstallMethod(TranslationalHull, "for a rectangular band",
+InstallMethod(LeftTranslationsSemigroup, "for a rectangular band", 
+[IsRectangularBand], 
+function(S) 
+	local fam, type, L;
+	
+	fam := NewFamily( "LeftTranslationsSemigroupElementsFamily",
+					IsTranslationsSemigroupElement);
+	
+	#create the semigroup of left translations
+	L := Objectify(NewType(CollectionsFamily(fam), IsLeftTranslationsSemigroup
+	 and IsWholeFamily and IsAttributeStoringRep), rec());
+		
+	#store the type of the elements in the semigroup
+	type := NewType(fam, IsLeftTranslationsSemigroupElement);
+	
+	fam!.type := type;
+	SetTypeLeftTranslationsSemigroupElements(L, type);
+	SetLeftTranslationsSemigroupOfFamily(fam, L); 
+	
+	SetUnderlyingSemigroup(L, S);
+	return L;
+end);
+
+InstallGlobalFunction(LeftTranslation,
+#why not filters? And should it be checked that this really is a translation?
+function(L, f)
+	local semiList, mapAsTransList, i;
+	if not (IsLeftTranslationsSemigroup(L)) then
+		Error("usage: the first argument must be a semigroup of left translations");
+		return;
+	fi;
+	
+	if not (UnderlyingSemigroup(L) = Source(f) and Source(f) = Range(f)) then
+		Error("usage: the second argument must be a function from the underlying ",
+		 "semigroup of the semigroup of left translations to itself");
+	fi;
+	
+	#this is a bit dodgy
+	semiList:=AsList(UnderlyingSemigroup(L));
+	mapAsTransList := [];
+	for i in [1..Length(semiList)] do
+		mapAsTransList[i] := Position(semiList, semiList[i]^f);
+	od;
+	
+	return Objectify(TypeLeftTranslationsSemigroupElements(L), 						
+		[Transformation(mapAsTransList)]);
+end);
+
+InstallMethod(RightTranslationsSemigroup, "for a rectangular band", 
+[IsRectangularBand], 
+function(S) 
+	local fam, type, R;
+	
+	fam := NewFamily( "RightTranslationsSemigroupElementsFamily",
+					IsTranslationsSemigroupElement);
+	
+	#create the semigroup of right translations
+	R := Objectify(NewType(CollectionsFamily(fam), IsRightTranslationsSemigroup 
+		and IsWholeFamily and IsAttributeStoringRep ), rec() );
+		
+	#store the type of the elements in the semigroup
+	type := NewType(fam, IsRightTranslationsSemigroupElement);
+	
+	fam!.type := type;
+	SetTypeRightTranslationsSemigroupElements(R, type);
+	SetRightTranslationsSemigroupOfFamily(fam, R); 
+	
+	SetUnderlyingSemigroup(R, S);
+	return R;
+end);
+
+InstallGlobalFunction(RightTranslation,
+#why not filters? And should it be checked that this really is a translation?
+function(R, f)
+	local semiList, mapAsTransList, i;
+	if not (IsRightTranslationsSemigroup(R)) then
+		Error("usage: the first argument must be a semigroup of right translations");
+		return;
+	fi;
+	
+	if not (UnderlyingSemigroup(R) = Source(f) and Source(f) = Range(f)) then
+		Error("usage: the second argument must be a function from the underlying semigroup",
+		" of the semigroup of right translations to itself");
+	fi;
+	
+	#this is a bit dodgy
+	semiList:=AsList(UnderlyingSemigroup(R));
+	mapAsTransList := [];
+	for i in [1..Length(semiList)] do
+		mapAsTransList[i] := Position(semiList, semiList[i]^f);
+	od;
+	
+	return Objectify(TypeRightTranslationsSemigroupElements(R), 
+	[Transformation(mapAsTransList)]);
+end);
+
+InstallMethod(TranslationalHull, "for a semigroup",
+[IsSemigroup],
+function(S)
+	local fam, type, H;
+	
+	fam := NewFamily( "TranslationalHullElementsFamily", 
+					IsTranslationalHullElement);
+	
+	#create the translational hull
+ 	H := Objectify ( NewType ( CollectionsFamily( fam ), IsTranslationalHull and
+ 		IsWholeFamily and IsAttributeStoringRep ), rec() );
+ 	
+ 	type := NewType(fam, IsTranslationalHullElement);
+ 	
+ 	fam!.type := type;
+ 	SetTypeTranslationalHullElements(H, type);
+ 	SetTranslationalHullOfFamily(fam, H);
+	SetUnderlyingSemigroup(H, S);
+	
+	return H;
+end);
+
+InstallGlobalFunction(TranslationalHullElement, 
+function(H, l, r) 
+	local S, L, R;
+	
+	if not IsTranslationalHull(H) then 
+		Error("usage: the first argument must be a translational hull");
+	fi;
+	
+	if not (IsLeftTranslationsSemigroupElement(l) and 
+						IsRightTranslationsSemigroupElement(r)) then
+		Error("usage: the second argument must be a left translation",
+			" and the third argument must be a right translation");
+		return;
+	fi;
+	
+	L := LeftTranslationsSemigroupOfFamily(FamilyObj(l));
+	R := RightTranslationsSemigroupOfFamily(FamilyObj(r));
+	
+	if not UnderlyingSemigroup(L) = UnderlyingSemigroup(R) then
+			Error("usage: each argument must have the same underlying semigroup");
+	fi;
+	
+	return Objectify(TypeTranslationalHullElements(H), [l, r]);
+end);
+
+
+InstallMethod(ViewObj, "for the semigroup of left or right translations of a rectangular band", 
+	[IsWholeTranslationsSemigroup], 
+function(T)
+	local S;
+	S:=UnderlyingSemigroup(T);
+	if not IsRectangularBand(S) then 
+		TryNextMethod(); 
+	fi;
+	
+	Print("<the semigroup of");
+	if IsLeftTranslationsSemigroup(T) then Print(" left");
+	else Print(" right"); fi;
+	Print(" translations of a ", NrRClasses(S), "x", NrLClasses(S));
+	Print(" rectangular band>"); 
+
+end);
+
+InstallMethod(PrintObj, "for the semigroup of left or right translations of a rectangular band",
+	[IsWholeTranslationsSemigroup],
+function(T)
+	local S;
+	S:=UnderlyingSemigroup(T);
+	if not IsRectangularBand(S) then 
+		TryNextMethod();
+  fi;
+	
+	Print("<the semigroup of");
+	if IsLeftTranslationsSemigroup(T) then Print(" left");
+	else Print(" right"); fi;
+	Print(" translations of ", S);
+	Print(">");
+	return;
+end);
+
+InstallMethod(ViewObj, "for a semigroup of left translations", 
+	[IsLeftTranslationsSemigroup], PrintObj);
+
+InstallMethod(PrintObj, "for a semigroup of left translations",
+	[IsLeftTranslationsSemigroup and HasGeneratorsOfSemigroup],
+function(L)
+	Print("<semigroup of left translations of ", 
+		UnderlyingSemigroup(L), " with ",
+		Length(GeneratorsOfSemigroup(L)),
+		" generators");
+	if Length(GeneratorsOfSemigroup(L)) > 1 then
+		Print("s");
+	fi;
+	Print(">");
+	return;
+end);
+
+InstallMethod(ViewObj, "for a translation", 
+[IsTranslationsSemigroupElement], PrintObj);
+
+InstallMethod(PrintObj, "for a translation",
+[IsTranslationsSemigroupElement],
+function(t)
+	local L, S;
+	L := IsLeftTranslationsSemigroupElement(t); 
+	if L then 
+		S := UnderlyingSemigroup(LeftTranslationsSemigroupOfFamily(FamilyObj(t)));
+		Print("<left ");
+	else 
+		S := UnderlyingSemigroup(RightTranslationsSemigroupOfFamily(FamilyObj(t)));
+		Print("<right ");
+	fi;
+	
+	Print("translation on ", S, ">");
+end);
+
+InstallMethod(ViewObj, "for a translational hull", 
+[IsTranslationalHull], PrintObj);
+
+InstallMethod(PrintObj, "for a translational hull",
+[IsTranslationalHull],
+function(H)
+	Print("<translational hull over ", UnderlyingSemigroup(H), ">");
+end);
+
+InstallMethod(ViewObj, "for a translational hull element", 
+[IsTranslationalHullElement], PrintObj);
+
+InstallMethod(PrintObj, "for a translational hull element",
+[IsTranslationalHullElement],
+function(t)
+	local H;
+	H := TranslationalHullOfFamily(FamilyObj(t));
+	Print("<linked pair of translations on ", UnderlyingSemigroup(H), ">");
+end);
+
+
+#do I actually need to define Size/enumerator or will it inherit it from IsSemigroup?
+
+InstallMethod(Size, "for the semigroup of left or right translations of a rectangular band", 
+[IsWholeTranslationsSemigroup],
+function(T)
+	local S, n;
+	S := UnderlyingSemigroup(T);
+	if not IsRectangularBand(S) then
+		TryNextMethod();
+	fi;
+	if IsLeftTranslationsSemigroup(T) then
+		n := NrRClasses(S);
+	else n := NrLClasses(S);
+	fi;
+	
+	return n^n;
+end);
+
+InstallMethod(Size, "for the translational hull of a rectangular band",
+[IsTranslationalHull],
+function(H)
+	local S, L, R;
+	S := UnderlyingSemigroup(H);
+	L := LeftTranslationsSemigroup(S);
+	R := RightTranslationsSemigroup(S);
+	return Size(L) * Size(R);
+end);
+	
+InstallMethod(Enumerator, "for the semigroup of left or right translations of a rectangular band", 
+[IsWholeTranslationsSemigroup],
+function(T)
+	local S, semiList, iso, inv, reesMatSemi, L, size, 
+		i, r, s, mapAsReesTransList, f;
+
+	if not IsRectangularBand(UnderlyingSemigroup(T)) then
+		TryNextMethod();
+	fi;
+	
+	S := UnderlyingSemigroup(T);
+	semiList := AsList(S);
+	iso := IsomorphismReesMatrixSemigroup(S);
+	inv := InverseGeneralMapping(iso);
+	reesMatSemi := Range(iso);
+	L := IsLeftTranslationsSemigroup(T);
+	if L then
+		size := Length(Rows(reesMatSemi));
+	else
+		size := Length(Columns(reesMatSemi));
+	fi;
+	
+	return EnumeratorByFunctions(T, rec(
+		enum := Enumerator(FullTransformationMonoid(size)),
+		
+		#TODO: find a better way of doing this
+		NumberElement := function(enum, x)
+			mapAsReesTransList := [];
+			if L then
+				for i in [1..size] do
+					r := RMSElement(S, i, (), 1);
+					s := semiList[Position(semiList, (r^inv))^x![1]]^iso;
+					mapAsReesTransList[i] := s[1];
+				od;
+			else 
+				for i in [1..size] do
+					r := RMSElement(S, 1, (), i);
+					s := semiList[Position(semiList, (r^inv))^x![1]]^iso;
+					mapAsReesTransList[i] := s[3];
+				od;
+			fi;
+			return Position(enum!.enum, Transformation(mapAsReesTransList));
+		end,
+		
+		ElementNumber := function(enum, n)
+			if L then
+				f := function(x)
+					return ReesMatrixSemigroupElement(reesMatSemi, x[1]^enum!.enum[n], 
+						(), x[3]);
+				end;
+				return LeftTranslation(T, CompositionMapping(InverseGeneralMapping(iso), 
+					MappingByFunction(reesMatSemi, reesMatSemi, f), iso));
+			else 
+				f := function(x)
+					return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
+						(), x[3]^enum!.enum[n]);
+				end;
+				return RightTranslation(T, CompositionMapping(InverseGeneralMapping(iso), 
+					MappingByFunction(reesMatSemi, reesMatSemi, f), iso));
+			fi;
+		end,
+		
+		Length := enum -> Length(enum!.enum),
+		
+		PrintObj := function(enum)
+			Print("<enumerator of translations of a rectangular band>");
+			return;
+		end));
+end); 
+
+InstallMethod(Enumerator, "for the translational hull of a rectangular band",
+[IsTranslationalHull], 
+function(H)
+	local S;
+	S := UnderlyingSemigroup(H);
+	if not IsRectangularBand(S) then
+		TryNextMethod();
+	fi;
+	
+	return EnumeratorByFunctions(H, rec(
+		
+		enum:=EnumeratorOfCartesianProduct(Enumerator(LeftTranslationsSemigroup(S)),
+			Enumerator(RightTranslationsSemigroup(S))),
+			
+		NumberElement := function(enum, x)
+			return Position(enum!.enum, [x![1], x![2]]);
+		end,
+		
+		ElementNumber := function(enum, n)
+			return Objectify(TypeTranslationalHullElements(H), enum!.enum[n]);
+		end,
+		
+		Length := enum -> Length(enum!.enum),
+		
+		PrintObj := function(enum)
+			Print("<enumerator of translational hull>");
+			return;
+		end));
+end);
+
+
+InstallMethod(\*, "for translations of a semigroup",
+IsIdenticalObj,
+[IsTranslationsSemigroupElement, IsTranslationsSemigroupElement],
+function(x, y)
+	return Objectify(FamilyObj(x)!.type, [x![1]*y![1]]);
+end);
+
+InstallMethod(\=, "for translations of a semigroup",
+IsIdenticalObj,
+[IsTranslationsSemigroupElement, IsTranslationsSemigroupElement],
+function(x, y) 
+	return x![1] = y![1];
+end);
+
+InstallMethod(\<, "for translations of a semigroup",
+IsIdenticalObj,
+[IsTranslationsSemigroupElement, IsTranslationsSemigroupElement],
+function(x, y) 
+	return x![1] < y![1];
+end);
+
+InstallMethod(\*, "for translation hull elements (linked pairs)",
+IsIdenticalObj,
+[IsTranslationalHullElement, IsTranslationalHullElement],
+function(x, y)
+	return Objectify(FamilyObj(x)!.type, [x![1]*y![1], x![2]*y![2]]);
+end);
+
+InstallMethod(\=, "for translational hull elements (linked pairs)",
+IsIdenticalObj,
+[IsTranslationalHullElement, IsTranslationalHullElement],
+function(x, y)
+	return x![1] = y![1] and x![2] = y![2];
+end);
+
+InstallMethod(\<, "for translational hull elements (linked pairs)",
+IsIdenticalObj,
+[IsTranslationalHullElement, IsTranslationalHullElement],
+function(x, y)
+	return x![1] < y![1] or (x![1] = y![1] and x![2] < y![2]);
+end);
+
+InstallMethod(IsWholeFamily, "for a semigroup of translations of a rectangular band",
+[IsTranslationsSemigroup],
+function(T)
+	if IsLeftTranslationsSemigroup(T) then	
+		return Size(T)=Size(LeftTranslationsSemigroupOfFamily(ElementsFamily(
+			FamilyObj(T))));
+	else return Size(T)=Size(RightTranslationsSemigroupOfFamily(ElementsFamily(
+			FamilyObj(T)))); 
+	fi;
+end);
+
+
+
+
+
+
+
+
+
+
+
+
+
+InstallMethod(TranslationalHull2, "for a rectangular band",
 [IsRectangularBand], 
 function(S)
 	local iso, reesMatSemi, reesMat, sizeI, sizeL, leftGens, rightGens, map,
-	 mapAsTransList, semiList, leftHullGens, rightHullGens, hull, reesMappingFunction, 
-	 i, j, k, l;
+	 mapAsTransList, semiList, leftHullGens, rightHullGens, hull, 
+	 reesMappingFunction, i, j, k, l;
 	
 	iso := IsomorphismReesMatrixSemigroup(S);
 	reesMatSemi := Range(iso);

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -7,7 +7,6 @@
 ##
 #############################################################################
 ##
-# (a * b) f = (a) f * b
 
 InstallMethod(LeftTranslations, "for a semigroup", 
 [IsSemigroup and IsFinite], 
@@ -512,6 +511,311 @@ InstallMethod(ChooseHashFunction, "for a translational hull element and int",
 function(x, hashlen)
   return rec(func := SEMIGROUPS.HashFunctionForTranslationalHullElements,
              data := hashlen);
+end);
+
+InstallMethod(TranslationalElements, "for the translational hull of an arbitrary finite semigroup",
+[IsTranslationalHull and IsWholeFamily],
+function(H)
+  local S, multtable, transpose, reps, repspos, dclasses, lclasses, rclasses,
+        d, f, g, i, j, k, m, n, p, r, s, slist, fposrepk, gposrepk,
+        possiblefrepvals, possiblegrepvals, whenboundfvals, whenboundgvals, pos,
+        fvalsi, gvalsi, ftransrestrictionatstage, gtransrestrictionatstage, 
+        flinkedrestrictionatstage, glinkedrestrictionatstage, 
+        extendf, extendg, reject, propagatef, propagateg, restrictfromf,
+        restrictfromg, bt, unrestrict, linkedpairs;
+  
+  S := UnderlyingSemigroup(H);                  
+  n := Size(S);
+  slist := ShallowCopy(AsList(S));
+  Sort(slist);
+  multtable := MultiplicationTable(S);
+  transpose := TransposedMat(multtable);
+  #for now, choose the reps by L/R classes 
+  dclasses := DClasses(S);
+  reps := [];
+  repspos := [];
+  
+  for d in dclasses do
+    lclasses := ShallowCopy(LClasses(d));
+    rclasses := ShallowCopy(RClasses(d));
+    for i in [1 .. Minimum(Size(lclasses), Size(rclasses)) - 1] do
+      r := Representative(Intersection(lclasses[1], rclasses[1]));
+      Add(reps, r);
+      Add(repspos, Position(slist, r));
+      Remove(lclasses, 1);
+      Remove(rclasses, 1);
+    od;
+    if Size(lclasses) > Size(rclasses) then
+      #Size(rclasses) = 1
+      for j in [1 .. Size(lclasses)] do
+        r := Representative(Intersection(lclasses[1], rclasses[1]));
+        Add(reps, r);
+        Add(repspos, Position(slist, r));
+        Remove(lclasses, 1);
+      od;
+    else
+      #Size(lclasses) = 1
+      for j in [1 .. Size(rclasses)] do
+        r := Representative(Intersection(lclasses[1], rclasses[1]));
+        Add(reps, r);
+        Add(repspos, Position(slist, r));
+        Remove(rclasses, 1);
+      od;
+    fi;
+  od;
+  
+  m := Size(reps);
+    
+  extendf := function(k)
+    f[repspos[k + 1]] := possiblefrepvals[k + 1][1];
+    return k + 1;
+  end;
+  
+  propagatef := function(k)
+    for s in S do
+      pos := Position(slist, reps[k] * s);
+      if IsBound(f[pos]) then
+        if not f[pos] = Position(slist, slist[f[repspos[k]]] * s) then
+          UniteSet(glinkedrestrictionatstage[k][k], possiblegrepvals[k]);
+          possiblegrepvals[k] := [];
+          return fail;
+        fi;
+      else
+        f[pos] := Position(slist, slist[f[repspos[k]]] * s);
+        whenboundfvals[pos] := k;
+        if pos in repspos then
+          j := Position(repspos, pos);
+          UniteSet(ftransrestrictionatstage[j][k],
+                   Difference(possiblefrepvals[j], [Position(slist, 
+                                                slist[f[repspos[k]]] * s)]));
+          possiblefrepvals[j] := Intersection(possiblefrepvals[j], 
+                                              [Position(slist, 
+                                                slist[f[repspos[k]]] * s)]);
+        fi;
+      fi;
+    od;
+    return k;
+  end;
+  
+  propagateg := function(k)
+    for s in S do
+      pos := Position(slist, s * reps[k]);
+      if IsBound(g[pos]) then
+        if not g[pos] = Position(slist, s * slist[g[repspos[k]]]) then
+          return fail;
+        fi;
+      else
+        g[pos] := Position(slist, s * slist[g[repspos[k]]]);
+        whenboundgvals[pos] := k;
+        if pos in repspos then
+          j := Position(repspos, pos);
+          UniteSet(gtransrestrictionatstage[j][k],
+                   Difference(possiblegrepvals[j], [Position(slist, 
+                                                s * slist[g[repspos[k]]])]));
+          possiblegrepvals[j] := Intersection(possiblegrepvals[j], 
+                                              [Position(slist, 
+                                                s * slist[g[repspos[k]]])]);
+        fi;
+      fi;
+    od;
+    return k;
+  end;
+  
+  restrictfromf := function(k)
+    for i in [k + 1 .. m] do
+      for s in S do
+        #restrict by the translation condition
+        for p in PositionsProperty(multtable[repspos[i]], 
+                  x -> x = Position(slist, reps[k] * s)) do
+          fvalsi := PositionsProperty(transpose[p], 
+                      x -> x = Position(slist, slist[f[repspos[k]]] * s));
+          UniteSet(ftransrestrictionatstage[i][k], 
+                    Difference(possiblefrepvals[i], fvalsi));
+          possiblefrepvals[i] := Intersection(possiblefrepvals[i], fvalsi);
+        od;
+        
+        #deal with the cases reps[i] = reps[k] * s and reps[i] * t = reps[k]
+        if reps[i] = reps[k] * s then 
+          fvalsi := [Position(slist, slist[f[repspos[k]]] * s)];
+          UniteSet(ftransrestrictionatstage[i][k],
+                    Difference(possiblefrepvals[i], fvalsi));
+          possiblefrepvals[i] := Intersection(possiblefrepvals[i], fvalsi);
+        fi;
+      od;
+      for p in PositionsProperty(multtable[repspos[i]], 
+                                   x -> x = repspos[k]) do
+        fvalsi := PositionsProperty(transpose[p], x -> x = f[repspos[k]]);  
+        UniteSet(ftransrestrictionatstage[i][k], 
+                  Difference(possiblefrepvals[i], fvalsi));
+        possiblefrepvals[i] := Intersection(possiblefrepvals[i], fvalsi);
+      od;
+      if Size(possiblefrepvals[i]) = 0 then
+        return fail;
+      fi;
+    od;
+    for i in [k .. m] do
+      for s in S do
+        #restrict by the linked pair condition
+        gvalsi := PositionsProperty(transpose[Position(slist, reps[k] * s)],
+                    x -> x = Position(slist, 
+                      reps[i] * slist[f[Position(slist, reps[k] * s)]]));  
+        UniteSet(glinkedrestrictionatstage[i][k], 
+                  Difference(possiblegrepvals[i], gvalsi));
+        possiblegrepvals[i] := Intersection(possiblegrepvals[i], gvalsi);
+      od;
+      #deal with linked condition on reps[k]
+      gvalsi := PositionsProperty(transpose[Position(slist, reps[k])],
+                  x -> x= Position(slist, reps[k] * slist[f[repspos[k]]]));
+      UniteSet(glinkedrestrictionatstage[i][k],
+                Difference(possiblegrepvals[i], gvalsi));
+      possiblegrepvals[i] := Intersection(possiblegrepvals[i], gvalsi);
+      if Size(possiblegrepvals[i]) = 0 then
+        return fail;
+      fi; 
+    od;
+    return k;
+  end;
+  
+  restrictfromg := function(k)
+    for i in [k + 1 .. m] do
+      for s in S do
+        for p in PositionsProperty(transpose[repspos[i]], 
+                  x -> x = Position(slist, s * reps[k])) do
+          gvalsi := PositionsProperty(multtable[p], 
+                      x -> x = Position(slist, s * slist[g[repspos[k]]]));
+          UniteSet(gtransrestrictionatstage[i][k],
+                    Difference(possiblegrepvals[i], gvalsi));
+          possiblegrepvals[i] := Intersection(possiblegrepvals[i], gvalsi);
+        od;
+        
+        #deal with the cases reps[i] = s * reps[k] and s * reps[i] = reps[k]
+        if reps[i] = s * reps[k] then 
+          gvalsi := [Position(slist, s * slist[g[repspos[k]]])];
+          UniteSet(gtransrestrictionatstage[i][k],
+                    Difference(possiblegrepvals[i], gvalsi));
+          possiblegrepvals[i] := Intersection(possiblegrepvals[i], gvalsi);
+        fi;
+        
+        for p in PositionsProperty(transpose[repspos[i]], 
+                                   x -> x = repspos[k]) do
+          gvalsi := PositionsProperty(multtable[p], x -> x = g[repspos[k]]);  
+          UniteSet(gtransrestrictionatstage[i][k],
+                    Difference(possiblegrepvals[i], gvalsi));
+          possiblegrepvals[i] := Intersection(possiblegrepvals[i], gvalsi);
+        od;
+        
+        fvalsi := PositionsProperty(multtable[Position(slist, s * reps[k])],
+                    x -> x = Position(slist, 
+                      slist[g[Position(slist, s * reps[k])]] * reps[i]));  
+        UniteSet(flinkedrestrictionatstage[i][k], 
+                  Difference(possiblefrepvals[i], fvalsi));
+        possiblefrepvals[i] := Intersection(possiblefrepvals[i], fvalsi);
+      od;
+      if Size(possiblefrepvals[i]) = 0 or Size(possiblegrepvals[i]) = 0 then
+        return fail;
+      fi;
+    od;
+    return k;
+  end;
+  
+  unrestrict := function(k, unrestrictf)
+    for i in [1 .. n] do
+        if whenboundgvals[i] = k then
+          Unbind(g[i]);
+          whenboundgvals[i] := 0;
+        fi;
+      od;
+      for i in [k .. m] do
+        UniteSet(possiblegrepvals[i], gtransrestrictionatstage[i][k]);
+        UniteSet(possiblefrepvals[i], flinkedrestrictionatstage[i][k]);
+        gtransrestrictionatstage[i][k] := [];
+        flinkedrestrictionatstage[i][k] := [];
+      od; 
+  
+    if(unrestrictf) then
+      for i in [1 .. n] do
+        if whenboundfvals[i] = k then
+          Unbind(f[i]);
+          whenboundfvals[i] := 0;
+        fi;
+      od;
+      for i in [k .. m] do
+        UniteSet(possiblefrepvals[i], ftransrestrictionatstage[i][k]);
+        UniteSet(possiblegrepvals[i], glinkedrestrictionatstage[i][k]);
+        ftransrestrictionatstage[i][k] := [];
+        glinkedrestrictionatstage[i][k] := [];
+      od;
+    fi;
+  end;
+  
+  reject := function(k)
+    if k = 0 then
+      return 0;
+    fi;
+    fposrepk := Position(possiblefrepvals[k], f[repspos[k]]);
+    if IsBound(g[repspos[k]]) then
+      gposrepk := Position(possiblegrepvals[k], g[repspos[k]]);
+    else
+      gposrepk := 0;
+    fi;
+    if gposrepk < Size(possiblegrepvals[k]) then
+      g[repspos[k]] := possiblegrepvals[k][gposrepk + 1];
+      unrestrict(k, false);
+      return k;
+    elif fposrepk < Size(possiblefrepvals[k]) then
+      f[repspos[k]] := possiblefrepvals[k][fposrepk + 1];
+      Unbind(g[repspos[k]]);
+      unrestrict(k, true);
+      return k;
+    else
+      if whenboundfvals[repspos[k]] = 0 then
+        Unbind(f[repspos[k]]);
+      fi;
+      if whenboundgvals[repspos[k]] = 0 then
+        Unbind(g[repspos[k]]);
+      fi;
+      unrestrict(k, true);
+      return reject(k - 1);
+    fi;
+  end;
+    
+  bt := function(k)
+    if k = m then
+      if not (propagatef(k) = fail or propagateg(k) = fail) then
+        Add(linkedpairs, [ShallowCopy(f), ShallowCopy(g)]);
+      fi;
+      return bt(reject(k));
+    elif k = 0 then
+      return 0;
+    elif not (propagatef(k) = fail or restrictfromf(k) = fail) then
+      if not IsBound(g[repspos[k]]) then
+        g[repspos[k]] := possiblegrepvals[k][1];
+      fi;
+      if not (propagateg(k) = fail or restrictfromg(k) = fail) then
+        return bt(extendf(k));
+      else
+        return bt(reject(k));
+      fi;
+    else 
+      return bt(reject(k));
+    fi;
+  end;
+  #The actual search
+  
+  ftransrestrictionatstage := List([1..m], x -> List([1..m], y -> []));  
+  flinkedrestrictionatstage := List([1..m], x -> List([1..m], y -> []));
+  gtransrestrictionatstage := List([1..m], x -> List([1..m], y -> []));
+  glinkedrestrictionatstage := List([1..m], x -> List([1..m], y -> []));
+  possiblefrepvals := List([1 .. m], x -> [1 .. n]);
+  possiblegrepvals := ShallowCopy(possiblefrepvals);
+  whenboundfvals := List([1 .. n], x -> 0);
+  whenboundgvals := ShallowCopy(whenboundfvals);
+  linkedpairs := [];
+  
+  f := [];
+  g := [];
+  bt(extendf(0));
+  return linkedpairs;
 end);
 
 InstallMethod(LeftTranslations, "for the left translations of a semigroup with known generators",

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -7,7 +7,6 @@
 ##
 #############################################################################
 ##
-
 # (a * b) f = (a) f * b
 
 InstallMethod(TranslationalHull, "for a rectangular band",
@@ -60,6 +59,31 @@ function(S)
 	hull := DirectProduct(Semigroup(leftHullGens), Semigroup(rightHullGens));
 	return hull;
 
+end);
+
+InstallMethod(LeftTranslations, "for a semigroup with known generators",
+[IsSemigroup and HasGeneratorsOfSemigroup],
+function(S)
+  local digraph, n, nrgens, out, colors, gens, i, j;
+
+  digraph := RightCayleyGraphSemigroup(S);
+  n       := Length(digraph);
+  nrgens  := Length(digraph[1]);
+  out     := [];
+  colors  := [];
+
+  for i in [1 .. n] do
+    out[i]    := [];
+    colors[i] := 1;
+    for j in [1 .. nrgens] do
+      out[i][j] := n + nrgens * (i - 1) + j;
+      out[n + nrgens * (i - 1) + j] := [digraph[i][j]];
+      colors[n + nrgens * (i - 1) + j] := j + 1;
+    od;
+  od;
+  gens := GeneratorsOfEndomorphismMonoid(Digraph(out), colors);
+  Apply(gens, x -> RestrictedTransformation(x, [1 .. n]));
+  return Semigroup(gens, rec(small := true));
 end);
 
 InstallMethod(RightTranslations, "for a semigroup with known generators",

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -412,12 +412,17 @@ SEMIGROUPS.TranslationalHullOfArbitraryElements := function(H)
     if k = 0 then
       return 0;
     fi;
+    if k = m + 1 then
+      return k;
+    fi;
     if k = m then
-      if not IsBound(g[repspos[k]]) then
-        g[repspos[k]] := possiblegrepvals[k][1];
-      fi;
-      if not (propagatef(k) = fail or propagateg(k) = fail) then
-        return k;
+      if not (propagatef(k) = fail or restrictfromf(k) = fail) then
+        if not IsBound(g[repspos[k]]) then
+          g[repspos[k]] := possiblegrepvals[k][1];
+        fi;
+        if not propagateg(k) = fail then
+          return m + 1;
+        fi;
       fi;
       return bt(reject(k));
     elif not (propagatef(k) = fail or restrictfromf(k) = fail) then
@@ -450,9 +455,9 @@ SEMIGROUPS.TranslationalHullOfArbitraryElements := function(H)
   
   k := extendf(0);
   k := bt(k);
-  while k <> 0 do
+  while k = m + 1 do
     Add(linkedpairs, [ShallowCopy(f), ShallowCopy(g)]);
-    k := bt(reject(k));
+    k := bt(reject(k - 1));
   od;
   
   linkedpairsunsorted := [];
@@ -684,7 +689,7 @@ function(R, x)
           "the first argument must be a semigroup of right translations");
     return;
   fi;
-  
+
   if IsGeneralMapping(x) then
     if not (S = Source(x) and Source(x) = Range(x)) then
       Error("Semigroups: RightTranslation (from Mapping): \n",
@@ -867,6 +872,32 @@ end);
 #############################################################################
 # 3. Methods for rectangular bands
 #############################################################################
+
+# For rectangular bands, don't calculate AsList for LeftTranslations 
+# Just get generators
+InstallMethod(LeftTranslations, "for a RZMS semigroup",
+[IsSemigroup and IsFinite and IsZeroSimpleSemigroup],
+function(S) 
+  local L;
+  
+  L := LeftTranslationsSemigroup(S);
+  GeneratorsOfSemigroup(L);
+  
+  return L;
+end);
+
+# For RZMS, don't calculate AsList for RightTranslations 
+# Just get generators
+InstallMethod(RightTranslations, "for a RZMS semigroup",
+[IsSemigroup and IsFinite and IsZeroSimpleSemigroup],
+function(S) 
+  local R;
+  
+  R := RightTranslationsSemigroup(S);
+  GeneratorsOfSemigroup(R);
+  
+  return R;
+end);
 
 # Every transformation on the relevant index set corresponds to a translation.
 # The R classes of an I x J rectangular band correspond to (i, J) for i in I.

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -485,9 +485,9 @@ SEMIGROUPS.TranslationalHullElementsGeneric := function(H)
     od;
     Add(linkedpairsunsorted, [ShallowCopy(p1), ShallowCopy(p2)]);
   od;
-  Apply(linkedpairsunsorted, x -> TranslationalHullElement(H, 
-                                  LeftTranslation(L, Transformation(x[1])),
-                                  RightTranslation(R, Transformation(x[2]))));
+  Apply(linkedpairsunsorted, x -> TranslationalHullElementNC(H, 
+                                  LeftTranslationNC(L, Transformation(x[1])),
+                                  RightTranslationNC(R, Transformation(x[2]))));
   return linkedpairsunsorted;
 end;
 

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  translat.gi
-#Y  Copyright (C) 2015-16                     James D. Mitchell, Finn Smith
+#Y  Copyright (C) 2015-17                     James D. Mitchell, Finn Smith
 ##
 ##  Licensing information can be found in the README file of this package.
 ##

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -1023,14 +1023,14 @@ function(T)
         return ReesMatrixSemigroupElement(reesMatSemi, x[1]^t, 
           (), x[3]);
       end;
-      Add(gens, LeftTranslation(T, CompositionMapping(inv, 
+      Add(gens, LeftTranslationNC(T, CompositionMapping(inv, 
       MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
     else 
       f := function(x)
         return ReesMatrixSemigroupElement(reesMatSemi, x[1], 
           (), x[3]^t);
       end;
-      Add(gens, RightTranslation(T, CompositionMapping(inv, 
+      Add(gens, RightTranslationNC(T, CompositionMapping(inv, 
         MappingByFunction(reesMatSemi, reesMatSemi, f), iso)));
     fi;
   od;
@@ -1055,7 +1055,7 @@ function(H)
   
   for l in leftGens do
     for r in rightGens do
-      Add(gens, TranslationalHullElement(H, l, r));
+      Add(gens, TranslationalHullElementNC(H, l, r));
     od;
   od;
   

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -7,32 +7,108 @@
 ##
 #############################################################################
 ##
-
 # (a * b) f = (a) f * b
 
-InstallMethod(LeftTranslations, "for a semigroup with known generators",
+InstallMethod(TranslationalHull, "for a rectangular band",
+[IsRectangularBand], 
+function(S)
+	local iso, reesMatSemi, reesMat, sizeI, sizeL, leftGens, rightGens, map,
+	 mapAsTransList, semiList, leftHullGens, rightHullGens, hull, reesMappingFunction, 
+	 i, j, k, l;
+	
+	iso := IsomorphismReesMatrixSemigroup(S);
+	reesMatSemi := Range(iso);
+	reesMat := Matrix(reesMatSemi);
+	sizeI := Length(reesMat[1]);
+	sizeL := Length(reesMat);
+	
+	leftGens := ShallowCopy(GeneratorsOfMonoid(FullTransformationMonoid(sizeI)));
+	rightGens := ShallowCopy(GeneratorsOfMonoid(FullTransformationMonoid(sizeL)));
+	Add(leftGens, IdentityTransformation);
+	Add(rightGens, IdentityTransformation);
+	
+	leftHullGens:=[];
+	semiList:= AsList(S);
+	for i in [1..Length(leftGens)] do
+		reesMappingFunction := function(x)
+			return ReesMatrixSemigroupElement(reesMatSemi, x[1]^leftGens[i], (), x[3]);
+		end;
+		map := CompositionMapping(InverseGeneralMapping(iso), MappingByFunction(
+			reesMatSemi, reesMatSemi, reesMappingFunction), iso);
+		mapAsTransList := [];
+		for l in [1..Length(semiList)] do
+			mapAsTransList[l] := Position(semiList, semiList[l]^map);
+		od;
+		Add(leftHullGens, Transformation(mapAsTransList));
+	od;	 
+	
+	rightHullGens:=[];
+	for j in [1..Length(rightGens)] do
+		reesMappingFunction := function(x)
+			return ReesMatrixSemigroupElement(reesMatSemi, x[1], (), x[3]^rightGens[j]);
+		end;
+		map := CompositionMapping(InverseGeneralMapping(iso), MappingByFunction(
+			reesMatSemi, reesMatSemi, reesMappingFunction), iso);
+		mapAsTransList := [];
+		for l in [1..Length(semiList)] do
+			mapAsTransList[l] := Position(semiList, semiList[l]^map);
+		od;
+		Add(rightHullGens, Transformation(mapAsTransList));
+	od;
+	
+	hull := DirectProduct(Semigroup(leftHullGens), Semigroup(rightHullGens));
+	return hull;
+
+end);
+
+InstallMethod(LeftTranslationsNew, "for a semigroup with known generators",
 [IsSemigroup and HasGeneratorsOfSemigroup],
 function(S)
-  local digraph, n, nrgens, out, colors, gens, i, j;
+  local digraph, n, nrgens, nrgraphs, out, colors, gens, i, tempi, revbinbitsi, 
+  j, k;
 
-  digraph := RightCayleyGraphSemigroup(S);
-  n       := Length(digraph);
-  nrgens  := Length(digraph[1]);
-  out     := [];
-  colors  := [];
+  digraph  := RightCayleyGraphSemigroup(S);
+  n        := Length(digraph);
+  nrgens   := Length(digraph[1]);
+  nrgraphs := LogInt(nrgens,2) + 1;
+  out      := [];
+  colors   := [];
 
-  for i in [1 .. n] do
-    out[i]    := [];
-    colors[i] := 1;
-    for j in [1 .. nrgens] do
-      out[i][j] := n + nrgens * (i - 1) + j;
-      out[n + nrgens * (i - 1) + j] := [digraph[i][j]];
-      colors[n + nrgens * (i - 1) + j] := j + 1;
-    od;
+
+  for i in [1 .. nrgraphs] do
+  	for j in [1 .. n] do
+  	  out[n * (i - 1) + j]    := [];
+  	    for k in [1 .. nrgraphs] do
+  	      if i <> k  then
+  	      	Add(out[n * (i - 1) + j], n * (k - 1) + j);
+  	      fi;
+  	    colors[n * (i - 1) + j] := i;
+  	    od;
+  	od;
   od;
+  
+  		
+  for i in [1 .. nrgens] do
+  	tempi       := i;
+  	revbinbitsi := [];
+  	while tempi > 0 do
+  		revbinbitsi[LogInt(tempi,2)+1] := 1;
+  		tempi := tempi - 2^LogInt(tempi,2);
+    od;
+    for j in [1 .. nrgraphs] do
+      if IsBound(revbinbitsi[j]) then
+        for k in [1 .. n] do
+        	Add(out[n * (j - 1) + k], n * (j - 1) + digraph[k][i]);
+  		od;
+  	  fi;
+  	od;
+  od;
+  	
   gens := GeneratorsOfEndomorphismMonoid(Digraph(out), colors);
   Apply(gens, x -> RestrictedTransformation(x, [1 .. n]));
   return Semigroup(gens, rec(small := true));
+  #DOESN'T PRESERVE ENDOMORPHISMS
+  #DOES PRESERVE AUTOMORPHISMS? TODO: Prove
 end);
 
 InstallMethod(RightTranslations, "for a semigroup with known generators",

--- a/gap/tools/utils.gi
+++ b/gap/tools/utils.gi
@@ -94,6 +94,7 @@ SEMIGROUPS.DocXMLFiles := ["../PackageInfo.g",
                            "semipperm.xml",
                            "semiringmat.xml",
                            "semitrans.xml",
+                           "translat.xml",
                            "utils.xml"];
 
 SEMIGROUPS.TestRec := rec();

--- a/read.g
+++ b/read.g
@@ -76,6 +76,7 @@ ReadPackage("semigroups", "gap/attributes/maximal.gi");
 ReadPackage("semigroups", "gap/attributes/normalizer.gi");
 ReadPackage("semigroups", "gap/attributes/properties.gi");
 ReadPackage("semigroups", "gap/attributes/isorms.gi");
+ReadPackage("semigroups/gap/attributes/rms-translat.gi");
 ReadPackage("semigroups", "gap/attributes/translat.gi");
 
 ReadPackage("semigroups", "gap/congruences/congpairs.gi");

--- a/tst/standard/translat.tst
+++ b/tst/standard/translat.tst
@@ -1,0 +1,144 @@
+#############################################################################
+##
+#W  standard/attributes.tst
+#Y  Copyright (C) 2016                                            Finn Smith
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+gap> START_TEST("Semigroups package: standard/translat.tst");
+gap> LoadPackage("semigroups", false);;
+
+#
+gap> SEMIGROUPS.StartTest();
+
+#T# TranslatTest1
+# creation of left/right translations semigroups (without calculation)
+gap> S := RectangularBand(3,4);;
+gap> LeftTranslationsSemigroup(S);
+<the semigroup of left translations of <regular transformation semigroup 
+ of size 12, degree 8 with 4 generators>>
+gap> RightTranslationsSemigroup(S);
+<the semigroup of right translations of <regular transformation semigroup 
+ of size 12, degree 8 with 4 generators>>
+gap> TranslationalHullSemigroup(S);
+<translational hull over <regular transformation semigroup of size 12, 
+ degree 8 with 4 generators>>
+
+# for semigroups it can't calculate translations semigroups of
+gap> S := SingularTransformationSemigroup(10);
+<regular transformation semigroup ideal of degree 10 with 1 generator>
+gap> S := SingularTransformationSemigroup(10);;
+gap> LeftTranslationsSemigroup(S);
+<the semigroup of left translations of <regular transformation semigroup 
+ ideal of degree 10 with 1 generator>>
+gap> RightTranslationsSemigroup(S);
+<the semigroup of right translations of <regular transformation semigroup 
+ ideal of degree 10 with 1 generator>>
+gap> TranslationalHullSemigroup(S);
+<translational hull over <regular transformation semigroup ideal of 
+ degree 10 with 1 generator>>
+
+# with calculation - rectangular bands
+gap> S := RectangularBand(3,4);
+<regular transformation semigroup of size 12, degree 8 with 4 generators>
+gap> L := LeftTranslations(S);
+<the semigroup of left translations of <simple transformation semigroup 
+ of size 12, degree 8 with 4 generators>>
+gap> R := RightTranslations(S);
+<the semigroup of right translations of <simple transformation semigroup 
+ of size 12, degree 8 with 4 generators>>
+gap> H := TranslationalHull(S);
+<translational hull over <simple transformation semigroup of size 12, 
+ degree 8 with 4 generators>>
+gap> Size(L);
+27
+gap> GeneratorsOfSemigroup(L);
+[ <left translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>>, 
+  <left translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>>, 
+  <left translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>> ]
+gap> GeneratorsOfSemigroup(R);
+[ <right translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>>, 
+  <right translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>>, 
+  <right translation on <simple transformation semigroup of size 12, degree 8 
+     with 4 generators>> ]
+gap> GeneratorsOfSemigroup(H);
+[ <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>>, 
+  <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>>, 
+  <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>>, 
+  <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>>, 
+  <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>>, 
+  <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>>, 
+  <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>>, 
+  <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>>, 
+  <linked pair of translations on <simple transformation semigroup 
+     of size 12, degree 8 with 4 generators>> ]
+
+# small RZMS
+gap> G := SmallGroup(4,2);;
+gap> G_list := AsList(G);;
+gap> mat := [ [G_list[1], 0, G_list[1]],
+> [G_list[2], G_list[2], G_list[4]],
+> [0, G_list[3], 0]];;
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> L := LeftTranslations(S);
+<the semigroup of left translations of <0-simple regular semigroup 
+ of size 37, with 6 generators>>
+gap> R := RightTranslations(S);
+<the semigroup of right translations of <0-simple regular semigroup 
+ of size 37, with 6 generators>>
+gap> H := TranslationalHull(S);
+<translational hull over <0-simple regular semigroup of size 37, with 6 
+ generators>>
+gap> Size(H);
+45
+gap> Size(L);
+2197
+gap> Size(R);
+2197
+gap> GeneratorsOfSemigroup(L);
+[ <left translation on <0-simple regular semigroup of size 37, with 6 
+     generators>>, <left translation on <0-simple regular semigroup 
+     of size 37, with 6 generators>>, 
+  <left translation on <0-simple regular semigroup of size 37, with 6 
+     generators>>, <left translation on <0-simple regular semigroup 
+     of size 37, with 6 generators>>, 
+  <left translation on <0-simple regular semigroup of size 37, with 6 
+     generators>>, <left translation on <0-simple regular semigroup 
+     of size 37, with 6 generators>> ]
+
+gap> GeneratorsOfSemigroup(R);
+[ <right translation on <0-simple regular semigroup of size 37, with 6 
+     generators>>, <right translation on <0-simple regular semigroup 
+     of size 37, with 6 generators>>, 
+  <right translation on <0-simple regular semigroup of size 37, with 6 
+     generators>>, <right translation on <0-simple regular semigroup 
+     of size 37, with 6 generators>>, 
+  <right translation on <0-simple regular semigroup of size 37, with 6 
+     generators>>, <right translation on <0-simple regular semigroup 
+     of size 37, with 6 generators>> ]
+          
+          
+gap> Unbind(G);
+gap> Unbind(G_list);
+gap> Unbind(L);
+gap> Unbind(H);
+gap> Unbind(R);
+gap> Unbind(S);
+
+#E#
+gap> STOP_TEST("Semigroups package: standard/translat.tst");

--- a/tst/standard/translat.tst
+++ b/tst/standard/translat.tst
@@ -159,6 +159,64 @@ gap> R := RightTranslations(S);
 gap> Size(R);
 55
 
+#T# Translations and translational hulls of monoids that couldn't be calculated
+gap> S := BrauerMonoid(5);;
+gap> L := LeftTranslations(S);
+Monoid( 
+[ <left translation on <regular bipartition *-monoid of size 945, degree 5 
+     with 3 generators>>, <left translation on <regular bipartition *-monoid 
+     of size 945, degree 5 with 3 generators>>, 
+  <left translation on <regular bipartition *-monoid of size 945, degree 5 
+     with 3 generators>>, <left translation on <regular bipartition *-monoid 
+     of size 945, degree 5 with 3 generators>> ] )
+gap> Size(L);
+945
+gap> R := RightTranslations(S);
+Monoid( 
+[ <right translation on <regular bipartition *-monoid of size 945, degree 5 
+     with 3 generators>>, <right translation on <regular bipartition *-monoid 
+     of size 945, degree 5 with 3 generators>>, 
+  <right translation on <regular bipartition *-monoid of size 945, degree 5 
+     with 3 generators>>, <right translation on <regular bipartition *-monoid 
+     of size 945, degree 5 with 3 generators>> ] )
+gap> Size(R);
+945
+gap> H := TranslationalHull(S);
+Monoid( 
+[ <linked pair of translations on <regular bipartition *-monoid of size 945, 
+     degree 5 with 3 generators>>, <linked pair of translations on 
+    <regular bipartition *-monoid of size 945, degree 5 with 3 generators>>, 
+  <linked pair of translations on <regular bipartition *-monoid of size 945, 
+     degree 5 with 3 generators>>, <linked pair of translations on 
+    <regular bipartition *-monoid of size 945, degree 5 with 3 generators>> 
+ ] )
+gap> Size(H);
+945
+gap> S := FullTransformationMonoid(5);;
+gap> L := LeftTranslations(S);
+Monoid( [ <left translation on <full transformation monoid of degree 5>>, 
+  <left translation on <full transformation monoid of degree 5>>, 
+  <left translation on <full transformation monoid of degree 5>>, 
+  <left translation on <full transformation monoid of degree 5>> ] )
+gap> Size(L);
+3125
+gap> R := RightTranslations(S);
+Monoid( [ <right translation on <full transformation monoid of degree 5>>, 
+  <right translation on <full transformation monoid of degree 5>>, 
+  <right translation on <full transformation monoid of degree 5>>, 
+  <right translation on <full transformation monoid of degree 5>> ] )
+gap> Size(R);
+3125
+gap> H := TranslationalHull(S);
+Monoid( 
+[ <linked pair of translations on <full transformation monoid of degree 5>>, 
+  <linked pair of translations on <full transformation monoid of degree 5>>, 
+  <linked pair of translations on <full transformation monoid of degree 5>>, 
+  <linked pair of translations on <full transformation monoid of degree 5>> 
+ ] )
+gap> Size(H);
+3125
+
 #T# A tiny bit of brute force checking   
 gap> SEMIGROUPS.bruteforcetranshull := function(S)
 >   local a, d, L, R, H, linkedpairs, dclasses, rclasses, lclasses, reps, i, j, 

--- a/tst/standard/translat.tst
+++ b/tst/standard/translat.tst
@@ -9,7 +9,6 @@
 ##
 gap> START_TEST("Semigroups package: standard/translat.tst");
 gap> LoadPackage("semigroups", false);;
-
 gap> SEMIGROUPS.StartTest();
 
 #T# Creation of translations semigroups
@@ -133,7 +132,7 @@ gap> GeneratorsOfSemigroup(R);
   <right translation on <0-simple regular semigroup of size 37, with 6 
      generators>>, <right translation on <0-simple regular semigroup 
      of size 37, with 6 generators>> ]
-          
+
 #T# A tiny bit of brute force checking   
 gap> SEMIGROUPS.bruteforcetranshull := function(S)
 >   local a, d, L, R, H, linkedpairs, dclasses, rclasses, lclasses, reps, i, j, 

--- a/tst/standard/translat.tst
+++ b/tst/standard/translat.tst
@@ -133,6 +133,33 @@ gap> GeneratorsOfSemigroup(R);
      generators>>, <right translation on <0-simple regular semigroup 
      of size 37, with 6 generators>> ]
 
+#T# Test translations generation by digraph endomorphisms
+gap> S := ZeroSemigroup(4);;
+gap> L := SEMIGROUPS.LeftTranslationsSemigroupElementsByGenerators(
+> LeftTranslations(S));
+<semigroup of left translations of <commutative non-regular transformation 
+ semigroup of size 4, degree 4 with 3 generators> with 17 generatorss>
+gap> Size(L);
+64
+gap> R := SEMIGROUPS.RightTranslationsSemigroupElementsByGenerators(
+> RightTranslations(S));
+<semigroup of right translations of <commutative non-regular transformation 
+ semigroup of size 4, degree 4 with 3 generators> with 17 generatorss>
+
+#T# Further test translations generation by digraph endomorphisms
+gap> S := Semigroup([Transformation([2,4,4,1]), Transformation([2,3,2,1]), 
+> Transformation([3,3,3])]);;
+gap> L := LeftTranslations(S);
+<the semigroup of left translations of <transformation semigroup of size 49, 
+ degree 4 with 3 generators>>
+gap> Size(L);
+123
+gap> R := RightTranslations(S);
+<the semigroup of right translations of <transformation semigroup of size 49, 
+ degree 4 with 3 generators>>
+gap> Size(R);
+55
+
 #T# A tiny bit of brute force checking   
 gap> SEMIGROUPS.bruteforcetranshull := function(S)
 >   local a, d, L, R, H, linkedpairs, dclasses, rclasses, lclasses, reps, i, j, 
@@ -195,6 +222,34 @@ true
 gap> S := RectangularBand(2,3);;
 gap> Size(Semigroup(GeneratorsOfSemigroup(TranslationalHull(S))))
 > = Size(SEMIGROUPS.bruteforcetranshull(S));
+true
+
+#T# Test translational hull method for arbitrary semigroups
+gap> S := ZeroSemigroup(4);;
+gap> Size(TranslationalHull(S));
+4096
+gap> S := Semigroup([Transformation([1,1,2,2]), Transformation([3,4,3,1])]);;
+gap> H := TranslationalHull(S);
+<translational hull over <transformation semigroup of size 23, degree 4 with 
+ 2 generators>>
+gap> H = Semigroup(H);
+true
+gap> Size(H);
+32
+
+#T# Make sure the generic method and special methods agree for hulls
+gap> S := RectangularBand(2,3);;
+gap> H := TranslationalHull(S);;
+gap> Semigroup(SEMIGROUPS.TranslationalHullElementsGeneric(H)) = H;
+true
+gap> G := SmallGroup(6, 1);;
+gap> a := G.1;; b := G.2;;
+gap> mat := [[a, 0, b],
+> [b, a, 0],
+> [0, a, b]];;
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> H := TranslationalHull(S);;
+gap> Semigroup(SEMIGROUPS.TranslationalHullElementsGeneric(H)) = H;
 true
 
 #T# OneOp for translations semigroups elements and translational hull elements

--- a/tst/standard/translat.tst
+++ b/tst/standard/translat.tst
@@ -28,7 +28,7 @@ gap> Size(L);
 gap> Size(R);
 256
 
-#T# creation of translations semigroups it can't calclate
+#T# Creation of translations semigroups it can't calclate
 gap> S := SingularTransformationSemigroup(10);
 <regular transformation semigroup ideal of degree 10 with 1 generator>
 gap> S := SingularTransformationSemigroup(10);;
@@ -195,6 +195,22 @@ true
 gap> S := RectangularBand(2,3);;
 gap> Size(Semigroup(GeneratorsOfSemigroup(TranslationalHull(S))))
 > = Size(SEMIGROUPS.bruteforcetranshull(S));
+true
+
+#T# OneOp for translations semigroups elements and translational hull elements
+gap> G := SmallGroup(6, 1);;
+gap> a := G.1;; b := G.2;;
+gap> mat := [[a, 0, b],
+> [b, a, 0],
+> [0, a, b]];;
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> IsSemigroup(S) and IsFinite(S) and IsZeroSimpleSemigroup(S);;
+gap> L := LeftTranslations(S);;
+gap> R := RightTranslations(S);;
+gap> H := TranslationalHull(S);;
+gap> OneOp(L.1) = LeftTranslation(L, MappingByFunction(S, S, x -> x));
+true
+gap> OneOp(R.1) = RightTranslation(R, MappingByFunction(S, S, x -> x));
 true
 
 #T# SEMIGROUPS_UnbindVariables

--- a/tst/standard/translat.tst
+++ b/tst/standard/translat.tst
@@ -28,8 +28,6 @@ gap> Size(R);
 256
 
 #T# Creation of translations semigroups it can't calclate
-gap> S := SingularTransformationSemigroup(10);
-<regular transformation semigroup ideal of degree 10 with 1 generator>
 gap> S := SingularTransformationSemigroup(10);;
 gap> LeftTranslationsSemigroup(S);
 <the semigroup of left translations of <regular transformation semigroup 
@@ -42,95 +40,88 @@ gap> TranslationalHullSemigroup(S);
  degree 10 with 1 generator>>
 
 #T# with calculation - rectangular bands
-gap> S := RectangularBand(3,4);
-<regular transformation semigroup of size 12, degree 8 with 4 generators>
+gap> S := RectangularBand(3,3);
+<regular transformation semigroup of size 9, degree 7 with 3 generators>
 gap> L := LeftTranslations(S);
 <the semigroup of left translations of <simple transformation semigroup 
- of size 12, degree 8 with 4 generators>>
+ of size 9, degree 7 with 3 generators>>
 gap> R := RightTranslations(S);
 <the semigroup of right translations of <simple transformation semigroup 
- of size 12, degree 8 with 4 generators>>
+ of size 9, degree 7 with 3 generators>>
 gap> H := TranslationalHull(S);
-<translational hull over <simple transformation semigroup of size 12, 
- degree 8 with 4 generators>>
+<translational hull over <simple transformation semigroup of size 9, degree 7 
+ with 3 generators>>
 gap> Size(L);
 27
 gap> GeneratorsOfSemigroup(L);
-[ <left translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>>, 
-  <left translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>>, 
-  <left translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>> ]
+[ <left translation on <simple transformation semigroup of size 9, degree 7 
+     with 3 generators>>, 
+  <left translation on <simple transformation semigroup of size 9, degree 7 
+     with 3 generators>>, 
+  <left translation on <simple transformation semigroup of size 9, degree 7 
+     with 3 generators>> ]
 gap> GeneratorsOfSemigroup(R);
-[ <right translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>>, 
-  <right translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>>, 
-  <right translation on <simple transformation semigroup of size 12, degree 8 
-     with 4 generators>> ]
+[ <right translation on <simple transformation semigroup of size 9, degree 7 
+     with 3 generators>>, 
+  <right translation on <simple transformation semigroup of size 9, degree 7 
+     with 3 generators>>, 
+  <right translation on <simple transformation semigroup of size 9, degree 7 
+     with 3 generators>> ]
 gap> GeneratorsOfSemigroup(H);
-[ <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>>, 
-  <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>>, 
-  <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>>, 
-  <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>>, 
-  <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>>, 
-  <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>>, 
-  <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>>, 
-  <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>>, 
-  <linked pair of translations on <simple transformation semigroup 
-     of size 12, degree 8 with 4 generators>> ]
+[ <linked pair of translations on <simple transformation semigroup of size 9, 
+     degree 7 with 3 generators>>, <linked pair of translations on 
+    <simple transformation semigroup of size 9, degree 7 with 3 generators>>, 
+  <linked pair of translations on <simple transformation semigroup of size 9, 
+     degree 7 with 3 generators>>, <linked pair of translations on 
+    <simple transformation semigroup of size 9, degree 7 with 3 generators>>, 
+  <linked pair of translations on <simple transformation semigroup of size 9, 
+     degree 7 with 3 generators>>, <linked pair of translations on 
+    <simple transformation semigroup of size 9, degree 7 with 3 generators>>, 
+  <linked pair of translations on <simple transformation semigroup of size 9, 
+     degree 7 with 3 generators>>, <linked pair of translations on 
+    <simple transformation semigroup of size 9, degree 7 with 3 generators>>, 
+  <linked pair of translations on <simple transformation semigroup of size 9, 
+     degree 7 with 3 generators>> ]
 
 #T# small RZMS
 gap> G := SmallGroup(4,2);;
 gap> H := AsList(G);;
-gap> mat := [ [H[1], 0, H[1]],
-> [H[2], H[2], H[4]],
-> [0, H[3], 0]];;
+gap> mat := [ [H[1], 0],
+> [H[2], H[2]] ];;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
 gap> L := LeftTranslations(S);
 <the semigroup of left translations of <0-simple regular semigroup 
- of size 37, with 6 generators>>
+ of size 17, with 4 generators>>
 gap> R := RightTranslations(S);
 <the semigroup of right translations of <0-simple regular semigroup 
- of size 37, with 6 generators>>
+ of size 17, with 4 generators>>
 gap> H := TranslationalHull(S);
-<translational hull over <0-simple regular semigroup of size 37, with 6 
+<translational hull over <0-simple regular semigroup of size 17, with 4 
  generators>>
 gap> Size(H);
-45
+21
 gap> Size(L);
-2197
+81
 gap> Size(R);
-2197
+81
 gap> GeneratorsOfSemigroup(L);
-[ <left translation on <0-simple regular semigroup of size 37, with 6 
+[ <left translation on <0-simple regular semigroup of size 17, with 4 
      generators>>, <left translation on <0-simple regular semigroup 
-     of size 37, with 6 generators>>, 
-  <left translation on <0-simple regular semigroup of size 37, with 6 
+     of size 17, with 4 generators>>, 
+  <left translation on <0-simple regular semigroup of size 17, with 4 
      generators>>, <left translation on <0-simple regular semigroup 
-     of size 37, with 6 generators>>, 
-  <left translation on <0-simple regular semigroup of size 37, with 6 
-     generators>>, <left translation on <0-simple regular semigroup 
-     of size 37, with 6 generators>> ]
+     of size 17, with 4 generators>>, 
+  <left translation on <0-simple regular semigroup of size 17, with 4 
+     generators>> ]
 gap> GeneratorsOfSemigroup(R);
-[ <right translation on <0-simple regular semigroup of size 37, with 6 
+[ <right translation on <0-simple regular semigroup of size 17, with 4 
      generators>>, <right translation on <0-simple regular semigroup 
-     of size 37, with 6 generators>>, 
-  <right translation on <0-simple regular semigroup of size 37, with 6 
+     of size 17, with 4 generators>>, 
+  <right translation on <0-simple regular semigroup of size 17, with 4 
      generators>>, <right translation on <0-simple regular semigroup 
-     of size 37, with 6 generators>>, 
-  <right translation on <0-simple regular semigroup of size 37, with 6 
-     generators>>, <right translation on <0-simple regular semigroup 
-     of size 37, with 6 generators>> ]
+     of size 17, with 4 generators>>, 
+  <right translation on <0-simple regular semigroup of size 17, with 4 
+     generators>> ]
 
 #T# Test translations generation by digraph endomorphisms
 gap> S := ZeroSemigroup(4);;
@@ -285,21 +276,20 @@ true
 gap> S := ZeroSemigroup(4);;
 gap> Size(TranslationalHull(S));
 4096
-gap> S := Semigroup([Transformation([1,1,2,2]), Transformation([3,4,3,1])]);;
+gap> S := Semigroup([Transformation([1,1,2]), Transformation([3,1,3])]);;
 gap> H := TranslationalHull(S);
-<translational hull over <transformation semigroup of size 23, degree 4 with 
+<translational hull over <transformation semigroup of size 11, degree 3 with 
  2 generators>>
 gap> H = Semigroup(H);
 true
 gap> Size(H);
-32
+13
 
 #T# OneOp for translations semigroups elements and translational hull elements
 gap> G := SmallGroup(6, 1);;
 gap> a := G.1;; b := G.2;;
-gap> mat := [[a, 0, b],
-> [b, a, 0],
-> [0, a, b]];;
+gap> mat := [[a, 0],
+> [b, a]];;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
 gap> IsSemigroup(S) and IsFinite(S) and IsZeroSimpleSemigroup(S);;
 gap> L := LeftTranslations(S);;
@@ -314,10 +304,6 @@ gap> OneOp(Representative(H)) = TranslationalHullElement(
 true
 
 #T# Make sure the generic method and special methods agree for hulls
-gap> Semigroup(SEMIGROUPS.TranslationalHullElementsGeneric(H)) = H;
-true
-gap> S := RectangularBand(2,3);;
-gap> H := TranslationalHull(S);;
 gap> Semigroup(SEMIGROUPS.TranslationalHullElementsGeneric(H)) = H;
 true
 

--- a/tst/standard/translat.tst
+++ b/tst/standard/translat.tst
@@ -10,23 +10,26 @@
 gap> START_TEST("Semigroups package: standard/translat.tst");
 gap> LoadPackage("semigroups", false);;
 
-#
 gap> SEMIGROUPS.StartTest();
 
-#T# TranslatTest1
+#T# Creation of translations semigroups
 # creation of left/right translations semigroups (without calculation)
 gap> S := RectangularBand(3,4);;
-gap> LeftTranslationsSemigroup(S);
+gap> L := LeftTranslationsSemigroup(S);
 <the semigroup of left translations of <regular transformation semigroup 
  of size 12, degree 8 with 4 generators>>
-gap> RightTranslationsSemigroup(S);
+gap> R := RightTranslationsSemigroup(S);
 <the semigroup of right translations of <regular transformation semigroup 
  of size 12, degree 8 with 4 generators>>
 gap> TranslationalHullSemigroup(S);
 <translational hull over <regular transformation semigroup of size 12, 
  degree 8 with 4 generators>>
+gap> Size(L);
+27
+gap> Size(R);
+256
 
-# for semigroups it can't calculate translations semigroups of
+#T# creation of translations semigroups it can't calclate
 gap> S := SingularTransformationSemigroup(10);
 <regular transformation semigroup ideal of degree 10 with 1 generator>
 gap> S := SingularTransformationSemigroup(10);;
@@ -40,7 +43,7 @@ gap> TranslationalHullSemigroup(S);
 <translational hull over <regular transformation semigroup ideal of 
  degree 10 with 1 generator>>
 
-# with calculation - rectangular bands
+#T# with calculation - rectangular bands
 gap> S := RectangularBand(3,4);
 <regular transformation semigroup of size 12, degree 8 with 4 generators>
 gap> L := LeftTranslations(S);
@@ -88,12 +91,12 @@ gap> GeneratorsOfSemigroup(H);
   <linked pair of translations on <simple transformation semigroup 
      of size 12, degree 8 with 4 generators>> ]
 
-# small RZMS
+#T# small RZMS
 gap> G := SmallGroup(4,2);;
-gap> G_list := AsList(G);;
-gap> mat := [ [G_list[1], 0, G_list[1]],
-> [G_list[2], G_list[2], G_list[4]],
-> [0, G_list[3], 0]];;
+gap> H := AsList(G);;
+gap> mat := [ [H[1], 0, H[1]],
+> [H[2], H[2], H[4]],
+> [0, H[3], 0]];;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
 gap> L := LeftTranslations(S);
 <the semigroup of left translations of <0-simple regular semigroup 
@@ -120,7 +123,6 @@ gap> GeneratorsOfSemigroup(L);
   <left translation on <0-simple regular semigroup of size 37, with 6 
      generators>>, <left translation on <0-simple regular semigroup 
      of size 37, with 6 generators>> ]
-
 gap> GeneratorsOfSemigroup(R);
 [ <right translation on <0-simple regular semigroup of size 37, with 6 
      generators>>, <right translation on <0-simple regular semigroup 
@@ -132,13 +134,77 @@ gap> GeneratorsOfSemigroup(R);
      generators>>, <right translation on <0-simple regular semigroup 
      of size 37, with 6 generators>> ]
           
-          
+#T# A tiny bit of brute force checking   
+gap> SEMIGROUPS.bruteforcetranshull := function(S)
+>   local a, d, L, R, H, linkedpairs, dclasses, rclasses, lclasses, reps, i, j, 
+>         l, r, flag;
+>   L := LeftTranslations(S);
+>   R := RightTranslations(S);
+>   H := TranslationalHullSemigroup(S);
+>   linkedpairs := [];
+>   dclasses := DClasses(S);
+>   reps := [];
+>   
+>   for d in dclasses do
+>     lclasses := ShallowCopy(LClasses(d));
+>     rclasses := ShallowCopy(RClasses(d));
+>     for i in [1 .. Minimum(Size(lclasses), Size(rclasses)) - 1] do
+>       r := Representative(Intersection(lclasses[1], rclasses[1]));
+>       Add(reps, r);
+>       Remove(lclasses, 1);
+>       Remove(rclasses, 1);
+>     od;
+>     if Size(lclasses) > Size(rclasses) then
+>       #Size(rclasses) = 1
+>       for j in [1 .. Size(lclasses)] do
+>         r := Representative(Intersection(lclasses[1], rclasses[1]));
+>         Add(reps, r);
+>         Remove(lclasses, 1);
+>       od;
+>     else
+>       #Size(lclasses) = 1
+>       for j in [1 .. Size(rclasses)] do
+>         r := Representative(Intersection(lclasses[1], rclasses[1]));
+>         Add(reps, r);
+>         Remove(rclasses, 1);
+>       od;
+>     fi;
+>   od;
+>   
+>   for l in L do
+>     for r in R do
+>       flag := true;
+>         for a in Cartesian(reps, reps) do
+>           if not a[1] * (a[2] ^ l) = (a[1] ^ r) * a[2] then
+>             flag := false;
+>             break;
+>           fi;
+>         od;
+>       if flag then 
+>         Add(linkedpairs, TranslationalHullElement(H, l, r));
+>       fi;
+>     od;
+>   od;
+>   return linkedpairs;
+> end;;
+gap> G := SmallGroup(4,1);;
+gap> H := ShallowCopy(AsList(G));;
+gap> mat := [[0, H[4]], [H[4], 0]];;
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> Size(TranslationalHull(S)) = Size(SEMIGROUPS.bruteforcetranshull(S));
+true
+gap> S := RectangularBand(2,3);;
+gap> Size(Semigroup(GeneratorsOfSemigroup(TranslationalHull(S))))
+> = Size(SEMIGROUPS.bruteforcetranshull(S));
+true
+
+#T# SEMIGROUPS_UnbindVariables
 gap> Unbind(G);
-gap> Unbind(G_list);
 gap> Unbind(L);
 gap> Unbind(H);
 gap> Unbind(R);
 gap> Unbind(S);
+gap> Unbind(SEMIGROUPS.bruteforcetranshull);
 
 #E#
 gap> STOP_TEST("Semigroups package: standard/translat.tst");

--- a/tst/standard/translat.tst
+++ b/tst/standard/translat.tst
@@ -1,7 +1,7 @@
 #############################################################################
 ##
-#W  standard/attributes.tst
-#Y  Copyright (C) 2016                                            Finn Smith
+#W  standard/translat.tst
+#Y  Copyright (C) 2016-17                                          Finn Smith
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -12,7 +12,6 @@ gap> LoadPackage("semigroups", false);;
 gap> SEMIGROUPS.StartTest();
 
 #T# Creation of translations semigroups
-# creation of left/right translations semigroups (without calculation)
 gap> S := RectangularBand(3,4);;
 gap> L := LeftTranslationsSemigroup(S);
 <the semigroup of left translations of <regular transformation semigroup 
@@ -237,21 +236,6 @@ true
 gap> Size(H);
 32
 
-#T# Make sure the generic method and special methods agree for hulls
-gap> S := RectangularBand(2,3);;
-gap> H := TranslationalHull(S);;
-gap> Semigroup(SEMIGROUPS.TranslationalHullElementsGeneric(H)) = H;
-true
-gap> G := SmallGroup(6, 1);;
-gap> a := G.1;; b := G.2;;
-gap> mat := [[a, 0, b],
-> [b, a, 0],
-> [0, a, b]];;
-gap> S := ReesZeroMatrixSemigroup(G, mat);;
-gap> H := TranslationalHull(S);;
-gap> Semigroup(SEMIGROUPS.TranslationalHullElementsGeneric(H)) = H;
-true
-
 #T# OneOp for translations semigroups elements and translational hull elements
 gap> G := SmallGroup(6, 1);;
 gap> a := G.1;; b := G.2;;
@@ -267,11 +251,25 @@ gap> OneOp(L.1) = LeftTranslation(L, MappingByFunction(S, S, x -> x));
 true
 gap> OneOp(R.1) = RightTranslation(R, MappingByFunction(S, S, x -> x));
 true
+gap> OneOp(Representative(H)) = TranslationalHullElement(
+> H, OneOp(L.1), OneOp(R.1));
+true
+
+#T# Make sure the generic method and special methods agree for hulls
+gap> Semigroup(SEMIGROUPS.TranslationalHullElementsGeneric(H)) = H;
+true
+gap> S := RectangularBand(2,3);;
+gap> H := TranslationalHull(S);;
+gap> Semigroup(SEMIGROUPS.TranslationalHullElementsGeneric(H)) = H;
+true
 
 #T# SEMIGROUPS_UnbindVariables
+gap> Unbind(a);
+gap> Unbind(b);
 gap> Unbind(G);
 gap> Unbind(L);
 gap> Unbind(H);
+gap> Unbind(mat);
 gap> Unbind(R);
 gap> Unbind(S);
 gap> Unbind(SEMIGROUPS.bruteforcetranshull);


### PR DESCRIPTION
I've decided to make this pull request now for visibility (and to force myself to work on this tidying this up), but there are some things to do before merging (detailed at the end).

This pull request adds functionality for translations and translational hulls of finite semigroups. Definitions and some results on this topic can be found in Howie's _Fundamentals of Semigroup theory_,.
Over an arbitrary semigroup, there may be far too many translations for any naive search to find. For certain semigroups, it is possible to give nice descriptions of the semigroup of left or right translations, and the translational hull. The cases implemented in this PR are:

1. Rectangular bands: complete description for the left/right translations semigroups and translational hull is known (given in Howie), allowing efficient computation of size, generators, etc. 
2. 0-simple semigroups: detailed in (Petrich, 1968).  For the left/right translations semigroup, can efficiently compute generators and size [0simpletranslations.pdf](https://github.com/gap-packages/Semigroups/files/795045/0simpletranslations.pdf). For the translational hull, an algorithm specific to RZMS is implemented.
3. Monoids: the left/right translations semigroups of a monoid are the inner translations semigroups; the translational hull is the inner translational hull.
4. Arbitrary semigroups: for a (small) semigroup with known generators, left/right translations can be computed as edge-label preserving endomorphisms of the right/left Cayley graph. Also implemented is a backtrack search for the elements of the translational hull, detailed in [transhull.pdf](https://github.com/gap-packages/Semigroups/files/794972/transhull.pdf)

Left/right translations are internally represented as transformations to act on the list AsList(S) of the underlying semigroup S. Translational hull elements (bitranslations) are stored as a pair [L, R] where L is a left translation and R is a right translation.  An important implementation detail is that such elements _must_ belong to a semigroup; they cannot be created alone. To avoid having to calculate the whole translations semigroup or translational hull to work with a single element, you can create the left/right translations semigroup or translational hull in one of two ways.

1. LeftTranslationsSemigroup, RightTranslationsSemigroup, TranslationalHullSemigroup are global functions that create semigroups of the correct sort, and store them in 
2. LeftTranslations, RightTranslations, TranslationalHull, which are attributes of the underlying semigroup. Calling these functions will cause a call to AsList and attempt to enumerate the semigroup, which may or may not be desired.

Work remaining to be completed includes: 

- some issues mentioned in the header of the translat.gi file, regarding objects not remembering properties
- increase code coverage in test files (currently 75-95%)
- reduce runtime of test files (currently ~10s)
- refactor parts of certain functions to be clearer (in particular, the backtrack search for arbitrary semigroups)
- complete documentation of functionality added recently (regarding inner translations)
- stylistic changes

Howie, J.M. (1995) 'Fundamentals of Semigroup theory'.  United Kingdom: Oxford University Press.
Petrich, M. (1968) ,‘The translational hull of a completely 0-simple semigroup’,Glasgow Mathematical Journal, 9(01), p. 1. doi: 10.1017/s0017089500000239