### PR TITLE
conglatt: avoid extra work in BlistList

### DIFF
--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -168,7 +168,7 @@ function(poset, join_func)
   length := 0;
   found := true;
   # 'ignore' is a list of congs that we don't try joining
-  ignore := BlistList(congs, []);
+  ignore := BlistList([1 .. nrcongs], []);
   while found do
     # There are new congs to try joining
     start := length + 1;     # New congs start here

--- a/tst/standard/conglatt.tst
+++ b/tst/standard/conglatt.tst
@@ -123,15 +123,11 @@ gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([2, 2, 2])];;
 gap> latt := LatticeOfRightCongruences(S, restriction);
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ] ]
-gap> CongruencesOfPoset(latt);
-[ <right semigroup congruence over <transformation semigroup of size 11, 
-     degree 3 with 2 generators> with 0 generating pairs>, 
-  <right semigroup congruence over <transformation semigroup of size 11, 
-     degree 3 with 2 generators> with 1 generating pairs>, 
-  <right semigroup congruence over <transformation semigroup of size 11, 
-     degree 3 with 2 generators> with 1 generating pairs>, 
-  <right semigroup congruence over <transformation semigroup of size 11, 
-     degree 3 with 2 generators> with 1 generating pairs> ]
+gap> congs := CongruencesOfPoset(latt);;
+gap> Length(congs);
+4
+gap> IsDuplicateFreeList(congs);
+true
 gap> restriction := [Transformation([3, 1, 3]), Transformation([3, 2, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
 [ [  ], [ 1 ] ]


### PR DESCRIPTION
@james-d-mitchell found a problem when using `LatticeOfCongruences`, which looked like this:

```gap
gap> LoadPackage("smallsemi", false);;
gap> S := AsSemigroup(IsTransformationSemigroup, SmallSemigroup(5, 11));;
gap> LatticeOfCongruences(S);
Error, UniteSet: <set1> must be a mutable proper set (not a list (plain,hom,nsort)) in
  UniteSet( I, AsSSortedList( C2 ) ); at /home/mtorpey/gap/lib/coll.gi:2573 called from 
Union2( tounite[1], tounite[2] ) at /home/mtorpey/gap/lib/coll.gi:2764 called from
Union( PreImagesRange( map1 ), PreImagesRange( map2 ) ) at /home/mtorpey/gap/lib/mapping.gi:1420 called from
...
```

It turns out this isn't to do with the lattice code, but an issue with smallsemi and `AsSemigroup` which I've now made into Issue #269.  However, I was surprised to see that so much work was being done sorting sets and so on from a call to `BlistList`.

The line I've changed simply creates an all-false blist with length the same length as `congs`.  When we call `BlistList(congs, [])` it does all sorts of stuff making sure `congs` is sorted and duplicate-free and so on, which is where the error was hit.  To avoid doing all that stuff, I've just changed it to use a range.  This does in fact fix the original problem that was encountered (although #269 still needs to be fixed) and is theoretically faster.