### PR TITLE
Document and slightly change DigraphOfActionOnPoints

### DIFF
--- a/doc/semitrans.xml
+++ b/doc/semitrans.xml
@@ -233,7 +233,7 @@ Transformation( [ 7, 8, 8, 7, 8, 8, 8, 7, 8, 8 ] )]]></Example>
       If <A>S</A> is a transformation semigroup and <A>n</A> is a non-negative
       integer such that <A>S</A> acts on the points <C>[1 .. <A>n</A>]</C>, then
       <C>DigraphOfActionOnPairs(<A>S</A>, <A>n</A>)</C> returns a digraph
-      representing the <Ref Oper="OnSets" BookName="ref"/> action of <A>S</A> on
+      representing the <Ref Func="OnSets" BookName="ref"/> action of <A>S</A> on
       the pairs of points in <C>[1 ..  <A>n</A>]</C>.
       <P/>
 
@@ -254,17 +254,16 @@ Transformation( [ 7, 8, 8, 7, 8, 8, 8, 7, 8, 8 ] )]]></Example>
 
       The edges of the digraph are defined as follows. For each pair <C>{i,
         j}</C> in <C>[1 .. <A>n</A>]</C>, and for each generator <C>f</C> in
-      <C>GeneratorsOfSemigroup(<A>S</A>)</C> (see <Ref
-        Attr="GeneratorsOfSemigroup" BookName="ref" />), there is an edge from
-      the vertex corresponding to <C>{i, j}</C> to the vertex corresponding to
-      <C>{i ^ f, j ^ f}</C>.  Since <C>f</C> is a transformation, the set <C>{i
-        ^ f, j ^ f}</C> may correspond to a pair (in the case that <C>i ^ f
-        &lt;&gt; j ^ f</C>), or to a point (in the case that <C>i ^ f = j ^
-        f</C>).  The label of an edge (<Ref Oper="DigraphEdgeLabels"
-        BookName="Digraphs" />) is the position of the first transformation
-      within <C>GeneratorsOfSemigroup(<A>S</A>)</C> that maps the pair
-      corresponding to the source vertex to the pair/point corresponding to the
-      range vertex.
+      <C>GeneratorsOfSemigroup(<A>S</A>)</C>, there is an edge from the vertex
+      corresponding to <C>{i, j}</C> to the vertex corresponding to <C>{i ^ f, j
+        ^ f}</C>.  Since <C>f</C> is a transformation, the set <C>{i ^ f, j ^
+        f}</C> may correspond to a pair (in the case that <C>i ^ f &lt;&gt; j ^
+        f</C>), or to a point (in the case that <C>i ^ f = j ^ f</C>).  The
+      label of an edge is the position of the first transformation within
+      <C>GeneratorsOfSemigroup(<A>S</A>)</C> that maps the pair corresponding to
+      the source vertex to the pair/point corresponding to the range vertex. See
+      <Ref Attr="GeneratorsOfSemigroup" BookName="ref" /> and <Ref
+        Oper="DigraphEdgeLabels" BookName="Digraphs" /> for further information.
       <P/>
 
       Note that the digraph returned by <C>DigraphOfActionOnPairs</C> has no
@@ -291,6 +290,58 @@ gap> DigraphVertexLabels(gr);
 [ 1, 2, 3, 4, [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], 
   [ 3, 4 ] ]
 gap> DigraphOfActionOnPairs(S, 5);
