### PR TITLE
makefile: add libsemigroups/util/uf.cc to SOURCES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ semigroups_la_SOURCES += src/libsemigroups/elements.cc
 semigroups_la_SOURCES += src/libsemigroups/rws.cc
 semigroups_la_SOURCES += src/libsemigroups/rwse.cc
 semigroups_la_SOURCES += src/libsemigroups/semigroups.cc 
+semigroups_la_SOURCES += src/libsemigroups/util/uf.cc
 
 semigroups_la_CXXFLAGS = -std=c++11 -O3 -g -DNDEBUG
 


### PR DESCRIPTION
This causes things to be linked properly together on my PC, as described in [libsemigroups issue #25](https://github.com/james-d-mitchell/libsemigroups/issues/25).