### PR TITLE
Lattice of congruences: info warning

### DIFF
--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -61,6 +61,10 @@ SEMIGROUPS.PrincipalXCongruencePosetNC := function(S, restriction, cong_func)
   local report, pairs, total, congs, nrcongs, children, parents, last_collected,
         nr, pair, badcong, newchildren, newparents, newcong, i, c, p, po, poset;
 
+  # Display warning
+  Info(InfoSemigroups, 1,
+       "Finding a semigroup's congruences can take a very long time!");
+
   # Suppress reporting
   report := SEMIGROUPS.OptionsRec(S).report;
   SEMIGROUPS.OptionsRec(S).report := false;


### PR DESCRIPTION
Finding all the congruences of a semigroup can take a long time, except for very small semigroups.  This PR sends an info warning to inform the user that this is the case - full disclosure!