### PR TITLE
Add CongruenceTestMembershipNC

### DIFF
--- a/gap/congruences/cong.gd
+++ b/gap/congruences/cong.gd
@@ -118,3 +118,8 @@ DeclareOperation("LeftCongruenceClassOfElement", [IsLeftSemigroupCongruence,
                                                   IsMultiplicativeElement]);
 DeclareOperation("RightCongruenceClassOfElement", [IsRightSemigroupCongruence,
                                                    IsMultiplicativeElement]);
+
+# No-checks version of the "\in" operation
+DeclareOperation("CongruenceTestMembershipNC", [IsEquivalenceRelation,
+                                                IsMultiplicativeElement,
+                                                IsMultiplicativeElement]);

--- a/gap/congruences/cong.gi
+++ b/gap/congruences/cong.gi
@@ -21,6 +21,44 @@
 ## cong.gd contains declarations for many of these.
 ##
 
+InstallMethod(\in,
+"for dense list and left semigroup congruence",
+[IsDenseList, IsLeftSemigroupCongruence],
+function(pair, cong)
+  local S;
+  S := Range(cong);
+  if Size(pair) <> 2 then
+    ErrorNoReturn("Semigroups: \\in (for a relation): usage,\n",
+                  "the first arg <pair> must be a list of length 2,");
+  elif not (pair[1] in S and pair[2] in S) then
+    ErrorNoReturn("Semigroups: \\in (for a relation): usage,\n",
+                  "elements of the first arg <pair> must be\n",
+                  "in the range of the second arg <cong>,");
+  elif CanEasilyCompareElements(pair[1]) and pair[1] = pair[2] then
+    return true;
+  fi;
+  return CongruenceTestMembershipNC(cong, pair[1], pair[2]);
+end);
+
+InstallMethod(\in,
+"for dense list and right semigroup congruence",
+[IsDenseList, IsRightSemigroupCongruence],
+function(pair, cong)
+  local S;
+  S := Range(cong);
+  if Size(pair) <> 2 then
+    ErrorNoReturn("Semigroups: \\in (for a relation): usage,\n",
+                  "the first arg <pair> must be a list of length 2,");
+  elif not (pair[1] in S and pair[2] in S) then
+    ErrorNoReturn("Semigroups: \\in (for a relation): usage,\n",
+                  "elements of the first arg <pair> must be\n",
+                  "in the range of the second arg <cong>,");
+  elif CanEasilyCompareElements(pair[1]) and pair[1] = pair[2] then
+    return true;
+  fi;
+  return CongruenceTestMembershipNC(cong, pair[1], pair[2]);
+end);
+
 BindGlobal("_GenericCongEquality",
 function(cong1, cong2)
   local S;

--- a/gap/congruences/congfpmon.gi
+++ b/gap/congruences/congfpmon.gi
@@ -169,23 +169,11 @@ function(cong1, cong2)
   return SEMIGROUPS.FpMonCongFromFpSemiCong(M, iso, join);
 end);
 
