### PR TITLE
doc: multiple labels for Matrix and RandomMatrix functions

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -893,9 +893,9 @@ gap> RZMSConnectedComponents(R);
         If the index sets <M>I</M> and <M>\Lambda</M> are partitioned into
         <M>k</M> parts according to the <Ref Attr="RZMSConnectedComponents"/> of
         <M>S</M>, giving a disjoint union <M>I=I_1\cup\ldots\cup I_k</M> and
-        <M>\Lambda=\Lambda_1\cup\ldots\cup\Lambda_k</M>, then the
-        <M>r^{\text{th}}</M> block corresponds to the sub-matrix <M>Q_{r}</M> of
-        <M>Q</M> defined by <M>I_{r}</M> and <M>\Lambda_{r}</M>.
+        <M>\Lambda=\Lambda_1\cup\ldots\cup\Lambda_k</M>, then the <M>r</M>th
+        block corresponds to the sub-matrix <M>Q_{r}</M> of <M>Q</M> defined by
+        <M>I_{r}</M> and <M>\Lambda_{r}</M>.
       </Item>
       <Item>
         The first non-zero entry in a row occurs no sooner than

--- a/doc/semiringmat.xml
+++ b/doc/semiringmat.xml
@@ -256,8 +256,10 @@ gap> DimensionOfMatrixOverSemiring(x);
 
 <#GAPDoc Label="Matrix">
   <ManSection>
-    <Oper Name = "Matrix" Arg = "filt, mat[, threshold[, period]]"/>
-    <Oper Name = "Matrix" Arg = "semiring, mat"/>
+    <Oper Name = "Matrix" Arg = "filt, mat[, threshold[, period]]"
+          Label = "for a filter and a matrix"/>
+    <Oper Name = "Matrix" Arg = "semiring, mat"
+          Label = "for a semiring and a matrix"/>
     <Returns>A matrix over semiring.</Returns>
     <Description>
       This operation can be used to construct a matrix over
@@ -377,13 +379,15 @@ Matrix(GF(3), [[Z(3), Z(3)^0, Z(3)], [Z(3), Z(3)^0, Z(3)^0],
 
 <#GAPDoc Label="RandomMatrix">
   <ManSection>
-    <Func Name = "RandomMatrix" Arg = "filt, dim[, threshold[, period]]"/>
-    <Func Name = "RandomMatrix" Arg = "semiring, dim"/>
+    <Func Name = "RandomMatrix" Arg = "filt, dim[, threshold[, period]]"
+          Label = "for a filter and a matrix"/>
+    <Func Name = "RandomMatrix" Arg = "semiring, dim"
+          Label = "for a semiring and a matrix"/>
     <Returns>A matrix over semiring.</Returns>
     <Description>
       This operation can be used to construct a random matrix over a semiring
       in &Semigroups;. The usage of <C>RandomMatrix</C> is similar to that of
-        <Ref Oper = "Matrix"/>.
+        <Ref Oper = "Matrix" Label = "for a filter and a matrix"/>.
       <P/>
  
       In its first form, the first argument <A>filt</A> specifies the


### PR DESCRIPTION
`Matrix` and `RandomMatrix` were multiply defined, so I've added labels.

Also fixed a little LaTeX error to do with using `\text`.