+fail]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DigraphOfActionOnPoints">
+  <ManSection>
+    <Attr Name = "DigraphOfActionOnPoints" Arg = "S"
+      Label = "for a transformation semigroup" />
+    <Oper Name = "DigraphOfActionOnPoints" Arg = "S, n"
+      Label = "for a transformation semigroup and an integer" />
+    <Returns>A digraph, or <K>fail</K>.</Returns>
+    <Description>
+      If <A>S</A> is a transformation semigroup and <A>n</A> is a non-negative
+      integer such that <A>S</A> acts on the points <C>[1 .. <A>n</A>]</C>, then
+      <C>DigraphOfActionOnPoints(<A>S</A>, <A>n</A>)</C> returns a digraph
+      representing the <Ref Func="OnPoints" BookName="ref"/> action of <A>S</A>
+      on the set <C>[1 ..  <A>n</A>]</C>.
+      <P/>
+
+      If the optional argument <A>n</A> is not specified, then by default the
+      degree of <A>S</A> will be chosen for <A>n</A>; see <Ref
+        Attr="DegreeOfTransformationSemigroup" BookName="ref" />. If the
+      semigroup <A>S</A> does not act on <C>[1 ..  <A>n</A>]</C>, then
+      <C>DigraphOfActionOnPairs(<A>S</A>, <A>n</A>)</C> returns <K>fail</K>.
+      <P/>
+
+      The digraph returned by <C>DigraphOfActionOnPairs</C> has <A>n</A>
+      vertices, where the vertex <C>i</C> corresponds to the point <C>i</C>.
+      For each point <C>i</C> in <C>[1 .. <A>n</A>]</C>, and for each generator
+      <C>f</C> in <C>GeneratorsOfSemigroup(<A>S</A>)</C>, there is an edge from
+      the vertex <C>i</C> to the vertex <C>i ^ f</C>. See <Ref
+        Attr="GeneratorsOfSemigroup" BookName="ref" /> for further information.
+      <P/>
+
+      Note that the digraph returned by <C>DigraphOfActionOnPoints</C> has no
+      multiple edges; see <Ref Prop="IsMultiDigraph" BookName="Digraphs"/>.
+
+      <Example><![CDATA[
+gap> x := Transformation([2, 4, 2, 4, 7, 1, 6]);;
+gap> y := Transformation([3, 3, 2, 3, 5, 1, 5]);;
+gap> S := Semigroup(x, y);
+<transformation semigroup of degree 7 with 2 generators>
+gap> gr := DigraphOfActionOnPoints(S);
+<digraph with 7 vertices, 12 edges>
+gap> OnPoints(2, x);
+4
+gap> gr2 := DigraphOfActionOnPoints(S, 4);
+<digraph with 4 vertices, 7 edges>
+gap> gr2 = InducedSubdigraph(gr, [1 .. 4]);
+true
+gap> DigraphOfActionOnPoints(S, 5);
 fail]]></Example>
     </Description>
   </ManSection>

--- a/doc/z-chap13.xml
+++ b/doc/z-chap13.xml
@@ -191,6 +191,7 @@
     <#Include Label = "ComponentsOfTransformationSemigroup">
     <#Include Label = "CyclesOfTransformationSemigroup">
     <#Include Label = "DigraphOfActionOnPairs">
+    <#Include Label = "DigraphOfActionOnPoints">
     <#Include Label = "GeneratorsSmallest">
     <#Include Label = "IsTransitive">
     <#Include Label = "SmallestElementSemigroup">

