### PR TITLE
Fix issue #264 (MultiplicativeZero for RZMS)

### DIFF
--- a/gap/semigroups/semirms.gi
+++ b/gap/semigroups/semirms.gi
@@ -240,14 +240,27 @@ end);
 InstallMethod(MultiplicativeZero, "for a Rees 0-matrix semigroup",
 [IsReesZeroMatrixSubsemigroup],
 function(R)
-  local rep, x;
-  rep := Representative(R);
-  x := MultiplicativeZero(ReesMatrixSemigroupOfFamily(FamilyObj(rep)));
+  local super, x, gens, row, col, i;
+
+  super := ReesMatrixSemigroupOfFamily(FamilyObj(Representative(R)));
+  x := MultiplicativeZero(super);
   if (HasIsReesZeroMatrixSemigroup(R) and IsReesZeroMatrixSemigroup(R))
       or x in R then
     return x;
   fi;
-  return fail;
+
+  gens := GeneratorsOfSemigroup(R);
+  row := RowOfReesZeroMatrixSemigroupElement(gens[1]);
+  col := ColumnOfReesZeroMatrixSemigroupElement(gens[1]);
+  for i in [2 .. Length(gens)] do
+    x := gens[i];
+    if RowOfReesZeroMatrixSemigroupElement(x) <> row or
+        ColumnOfReesZeroMatrixSemigroupElement(x) <> col then
+      return fail;
+    fi;
+  od;
+
+  TryNextMethod();
 end);
 
 # same method for ideals

--- a/tst/standard/semirms.tst
+++ b/tst/standard/semirms.tst
@@ -2094,7 +2094,7 @@ gap> x := RMSElementNC(R, 1, (1,2), 1);
 gap> x in R;
 true
 
-# Test MultiplicativeZero
+#T# semirms: MultiplicativeZero, for a Rees 0-matrix semigroup, 1
 gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(4),
 > [[(1, 3, 2), (), (1, 4, 2)],
 >  [(), (1, 3)(2, 4), (1, 2, 3, 4)],
@@ -2104,6 +2104,49 @@ gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(4),
 gap> R := Semigroup(R);;
 gap> MultiplicativeZero(R);
 0
+
+#T# semirms: MultiplicativeZero, for a Rees 0-matrix subsemigroup, 1
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
+gap> U := Semigroup(RMSElement(R, 1, (), 1));;
+gap> MultiplicativeZero(U);
+(1,(),1)
+gap> IsTrivial(U);
+true
+gap> R := ReesZeroMatrixSemigroup(
+>  Semigroup([Transformation([1, 1]), Transformation([2, 2])]),
+>  [[Transformation([1, 1])]]);;
+gap> U := Semigroup(RMSElement(R, 1, Transformation([1, 1]), 1));
+<subsemigroup of 1x1 Rees 0-matrix semigroup with 1 generator>
+gap> MultiplicativeZero(U);
+(1,Transformation( [ 1, 1 ] ),1)
+
+#T# semirms: MultiplicativeZero, for a Rees 0-matrix subsemigroup, 2
+gap> G := SymmetricGroup(3);;
+gap> R := ReesZeroMatrixSemigroup(G,
+> [[(), 0, (1, 2)],
+>  [(), (1, 3, 2), (1, 2)],
+>  [(1, 3), 0, (1, 3, 2)]]);
+<Rees 0-matrix semigroup 3x3 over Sym( [ 1 .. 3 ] )>
+gap> U := ReesZeroMatrixSubsemigroup(R, [1], G, [1, 3]);
+<subsemigroup of 3x3 Rees 0-matrix semigroup with 3 generators>
+gap> MultiplicativeZero(U);
+fail
+gap> U := ReesZeroMatrixSubsemigroup(R, [1, 3], G, [1]);
+<subsemigroup of 3x3 Rees 0-matrix semigroup with 3 generators>
+gap> MultiplicativeZero(U);
+fail
+gap> U := ReesZeroMatrixSubsemigroup(R, [1, 3], G, [1, 3]);
+<subsemigroup of 3x3 Rees 0-matrix semigroup with 4 generators>
+gap> MultiplicativeZero(U);
+fail
+gap> U := ReesZeroMatrixSubsemigroup(R, [3], G, [3]);
+<subsemigroup of 3x3 Rees 0-matrix semigroup with 2 generators>
+gap> MultiplicativeZero(U);
+fail
+gap> U := ReesZeroMatrixSubsemigroup(R, [1], Group(()), [1]);
+<subsemigroup of 3x3 Rees 0-matrix semigroup with 1 generator>
+gap> MultiplicativeZero(U);
+(1,(),1)
 
 # Test IsomorphismPermGroup
 gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(4),


### PR DESCRIPTION
This PR resolves issue #264.

Let `R` be a Rees 0-matrix semigroup and let `U` be a subsemigroup of `R`. To check whether `U` had a multiplicative zero, the code previously essentially returned `true` if and only if `U` contained the special `0` element of `R`.

However, there is more to it than this. If `U` doesn't contain the `0` element of `R`, then it still might contain a multiplicative zero. If `U` contains elements from multiple rows or columns of `R`, then (fairly obviously) it can't have a multiplicative zero. I have added code to check this case. Otherwise, when `U` contains elements all from the same row and column `R`, there is more work to be done. I have added a `TryNextMethod` at the end of the function to handle this case - it will use the more general `MultiplicativeZero` methods.