### PR TITLE
kernel: remove incorrect INTOBJ_INT

### DIFF
--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -1088,7 +1088,7 @@ gap_list_t EN_SEMI_FACTORIZATION(Obj self, gap_semigroup_t so, gap_int_t pos) {
 
     return ELM_PLIST(ElmPRec(fp, RNam_words), pos_c);
   } else {
-    gap_rec_t fp = fropin(so, INTOBJ_INT(pos), 0, False);
+    gap_rec_t fp = fropin(so, pos, 0, False);
     return ELM_PLIST(ElmPRec(fp, RNam_words), pos_c);
   }
 }


### PR DESCRIPTION
This commit resolves Issue #284, as CAJ correctly points out, the
variable pos is already a GAP integer object, and so the `INTOBJ_INT` in
line 1091 was incorrect. I guess this didn't cause any problems because
the result of `INTOBJ_INT(pos)` is usually a large number. The second
argument of the function fropin, which this issue affects, is the limit,
so using a large argument will probably just have enumerated the
semigroup to the end.