### PR TITLE
Fix various errors in the doc

### DIFF
--- a/doc/isorms.xml
+++ b/doc/isorms.xml
@@ -46,9 +46,9 @@
       <Ref Func = "CompositionMapping" BookName = "ref"/>,
       <Ref Oper = "ImagesElm" Label = "for IsRMSIsoByTriple"/>,
       <Ref Oper = "ImagesRepresentative" Label = "for IsRMSIsoByTriple"/>,
-      <Ref Attr = "InverseGeneralMapping" Label = "for IsRMSIsoByTriple"/>,
+      <Ref Attr = "InverseGeneralMapping" BookName = "ref"/>,
       <Ref Oper = "PreImagesRepresentative" BookName = "ref"/>,
-      <Ref Prop = "IsOne" Label = "for IsRMSIsoByTriple"/>.
+      <Ref Prop = "IsOne" BookName = "ref"/>.
 
     </Description>
   </ManSection>

--- a/doc/z-chap01.xml
+++ b/doc/z-chap01.xml
@@ -163,7 +163,8 @@
         are described in Chapters <Ref Chap = "bipartition"/>, <Ref Chap =
           "Partitioned binary relations (PBRs)"/>, and <Ref Chap = 
           "Matrices over semirings"/>. These include <Ref Func="Bipartition"/>, 
-        <Ref Func="PBR"/>, and <Ref Func="Matrix"/>, which 
+        <Ref Func="PBR"/>, and
+        <Ref Func="Matrix" Label="for a filter and a matrix"/>, which
         supplement those already defined in the &GAP; library, such as <Ref
           Oper="Transformation" BookName="ref"/> or <Ref Oper="PartialPerm" 
           BookName="ref"/>. 

--- a/doc/z-chap05.xml
+++ b/doc/z-chap05.xml
@@ -83,19 +83,6 @@
   <!--**********************************************************************-->
 
   <Section Label = "Matrices over arbitrary semirings">
-    <Heading>The category <C>IsMatrixOverSemiring</C></Heading>
-    In this section we describe the categories, attributes, and operations
-    for matrices in the category <Ref Filt = "IsMatrixOverSemiring"/>.
-
-    <#Include Label = "IsMatrixOverSemiring">
-    <#Include Label = "IsMatrixOverSemiringCollection">
-    <#Include Label = "DimensionOfMatrixOverSemiring">
-  </Section>
-
-  <!--**********************************************************************-->
-  <!--**********************************************************************-->
-
-  <Section Label = "Matrices over arbitrary semirings">
     <Heading>Creating matrices over semirings</Heading>
     In this section we describe the two main operations for creating matrices
     over semirings in &Semigroups;, and the categories, attributes, and
@@ -110,6 +97,9 @@
     in section <Ref Sect = "Matrices over finite fields"/>.
     -->
 
+    <#Include Label = "IsMatrixOverSemiring">
+    <#Include Label = "IsMatrixOverSemiringCollection">
+    <#Include Label = "DimensionOfMatrixOverSemiring">
     <#Include Label = "Matrix">
     <#Include Label = "AsMatrix"/>
     <#Include Label = "RandomMatrix">

--- a/doc/z-chap17.xml
+++ b/doc/z-chap17.xml
@@ -30,11 +30,12 @@
     </Heading>
 
     PREAMBLE
+    <!-- TODO: Fill in this preamble, or remove it -->
 
     <!--********************************************************************-->
  
-    <Subsection Label = "Operators for isomorphisms of Rees (0-)matrix
-      semigroup by triples">
+    <Subsection Label =
+     "Operators for isomorphisms of Rees (0-)matrix semigroup by triples">
 
       <Heading>
         Operators for isomorphisms of Rees (0-)matrix semigroup by triples


### PR DESCRIPTION
Once Wilf's standard examples stuff and Chris's matrix stuff is merged in, this should finally mean that there are no errors or warnings in `SemigroupsMakeDoc` (though who knows, maybe one or two!)

A preamble wants to be written for *Isomorphisms of Rees (0-)matrix semigroups*.  I've made a [Trello card](https://trello.com/c/W7jasQ1D/178-doc-add-a-preamble-for-isomorphisms-of-rees-0-matrix-semigroups).