--- a/gap/semigroups/semitrans.gd
+++ b/gap/semigroups/semitrans.gd
@@ -12,7 +12,7 @@ DeclareOperation("\^", [IsTransformationCollection, IsPerm]);
 DeclareAttribute("FixedPoints", IsTransformationSemigroup);
 DeclareAttribute("DigraphOfActionOnPoints", IsTransformationSemigroup);
 DeclareOperation("DigraphOfActionOnPoints",
-                 [IsTransformationSemigroup, IsPosInt]);
+                 [IsTransformationSemigroup, IsInt]);
 DeclareAttribute("DigraphOfActionOnPairs", IsTransformationSemigroup);
 DeclareOperation("DigraphOfActionOnPairs",
                  [IsTransformationSemigroup, IsInt]);

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -207,32 +207,33 @@ end);
 InstallMethod(DigraphOfActionOnPoints,
 "for a transformation semigroup with known generators",
 [IsTransformationSemigroup and HasGeneratorsOfSemigroup],
-function(S)
-  local n;
-
-  n := DegreeOfTransformationSemigroup(S);
-  if n = 0 then
-    return EmptyDigraph(0);
-  fi;
-  return DigraphOfActionOnPoints(S, n);
-end);
+S -> DigraphOfActionOnPoints(S, DegreeOfTransformationSemigroup(S)));
 
 InstallMethod(DigraphOfActionOnPoints,
-"for a transformation semigroup with known generators and pos int",
-[IsTransformationSemigroup and HasGeneratorsOfSemigroup, IsPosInt],
+"for a transformation semigroup with known generators and int",
+[IsTransformationSemigroup and HasGeneratorsOfSemigroup, IsInt],
 function(S, n)
-  local out, gens, x, k, i, j;
+  local gens, out, range, i, j;
 
-  out := List([1 .. n], x -> []);
+  if n < 0 then
+    ErrorNoReturn("Semigroups: DigraphOfActionOnPoints: usage,\n",
+                  "the second argument <n> must be non-negative,");
+  elif n = 0 then
+    return EmptyDigraph(0);
+  elif HasDigraphOfActionOnPoints(S)
+      and n = DegreeOfTransformationSemigroup(S) then
+    return DigraphOfActionOnPoints(S);
+  fi;
+
   gens := GeneratorsOfSemigroup(S);
-  for i in [1 .. Length(gens)] do
-    x := gens[i];
-    for j in [1 .. n] do
-      k := j ^ x;
-      if k > n then
+  out := List([1 .. n], x -> []);
+  for i in [1 .. n] do
+    for j in [1 .. Length(gens)] do
+      range := i ^ gens[j];
+      if range > n then
         return fail;
       fi;
-      AddSet(out[j], k);
+      AddSet(out[i], range);
     od;
   od;
   return DigraphNC(out);
@@ -296,15 +297,7 @@ end;
 InstallMethod(DigraphOfActionOnPairs,
 "for a transformation semigroup",
 [IsTransformationSemigroup],
-function(S)
-  local n;
-
-  n := DegreeOfTransformationSemigroup(S);
-  if n = 0 then
-    return EmptyDigraph(0);
-  fi;
-  return DigraphOfActionOnPairs(S, n);
-end);
+S -> DigraphOfActionOnPairs(S, DegreeOfTransformationSemigroup(S)));
 
 InstallMethod(DigraphOfActionOnPairs,
 "for a transformation semigroup and int",
@@ -324,9 +317,7 @@ function(S, n)
     return fail;
   elif n <= 1 then
     return EmptyDigraph(n);
-  fi;
-
-  if HasDigraphOfActionOnPairs(S)
+  elif HasDigraphOfActionOnPairs(S)
       and DegreeOfTransformationSemigroup(S) = n then
     return DigraphOfActionOnPairs(S);
   fi;
@@ -358,7 +349,7 @@ function(S, n)
     od;
   od;
 
-  gr := Digraph(out_nbs);
+  gr := DigraphNC(out_nbs);
   SetInNeighbours(gr, inn_nbs);
   SetDigraphEdgeLabels(gr, label);
   SetDigraphVertexLabels(gr, PairNumber);

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -1,7 +1,7 @@
 ############################################################################
 ##
 #W  standard/semitrans.tst
-#Y  Copyright (C) 2015                                      Wilf A. Wilson
+#Y  Copyright (C) 2015-17                                   Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -163,17 +163,26 @@ gap> GeneratorsOfSemigroup(S ^ (1, 7, 8, 6, 10)(3, 9, 5, 4));
 
 #T# SemiTransTest6
 # DigraphOfActionOnPoints for a transformation semigroup (and a pos int)
-gap> DigraphOfActionOnPoints(FullTransformationSemigroup(4));
+gap> gr := DigraphOfActionOnPoints(FullTransformationSemigroup(4));
 <digraph with 4 vertices, 9 edges>
-gap> OutNeighbours(last);
+gap> OutNeighbours(gr);
 [ [ 1, 2 ], [ 1, 2, 3 ], [ 3, 4 ], [ 1, 4 ] ]
 gap> S := Semigroup([
 > Transformation([2, 6, 7, 2, 6, 1, 1, 5]),
->  Transformation([3, 8, 1, 4, 5, 6, 7, 1]),
->  Transformation([4, 3, 2, 7, 7, 6, 6, 5])]);;
-gap> DigraphOfActionOnPoints(S);
+>  Transformation([4, 3, 2, 7, 7, 6, 6, 5]),
+>  Transformation([3, 8, 1, 4, 5, 6, 7, 1])]);;
+gap> DigraphOfActionOnPoints(S, -1);
+Error, Semigroups: DigraphOfActionOnPoints: usage,
+the second argument <n> must be non-negative,
+gap> DigraphOfActionOnPoints(S, 5);
+fail
+gap> gr := DigraphOfActionOnPoints(S);
 <digraph with 8 vertices, 22 edges>
-gap> OutNeighbours(last);
+gap> DigraphOfActionOnPoints(S, 0) = EmptyDigraph(0);
+true
+gap> DigraphOfActionOnPoints(S, 8) = gr;
+true
+gap> OutNeighbours(gr);
 [ [ 2, 3, 4 ], [ 3, 6, 8 ], [ 1, 2, 7 ], [ 2, 4, 7 ], [ 5, 6, 7 ], [ 1, 6 ], 
   [ 1, 6, 7 ], [ 1, 5 ] ]
 gap> DigraphOfActionOnPoints(FullTransformationMonoid(1));


### PR DESCRIPTION
`DigraphOfActionOnPoints` was undocumented. I've documented it. In the process, I thought it made sense to make it consistent with `DigraphOfActionOnPairs`. Thus the digraph now has edge labels that give the index of the generator that corresponds to an edge.

Due to this, the method takes a small performance hit - we previously added new edges using `AsSet` to avoid creating duplicates, but this sorts the out-neighbours list in a way that makes it impossible to keep track of edge labels. Since the out-neighbours are not sorted, this (harmlessly) changes the output of some tests, with functions that use `DigraphOfActionOnPoints`.