-InstallMethod(\in,
-"for a multiplicative element collection and an fp monoid congruence",
-[IsMultiplicativeElementCollection, IsFpMonoidCongruence],
-function(pair, cong)
-  local M;
-  # Input checks
-  M := Range(cong);
-  if Size(pair) <> 2 then
-    ErrorNoReturn("Semigroups: \\in (for a congruence): usage,\n",
-                  "the first arg <pair> must be a list of length 2,");
-  fi;
-  if not (pair[1] in M and pair[2] in M) then
-    ErrorNoReturn("Semigroups: \\in (for a congruence): usage,\n",
-                  "elements of the first arg <pair> must be\n",
-                  "in the range of the second arg <cong>,");
-  fi;
-  return [pair[1] ^ cong!.iso, pair[2] ^ cong!.iso] in cong!.semicong;
+InstallMethod(CongruenceTestMembershipNC,
+"for fp monoid congruence and two multiplicative elements",
+[IsFpMonoidCongruence, IsMultiplicativeElement, IsMultiplicativeElement],
+function(cong, elm1, elm2)
+  return [elm1 ^ cong!.iso, elm2 ^ cong!.iso] in cong!.semicong;
 end);
 
 InstallMethod(ImagesElm,

--- a/gap/congruences/conginv.gi
+++ b/gap/congruences/conginv.gi
@@ -240,26 +240,16 @@ function(cong)
   return table;
 end);
 
-InstallMethod(\in,
-"for dense list and inverse semigroup congruence",
-[IsDenseList, IsInverseSemigroupCongruenceByKernelTrace],
-function(pair, cong)
-  local S;
-  if Size(pair) <> 2 then
-    ErrorNoReturn("Semigroups: \\in: usage,\n",
-                  "the first arg <pair> must be a list of length 2,");
-  fi;
-  S := Range(cong);
-  if not (pair[1] in S and pair[2] in S) then
-    ErrorNoReturn("Semigroups: \\in: usage,\n",
-                  "the entries of the first arg <pair> must\n",
-                  "belong to the semigroup of <cong>,");
-  fi;
+InstallMethod(CongruenceTestMembershipNC,
+"for inverse semigroup congruence and two multiplicative elements",
+[IsInverseSemigroupCongruenceByKernelTrace,
+ IsMultiplicativeElement, IsMultiplicativeElement],
+function(cong, elm1, elm2)
   # Is (a^-1 a, b^-1 b) in the trace?
-  if pair[1] ^ -1 * pair[1] in
-      First(cong!.traceBlocks, c -> pair[2] ^ -1 * pair[2] in c) then
+  if elm1 ^ -1 * elm1 in
+      First(cong!.traceBlocks, c -> elm2 ^ -1 * elm2 in c) then
     # Is ab^-1 in the kernel?
-    if pair[1] * pair[2] ^ -1 in cong!.kernel then
+    if elm1 * elm2 ^ -1 in cong!.kernel then
       return true;
     fi;
   fi;

--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -59,7 +59,8 @@ end);
 
 SEMIGROUPS.PrincipalXCongruencePosetNC := function(S, restriction, cong_func)
   local report, pairs, total, congs, nrcongs, children, parents, last_collected,
-        nr, pair, badcong, newchildren, newparents, newcong, i, c, p, po, poset;
+        nr, pair, badcong, newchildren, newparents, newcong, i, pair1, c, p, po,
+        poset;
 
   # Suppress reporting
   report := SEMIGROUPS.OptionsRec(S).report;
@@ -83,15 +84,16 @@ SEMIGROUPS.PrincipalXCongruencePosetNC := function(S, restriction, cong_func)
     newparents := [];  # Parents of newcong
     newcong := cong_func(S, pair);
     for i in [1 .. Length(congs)] do
-      if CONG_PAIRS_IN(congs[i], pair) then
-        if CONG_PAIRS_IN(newcong, congs[i]!.genpairs[1]) then
+      pair1 := congs[i]!.genpairs[1];
+      if CongruenceTestMembershipNC(congs[i], pair[1], pair[2]) then
+        if CongruenceTestMembershipNC(newcong, pair1[1], pair1[2]) then
           # This is not a new cong - drop it!
           badcong := true;
           break;
         else
           Add(newparents, i);
         fi;
-      elif CONG_PAIRS_IN(newcong, congs[i]!.genpairs[1]) then
+      elif CongruenceTestMembershipNC(newcong, pair1[1], pair1[2]) then
         Add(newchildren, i);
       fi;
     od;

--- a/gap/congruences/congpairs.gi
+++ b/gap/congruences/congpairs.gi
@@ -525,44 +525,22 @@ function(cong1, cong2)
   return ForAll(cong2!.genpairs, pair -> pair in cong1);
 end);
 
-InstallMethod(\in,
-"for dense list and enumerable semigroup congruence",
-[IsDenseList, IsEnumerableSemigroupCongruence],
-function(pair, cong)
-  local S;
-  S := Range(cong);
-  if Size(pair) <> 2 then
-    ErrorNoReturn("Semigroups: \\in (for a congruence): usage,\n",
-                  "the first arg <pair> must be a list of length 2,");
-  elif not (pair[1] in S and pair[2] in S) then
-    ErrorNoReturn("Semigroups: \\in (for a congruence): usage,\n",
-                  "elements of the first arg <pair> must be\n",
-                  "in the range of the second arg <cong>,");
-  elif CanEasilyCompareElements(pair[1]) and pair[1] = pair[2] then
-    return true;
-  fi;
-  return CONG_PAIRS_IN(cong, pair);
+InstallMethod(CongruenceTestMembershipNC,
+"for enumerable semigroup congruence and two elements",
+[IsEnumerableSemigroupCongruence,
+ IsMultiplicativeElement, IsMultiplicativeElement],
+function(cong, elm1, elm2)
+  return CONG_PAIRS_IN(cong, elm1, elm2);
 end);
 
-InstallMethod(\in,
-"for dense list and fp semigroup congruence",
-[IsDenseList, IsFpSemigroupCongruence],
-function(pair, cong)
-  local S;
-  S := Range(cong);
-  if Size(pair) <> 2 then
-    ErrorNoReturn("Semigroups: \\in (for a congruence): usage,\n",
-                  "the first arg <pair> must be a list of length 2,");
-  elif not (pair[1] in S and pair[2] in S) then
-    ErrorNoReturn("Semigroups: \\in (for a congruence): usage,\n",
-                  "elements of the first arg <pair> must be\n",
-                  "in the range of the second arg <cong>,");
-  elif CanEasilyCompareElements(pair[1]) and pair[1] = pair[2] then
-    return true;
-  fi;
-  pair := [SEMIGROUPS.ExtRepObjToWord(ExtRepOfObj(pair[1])),
-           SEMIGROUPS.ExtRepObjToWord(ExtRepOfObj(pair[2]))];
-  return CONG_PAIRS_IN(cong, pair);
+InstallMethod(CongruenceTestMembershipNC,
+"for fp semigroup congruence and two elements",
+[IsFpSemigroupCongruence, IsMultiplicativeElement, IsMultiplicativeElement],
+function(cong, elm1, elm2)
+  local word1, word2;
+  word1 := SEMIGROUPS.ExtRepObjToWord(ExtRepOfObj(elm1));
+  word2 := SEMIGROUPS.ExtRepObjToWord(ExtRepOfObj(elm2));
+  return CONG_PAIRS_IN(cong, word1, word2);
 end);
 
 InstallMethod(\=,

--- a/gap/congruences/congrees.gi
+++ b/gap/congruences/congrees.gi
@@ -122,24 +122,13 @@ function(cong1, cong2)
   return ForAll(GeneratorsOfSemigroupIdeal(i2), gen -> gen in i1);
 end);
 
-InstallMethod(\in,
-"for a multiplicative element collection and a Rees congruence",
-[IsMultiplicativeElementCollection, IsReesCongruence],
-function(pair, cong)
-  local S, I;
-  # Check for validity
-  if Size(pair) <> 2 then
-    ErrorNoReturn("Semigroups: \\in: usage,\n",
-                  "the first arg <pair> must be a list of length 2,");
-  fi;
-  S := Range(cong);
-  if not ForAll(pair, x -> x in S) then
-    ErrorNoReturn("Semigroups: \\in: usage,\n",
-                  "the elements of 1st arg <pair> ",
-                  "must be in the range of 2nd arg <cong>,");
-  fi;
+InstallMethod(CongruenceTestMembershipNC,
+"for Rees congruence and two multiplicative elements",
+[IsReesCongruence, IsMultiplicativeElement, IsMultiplicativeElement],
+function(cong, elm1, elm2)
+  local I;
   I := SemigroupIdealOfReesCongruence(cong);
-  return (pair[1] = pair[2]) or (pair[1] in I and pair[2] in I);
+  return (elm1 = elm2) or (elm1 in I and elm2 in I);
 end);
 
 InstallMethod(ImagesElm,

--- a/gap/congruences/congrms.gi
+++ b/gap/congruences/congrms.gi
@@ -531,31 +531,19 @@ function(cong1, cong2)
                     b2 -> ForAny(cong1!.rowBlocks, b1 -> IsSubset(b1, b2)));
 end);
 
-InstallMethod(\in,
-"for RMS element coll and a semigroup congruence by linked triple",
-[IsReesMatrixSemigroupElementCollection, IsRMSCongruenceByLinkedTriple],
-function(pair, cong)
-  local S, i, a, u, j, b, v, mat, gpElm;
-
-  # Check for validity
-  if Size(pair) <> 2 then
-    ErrorNoReturn("Semigroups: \\in: usage,\n",
-                  "the first arg <pair> must be a list of length 2,");
-  fi;
-  S := Range(cong);
-  if not ForAll(pair, x -> x in S) then
-    ErrorNoReturn("Semigroups: \\in: usage,\n",
-                  "elements of first arg <pair> ",
-                  "must be in range of second arg <cong>,");
-  fi;
-
+InstallMethod(CongruenceTestMembershipNC,
+"for RMS congruence by linked triple and two RMS elements",
+[IsRMSCongruenceByLinkedTriple,
+ IsReesMatrixSemigroupElement, IsReesMatrixSemigroupElement],
+function(cong, elm1, elm2)
+  local i, a, u, j, b, v, mat, gpElm;
   # Read the elements as (i,a,u) and (j,b,v)
-  i := pair[1][1];
-  a := pair[1][2];
-  u := pair[1][3];
-  j := pair[2][1];
-  b := pair[2][2];
-  v := pair[2][3];
+  i := elm1[1];
+  a := elm1[2];
+  u := elm1[3];
+  j := elm2[1];
+  b := elm2[2];
+  v := elm2[3];
 
   # First, the columns and rows must be related
   if not (cong!.colLookup[i] = cong!.colLookup[j] and
@@ -564,43 +552,33 @@ function(pair, cong)
   fi;
 
   # Finally, check Lemma 3.5.6(2) in Howie, with row 1 and column 1
-  mat := Matrix(S);
+  mat := Matrix(Range(cong));
   gpElm := mat[1][i] * a * mat[u][1] * Inverse(mat[1][j] * b * mat[v][1]);
   return gpElm in cong!.n;
 end);
 
-InstallMethod(\in,
-"for RZMS elements and semigroup congruence by linked triple",
-[IsReesZeroMatrixSemigroupElementCollection, IsRZMSCongruenceByLinkedTriple],
-function(pair, cong)
-  local S, mat, gpElm, row, col, rows, cols, a, i, u, j, b, v;
-
-  # Check for validity
-  if Size(pair) <> 2 then
-    ErrorNoReturn("Semigroups: \\in: usage,\n",
-                  "the first arg <pair> must be a list of length 2,");
-  fi;
+InstallMethod(CongruenceTestMembershipNC,
+"for RZMS congruence by linked triple and two RZMS elements",
+[IsRZMSCongruenceByLinkedTriple,
+ IsReesZeroMatrixSemigroupElement, IsReesZeroMatrixSemigroupElement],
+function(cong, elm1, elm2)
+  local S, i, a, u, j, b, v, mat, rows, cols, col, row, gpElm;
   S := Range(cong);
-  if not ForAll(pair, x -> x in S) then
-    ErrorNoReturn("Semigroups: \\in: usage,\n",
-                  "elements of first arg <pair> ",
-                  "must be in range of second arg <cong>,");
-  fi;
 
   # Handling the case when one or more of the pair are zero
-  if pair[1] = pair[2] then
+  if elm1 = elm2 then
     return true;
-  elif MultiplicativeZero(S) in pair then
+  elif elm1 = MultiplicativeZero(S) or elm2 = MultiplicativeZero(S) then
     return false;
   fi;
 
   # Read the elements as (i,a,u) and (j,b,v)
-  i := pair[1][1];
-  a := pair[1][2];
-  u := pair[1][3];
-  j := pair[2][1];
-  b := pair[2][2];
-  v := pair[2][3];
+  i := elm1[1];
+  a := elm1[2];
+  u := elm1[3];
+  j := elm2[1];
+  b := elm2[2];
+  v := elm2[3];
 
   # First, the columns and rows must be related
   if not (cong!.colLookup[i] = cong!.colLookup[j] and

--- a/gap/congruences/congsimple.gi
+++ b/gap/congruences/congsimple.gi
@@ -95,23 +95,11 @@ function(cong1, cong2)
   return SEMIGROUPS.SimpleCongFromRMSCong(Range(cong1), cong1!.iso, meet);
 end);
 
-InstallMethod(\in,
-"for a multiplicative element collection and a (0-)simple semigroup congruence",
-[IsMultiplicativeElementCollection, IsSimpleSemigroupCongruence],
-function(pair, cong)
-  local S;
-    # Input checks
-    S := Range(cong);
-    if Size(pair) <> 2 then
-      ErrorNoReturn("Semigroups: \\in (for a congruence): usage,\n",
-                    "the first arg <pair> must be a list of length 2,");
-    fi;
-    if not (pair[1] in S and pair[2] in S) then
-      ErrorNoReturn("Semigroups: \\in (for a congruence): usage,\n",
-                    "elements of the first arg <pair> must be\n",
-                    "in the range of the second arg <cong>,");
-    fi;
-  return [pair[1] ^ cong!.iso, pair[2] ^ cong!.iso] in cong!.rmscong;
+InstallMethod(CongruenceTestMembershipNC,
+"for (0-)simple semigroup congruence and two multiplicative elements",
+[IsSimpleSemigroupCongruence, IsMultiplicativeElement, IsMultiplicativeElement],
+function(cong, elm1, elm2)
+  return [elm1 ^ cong!.iso, elm2 ^ cong!.iso] in cong!.rmscong;
 end);
 
 InstallMethod(ImagesElm,

--- a/gap/congruences/conguniv.gi
+++ b/gap/congruences/conguniv.gi
@@ -113,13 +113,12 @@ function(pcong, ucong)
   return Range(ucong) = Range(pcong) and NrEquivalenceClasses(pcong) = 1;
 end);
 
-InstallMethod(\in,
-"for dense list and universal semigroup congruence",
-[IsDenseList, IsUniversalSemigroupCongruence],
-function(pair, cong)
-  return(Size(pair) = 2
-          and pair[1] in Range(cong)
-          and pair[2] in Range(cong));
+InstallMethod(CongruenceTestMembershipNC,
+"for universal semigroup congruence and two multiplicative elements",
+[IsUniversalSemigroupCongruence,
+ IsMultiplicativeElement, IsMultiplicativeElement],
+function(pair, elm1, elm2)
+  return true;
 end);
 
 InstallMethod(IsSubrelation,

--- a/src/congpairs.cc
+++ b/src/congpairs.cc
@@ -216,18 +216,18 @@ Obj CONG_PAIRS_NR_CLASSES(Obj self, gap_cong_t o) {
   return INTOBJ_INT(cong_obj_get_cpp(o)->nr_classes());
 }
 
-Obj CONG_PAIRS_IN(Obj self, gap_cong_t o, gap_list_t pair) {
+Obj CONG_PAIRS_IN(Obj self, gap_cong_t o, Obj elm1, Obj elm2) {
   initRNams();
 
   word_t lhs, rhs;
 
   if (cong_obj_is_fp_cong(o)) {
-    lhs = plist_to_word_t(ELM_LIST(pair, 1));
-    rhs = plist_to_word_t(ELM_LIST(pair, 2));
+    lhs = plist_to_word_t(elm1);
+    rhs = plist_to_word_t(elm2);
   } else {
-    gap_semigroup_t S = cong_obj_get_range_obj(o);
-    size_t lhs_pos    = INT_INTOBJ(EN_SEMI_POSITION(0L, S, ELM_LIST(pair, 1)));
-    size_t rhs_pos    = INT_INTOBJ(EN_SEMI_POSITION(0L, S, ELM_LIST(pair, 2)));
+    gap_semigroup_t S       = cong_obj_get_range_obj(o);
+    size_t          lhs_pos = INT_INTOBJ(EN_SEMI_POSITION(0L, S, elm1));
+    size_t          rhs_pos = INT_INTOBJ(EN_SEMI_POSITION(0L, S, elm2));
     assert(lhs_pos != Semigroup::UNDEFINED);
     assert(rhs_pos != Semigroup::UNDEFINED);
 

--- a/src/congpairs.h
+++ b/src/congpairs.h
@@ -24,7 +24,7 @@
 // GAP level functions
 
 Obj CONG_PAIRS_NR_CLASSES(Obj, Obj);
-Obj CONG_PAIRS_IN(Obj, Obj, Obj);
+Obj CONG_PAIRS_IN(Obj, Obj, Obj, Obj);
 Obj CONG_PAIRS_LESS_THAN(Obj, Obj, Obj, Obj);
 Obj CONG_PAIRS_LOOKUP_PART(Obj, Obj);
 Obj CONG_PAIRS_ELM_COSET_ID(Obj, Obj, Obj);

--- a/src/pkg.cc
+++ b/src/pkg.cc
@@ -463,7 +463,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_ENTRY("semigrp.cc", EN_SEMI_NEXT_ITERATOR_SORTED, 1, "iter"),
 
     GVAR_ENTRY("congpairs.cc", CONG_PAIRS_NR_CLASSES, 1, "cong"),
-    GVAR_ENTRY("congpairs.cc", CONG_PAIRS_IN, 2, "cong, pair"),
+    GVAR_ENTRY("congpairs.cc", CONG_PAIRS_IN, 3, "cong, elm1, elm2"),
     GVAR_ENTRY("congpairs.cc", CONG_PAIRS_LESS_THAN, 3, "cong, rep1, rep2"),
     GVAR_ENTRY("congpairs.cc", CONG_PAIRS_LOOKUP_PART, 1, "cong"),
     GVAR_ENTRY("congpairs.cc", CONG_PAIRS_ELM_COSET_ID, 2, "cong, elm"),

--- a/tst/standard/cong.tst
+++ b/tst/standard/cong.tst
@@ -35,6 +35,38 @@ gap> SemigroupCongruence(S, 12, 13, 100);
 Error, Semigroups: SemigroupCongruence: usage,
 the arguments are not valid for this function,
 
+#T# \in: Bad input
+gap> S := Semigroup(Transformation([2, 1, 1, 2, 1]),
+>                   Transformation([2, 4, 2, 3, 5]),
+>                   Transformation([3, 4, 3, 4, 3]),
+>                   Transformation([4, 3, 3, 4, 4]));;
+gap> pair1 := [Transformation([3, 4, 3, 4, 3]),
+>              Transformation([1, 2, 1, 2, 1])];;
+gap> cong := LeftSemigroupCongruence(S, pair1);;
+gap> [Transformation([2, 1, 1, 2, 1])] in cong;
+Error, Semigroups: \in (for a relation): usage,
+the first arg <pair> must be a list of length 2,
+gap> [Transformation([2, 1, 1, 2, 1]), Transformation([5, 2, 1, 2, 2])] in cong;
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
+gap> cong := RightSemigroupCongruence(S, pair1);;
+gap> [Transformation([2, 1, 1, 2, 1])] in cong;
+Error, Semigroups: \in (for a relation): usage,
+the first arg <pair> must be a list of length 2,
+gap> [Transformation([2, 1, 1, 2, 1]), Transformation([5, 2, 1, 2, 2])] in cong;
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
+gap> cong := SemigroupCongruence(S, pair1);;
+gap> [Transformation([2, 1, 1, 2, 1])] in cong;
+Error, Semigroups: \in (for a relation): usage,
+the first arg <pair> must be a list of length 2,
+gap> [Transformation([2, 1, 1, 2, 1]), Transformation([5, 2, 1, 2, 2])] in cong;
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
+
 #T# SemigroupCongruence: Infinite semigroup
 gap> S := FreeSemigroup(2);;
 gap> SemigroupCongruence(S, [S.1, S.2]);
@@ -110,10 +142,14 @@ gap> EquivalenceRelationCanonicalPartition(cong);
 #T# SemigroupCongruence: left congruence
 gap> S := Semigroup([Transformation([3, 3, 3]),
 >                    Transformation([3, 4, 3, 3])]);;
-gap> pairs := [Transformation([3, 4, 3, 3]), Transformation([3, 3, 3, 3])];;
-gap> cong := LeftSemigroupCongruence(S, pairs);;
+gap> pair := [Transformation([3, 4, 3, 3]), Transformation([3, 3, 3, 3])];;
+gap> cong := LeftSemigroupCongruence(S, pair);;
 gap> EquivalenceRelationCanonicalPartition(cong);
 [ [ Transformation( [ 3, 3, 3, 3 ] ), Transformation( [ 3, 4, 3, 3 ] ) ] ]
+gap> pair in cong;
+true
+gap> [S.1, S.1] in cong;
+true
 
 #T# SemigroupCongruence: Giving an RMS cong
 gap> S := Semigroup(MinimalIdeal(FullTransformationMonoid(5)));;

--- a/tst/standard/congfpmon.tst
+++ b/tst/standard/congfpmon.tst
@@ -36,10 +36,10 @@ Error, Semigroups: RightSemigroupCongruenceByGeneratingPairs: usage,
 <pairs> must all be lists of elements of <M>,
 gap> cong := SemigroupCongruenceByGeneratingPairs(M, [[M.1, M.2]]);;
 gap> [M.1, M.2, M.2 ^ 2] in cong;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [F.1, F.2] in cong;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 elements of the first arg <pair> must be
 in the range of the second arg <cong>,
 gap> EquivalenceClassOfElement(cong, Transformation([1, 2, 1]));

--- a/tst/standard/conginv.tst
+++ b/tst/standard/conginv.tst
@@ -169,12 +169,12 @@ gap> S := InverseSemigroup([PartialPerm([1, 2, 3], [2, 5, 3]),
 gap> cong := SemigroupCongruence(S,
 >  [PartialPerm([4], [4]), PartialPerm([2], [1])]);;
 gap> [2] in cong;
-Error, Semigroups: \in: usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [PartialPerm([4], [4]), 42] in cong;
-Error, Semigroups: \in: usage,
-the entries of the first arg <pair> must
-belong to the semigroup of <cong>,
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
 gap> EquivalenceClassOfElement(cong, (2, 5, 4));
 Error, Semigroups: EquivalenceClassOfElement: usage,
 the second arg <elm> must be in the

--- a/tst/standard/congpairs.tst
+++ b/tst/standard/congpairs.tst
@@ -313,10 +313,10 @@ gap> pair1 := [Transformation([3, 4, 3, 4, 3]),
 >              Transformation([1, 2, 1, 2, 1])];;
 gap> cong := SemigroupCongruence(S, pair1);;
 gap> [Transformation([2, 1, 1, 2, 1])] in cong;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [Transformation([2, 1, 1, 2, 1]), Transformation([5, 2, 1, 2, 2])] in cong;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 elements of the first arg <pair> must be
 in the range of the second arg <cong>,
 
@@ -358,7 +358,7 @@ gap> class := CongruenceClassOfElement(cong, Transformation([1, 2, 2, 2, 1]));;
 gap> Transformation([1, 1, 5, 1, 1]) in class;
 true
 gap> Transformation([6, 2, 3, 4, 1, 1]) in class;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 elements of the first arg <pair> must be
 in the range of the second arg <cong>,
 gap> Size(class);
@@ -620,10 +620,10 @@ gap> S := F / [[F.2 ^ 2, F.2],
 gap> pair := [S.1 * S.2 * S.1, S.1];;
 gap> cong := RightSemigroupCongruence(S, pair);;
 gap> [Transformation([2, 1, 1, 2, 1])] in cong;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [Transformation([2, 1, 1, 2, 1]), Transformation([5, 2, 1, 2, 2])] in cong;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 elements of the first arg <pair> must be
 in the range of the second arg <cong>,
 

--- a/tst/standard/congrees.tst
+++ b/tst/standard/congrees.tst
@@ -107,11 +107,12 @@ false
 gap> [x, x] in cong;
 true
 gap> [x, y, y] in cong;
-Error, Semigroups: \in: usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [x, z] in cong;
-Error, Semigroups: \in: usage,
-the elements of 1st arg <pair> must be in the range of 2nd arg <cong>,
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
 gap> t := Transformation([1, 3, 4, 1, 4]);;   # in i
 gap> [t, y] in cong;
 true

--- a/tst/standard/congrms.tst
+++ b/tst/standard/congrms.tst
@@ -104,14 +104,15 @@ false
 gap> [y, z] in cong;
 false
 gap> [x] in cong;
-Error, Semigroups: \in: usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [x, y, z] in cong;
-Error, Semigroups: \in: usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [t, t] in cong;
-Error, Semigroups: \in: usage,
-elements of first arg <pair> must be in range of second arg <cong>,
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
 gap> ims := ImagesElm(cong, t);
 Error, Semigroups: ImagesElm: usage,
 the args <cong> and <elm> must refer to the same semigroup,
@@ -347,14 +348,15 @@ gap> y := ReesZeroMatrixSemigroupElement(S, 6, (1, 3, 5), 1);;
 gap> [x, y] in cong;
 true
 gap> [x] in cong;
-Error, Semigroups: \in: usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [x, y, z] in cong;
-Error, Semigroups: \in: usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [t, t] in cong;
-Error, Semigroups: \in: usage,
-elements of first arg <pair> must be in range of second arg <cong>,
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
 gap> [x, x] in cong;
 true
 gap> [zero, zero] in cong;

--- a/tst/standard/congsimple.tst
+++ b/tst/standard/congsimple.tst
@@ -53,10 +53,10 @@ true
 gap> [x, z] in cong;
 false
 gap> [x, y, z] in cong;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 the first arg <pair> must be a list of length 2,
 gap> [Transformation([2, 1, 1, 2, 1]), Transformation([5, 2, 1, 2, 2])] in cong;
-Error, Semigroups: \in (for a congruence): usage,
+Error, Semigroups: \in (for a relation): usage,
 elements of the first arg <pair> must be
 in the range of the second arg <cong>,
 

--- a/tst/standard/conguniv.tst
+++ b/tst/standard/conguniv.tst
@@ -116,11 +116,16 @@ gap> uni := UniversalSemigroupCongruence(S);;
 gap> [Transformation([1, 4, 2, 4]), Transformation([1, 4, 4, 4])] in uni;
 true
 gap> [Transformation([1, 3, 2, 4]), Transformation([1, 4, 4, 4])] in uni;
-false
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
 gap> [3, 4] in uni;
-false
+Error, Semigroups: \in (for a relation): usage,
+elements of the first arg <pair> must be
+in the range of the second arg <cong>,
 gap> [Transformation([1, 4, 2, 4])] in uni;
-false
+Error, Semigroups: \in (for a relation): usage,
+the first arg <pair> must be a list of length 2,
 
 #T# Classes
 gap> S := Semigroup([PartialPerm([1, 2], [3, 1]),


### PR DESCRIPTION
**tldr: this is a "no checks" version of `\in` for congruences.**

We want to be able to use
```gap
[x, y] in cong;
```
to check whether a pair is in a congruence.  Previously, we have had a different `\in` method for each type of congruence, which checks input and then does the appropriate thing.  However, we want to be able to call these methods without doing checks first, and even without constructing lists (which is also an overhead).

This PR replaces all the `\in` methods with methods for `CongruenceTestMembershipNC`, a new operation which takes three arguments `cong, elm1, elm2` and returns true iff `elm1` and `elm2` are congruent with respect to `cong`.  This faster method can now be used when we already know the input is valid (e.g. in `LatticeOfCongruences`, which at the moment is incorrectly using `CONG_PAIRS_IN`).  There is a single `\in` method in `cong.gi` (well, one for left congs and one for right congs) which does all the checks and then calls `CongruenceTestMembershipNC(cong, pair[1], pair[2])` and returns the answer.

While I was at it, I modified `CONG_PAIRS_IN` in `congpairs.cc` to work in the same way.