### PR TITLE
Improve code coverage of semitrans and fix bug in IsSynchronizingSemigroup

### DIFF
--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -99,6 +99,13 @@ gap> MultiplicativeZero(S);
 Transformation( [ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 ] )
 gap> IsSynchronizingSemigroup(S);
 true
+gap> IsSynchronizingSemigroup(S, 9);
+true
+gap> IsSynchronizingSemigroup(S, 10);
+true
+gap> S := Semigroup(S);;
+gap> IsSynchronizingSemigroup(S, 9);
+true
 gap> S := Semigroup(Transformation([1, 2, 2, 3]));
 <commutative transformation semigroup of degree 4 with 1 generator>
 gap> MultiplicativeZero(S);
@@ -169,6 +176,10 @@ gap> DigraphOfActionOnPoints(S);
 gap> OutNeighbours(last);
 [ [ 2, 3, 4 ], [ 3, 6, 8 ], [ 1, 2, 7 ], [ 2, 4, 7 ], [ 5, 6, 7 ], [ 1, 6 ], 
   [ 1, 6, 7 ], [ 1, 5 ] ]
+gap> DigraphOfActionOnPoints(FullTransformationMonoid(1));
+<digraph with 0 vertices, 0 edges>
+gap> DigraphOfActionOnPoints(FullTransformationMonoid(2), 1);
+fail
 
 #T# SemiTransTest7
 # SEMIGROUPS.SmallestElementRClass
@@ -2734,6 +2745,13 @@ gap> DigraphVertexLabels(gr);
 gap> DigraphEdgeLabels(gr);
 [ [  ], [  ], [  ], [  ], [ 1, 2 ], [ 1, 2, 3 ], [ 1, 2, 3, 4 ], [ 1, 2, 3 ], 
   [ 1, 2, 3, 4 ], [ 1, 2, 4 ] ]
+gap> DigraphOfActionOnPairs(FullTransformationMonoid(3), 2);
+fail
+gap> S := FullTransformationMonoid(3);;
+gap> DigraphOfActionOnPairs(S);
+<digraph with 6 vertices, 9 edges>
+gap> DigraphOfActionOnPairs(S, 3);
+<digraph with 6 vertices, 9 edges>
 
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1585,6 +1585,16 @@ gap> ##
 gap> HasEquivalenceRelationPartition(c);
 false
 
+#T# Issue 286: Bug in IsSynchronizingSemigroup
+gap> S := FullTransformationMonoid(10);
+<full transformation monoid of degree 10>
+gap> IsSynchronizingSemigroup(S, 9);
+true
+gap> IsSynchronizingSemigroup(S);
+true
+gap> IsSynchronizingSemigroup(S, 9);
+true
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(D);


### PR DESCRIPTION
This PR resolves Issue #286. This was caused by `IsSynchronizingSemigroup(S, n)` using the operation `DigraphOfActionOnPairs(S, n)`. However, `DigraphOfActionOnPairs(S, n)` only works if the the semigroup acts on `[1 .. n]` (i.e. `S` doesn't move a point within `[1 ..n]` to a point larger than `n`). This wasn't tested in code coverage - but when I added the coverage, we got the inconsistent results, as detailed in the issue.

The idea behind using the `DigraphOfActionOnPairs` was sound, and I've come up with a workaround, but it makes the code a bit more complicated unfortunately.

In this PR, I've also included the improved code coverage that led to me discovering this issue. At the moment, code coverage of `semitrans.gi` in `master` is:
```
semitrans.gi has 97% coverage: 539/555 lines
```
This PR takes it to:
```
semitrans.gi has 98% coverage: 556/565 lines
```
So this is an improvement.