### PR TITLE
Document the limits of bipartitions

### DIFF
--- a/doc/blocks.xml
+++ b/doc/blocks.xml
@@ -56,7 +56,7 @@ gap> RightProjection(x);
 <#GAPDoc Label="BlocksNC">
   <ManSection>
     <Func Name = "BlocksNC" Arg = "classes"/>
-    <Returns>A blocks.</Returns>
+    <Returns>An <C>IsBlocks</C> object.</Returns>
     <Description>
       This function makes it possible to create a &GAP; object corresponding
       to the left or right blocks of a bipartition without reference to any

--- a/doc/z-chap03.xml
+++ b/doc/z-chap03.xml
@@ -198,8 +198,8 @@
     <Heading>Creating bipartitions</Heading>
   There are several ways of creating bipartitions in &GAP;, which are
   described in this section. The maximum degree of a bipartition is set as 
-  2 ^ 31. In reality, bipartitions of degrees as small as 2 ^ 24 are unlikely
-  to work because they require too much memory.
+  2 ^ 31 - 1. In reality, it is unlikely to be possible to create bipartitions
+  of degrees as small as 2 ^ 24 because they require too much memory.
     <#Include Label = "Bipartition">
     <#Include Label = "BipartitionByIntRep">
     <#Include Label = "IdentityBipartition">

--- a/doc/z-chap03.xml
+++ b/doc/z-chap03.xml
@@ -197,7 +197,9 @@
   <Section Label = "creating-bipartitions">
     <Heading>Creating bipartitions</Heading>
   There are several ways of creating bipartitions in &GAP;, which are
-  described in this section.
+  described in this section. The maximum degree of a bipartition is set as 
+  2 ^ 31. In reality, bipartitions of degrees as small as 2 ^ 24 are unlikely
+  to work because they require too much memory.
     <#Include Label = "Bipartition">
     <#Include Label = "BipartitionByIntRep">
     <#Include Label = "IdentityBipartition">

--- a/gap/elements/bipart.gi
+++ b/gap/elements/bipart.gi
@@ -93,6 +93,14 @@ InstallGlobalFunction(Bipartition,
 function(classes)
   local n, copy, i, j;
 
+  n := Sum(List(classes, Length)) / 2;
+
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: Bipartition: usage,\n",
+                  "the argument <classes> must be a list of lists whose union",
+                  "has length at most 2 ^ 31 - 1,");
+  fi;
+
   if not IsList(classes)
       or ForAny(classes, x -> not IsHomogeneousList(x)
                               or not IsDuplicateFree(x)) then
@@ -116,7 +124,6 @@ function(classes)
                   "[-n..-1, 1..n],");
   fi;
 
-  n := Sum(List(classes, Length)) / 2;
   copy := List(classes, ShallowCopy);
   for i in [1 .. Length(copy)] do
     for j in [1 .. Length(copy[i])] do
@@ -151,6 +158,12 @@ function(blocks)
                   "integer,");
   fi;
 
+  if n >= 2 ^ 32 then
+    ErrorNoReturn("Semigroups: BipartitionByIntRep: usage,\n",
+                  "the length of the argument <blocks> must not exceed",
+                  "2 ^ 32 - 1,");
+  fi;
+
   n := n / 2;
   if not ForAll(blocks, IsPosInt) then
     ErrorNoReturn("Semigroups: BipartitionByIntRep: usage,\n",
@@ -167,7 +180,7 @@ function(blocks)
       if blocks[i] <> next then
         ErrorNoReturn("Semigroups: BipartitionByIntRep: usage,\n",
                       "expected ", next, " but found ", blocks[i],
-                      ", in position ", i);
+                      ", in position ", i, ",");
       fi;
       seen[blocks[i]] := true;
     fi;
@@ -181,7 +194,7 @@ function(blocks)
       if blocks[i] <> next then
         ErrorNoReturn("Semigroups: BipartitionByIntRep: usage,\n",
                       "expected ", next, " but found ", blocks[i],
-                      ", in position ", i);
+                      ", in position ", i, ",");
       fi;
       seen[blocks[i]] := true;
     fi;
@@ -200,6 +213,10 @@ InstallMethod(IdentityBipartition, "for a positive integer", [IsPosInt],
 function(n)
   local blocks, i;
 
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: IdentityBipartition: usage,\n",
+                  "the argument <n> must not exceed 2 ^ 31 - 1,");
+  fi;
   blocks := EmptyPlist(2 * n);
 
   for i in [1 .. n] do
@@ -215,6 +232,10 @@ InstallMethod(RandomBipartition, "for a random source and pos int",
 function(rs, n)
   local out, nrblocks, vals, j, i;
 
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: RandomBipartition: usage,\n",
+                  "the argument <n> must not exceed 2 ^ 31 - 1,");
+  fi;
   out := EmptyPlist(2 * n);
   nrblocks := 0;
   vals := [1];
@@ -240,6 +261,11 @@ InstallMethod(RandomBlockBijection, "for a random source and pos int",
 [IsRandomSource, IsPosInt],
 function(rs, n)
   local out, nrblocks, j, free, i;
+
+  if n >= 2^31 then
+    ErrorNoReturn("Semigroups: RandomBlockBipartition: usage,\n",
+                  "the argument <n> must not exceed 2 ^ 31 - 1,");
+  fi;
 
   out := EmptyPlist(2 * n);
   out[1] := 1;
@@ -677,6 +703,10 @@ end);
 InstallMethod(AsBipartition, "for a permutation and pos int",
 [IsPerm, IsPosInt],
 function(x, n)
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: AsBipartition: usage,\n",
+                  "the argument <n> must not exceed 2 ^ 31 - 1,");
+  fi;
   if OnSets([1 .. n], x) <> [1 .. n] then
     ErrorNoReturn("Semigroups: AsBipartition (for a permutation and pos int):",
                   "\nthe permutation <p> in the 1st argument must permute ",
@@ -768,6 +798,10 @@ InstallMethod(AsBipartition, "for a partial perm and pos int",
 function(x, n)
   local r, out, j, i;
 
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: AsBipartition: usage,\n",
+                  "the argument <n> must not exceed 2 ^ 31 - 1,");
+  fi;
   r := n;
   out := EmptyPlist(2 * n);
 
@@ -790,6 +824,10 @@ InstallMethod(AsBipartition, "for a transformation and a positive integer",
 function(f, n)
   local r, ker, out, g, i;
 
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: AsBipartition: usage,\n",
+                  "the argument <n> must not exceed 2 ^ 31 - 1,");
+  fi;
   if n < DegreeOfTransformation(f) then
     #verify <f> is a transformation on [1..n]
     for i in [1 .. n] do
@@ -831,6 +869,10 @@ InstallMethod(AsBipartition, "for a bipartition and pos int",
 function(f, n)
   local deg, blocks, out, nrblocks, nrleft, lookup, j, i;
 
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: AsBipartition: usage,\n",
+                  "the argument <n> must not exceed 2 ^ 31 - 1,");
+  fi;
   deg := DegreeOfBipartition(f);
   if n = deg then
     return f;
@@ -893,6 +935,11 @@ InstallMethod(AsBlockBijection, "for a partial perm and pos int",
 [IsPartialPerm, IsPosInt],
 function(f, n)
   local bigblock, nr, out, i;
+
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: AsBlockBijection: usage,\n",
+                  "the argument <n> must not exceed 2 ^ 31 - 1,");
+  fi;
 
   if n <= Maximum(DegreeOfPartialPerm(f), CodegreeOfPartialPerm(f)) then
     ErrorNoReturn("Semigroups: AsBlockBijection (for a partial perm and pos ",

--- a/gap/elements/bipart.gi
+++ b/gap/elements/bipart.gi
@@ -93,20 +93,19 @@ InstallGlobalFunction(Bipartition,
 function(classes)
   local n, copy, i, j;
 
-  n := Sum(classes, Length) / 2;
-
-  if n >= 2 ^ 31 then
-    ErrorNoReturn("Semigroups: Bipartition: usage,\n",
-                  "the argument <classes> must be a list of lists whose union",
-                  "has length at most 2 ^ 31 - 1,");
-  fi;
-
   if not IsList(classes)
       or ForAny(classes, x -> not IsHomogeneousList(x)
                               or not IsDuplicateFree(x)) then
     ErrorNoReturn("Semigroups: Bipartition: usage,\n",
                   "the argument <classes> must consist of duplicate-free ",
                   "homogeneous lists,");
+  fi;
+
+  n := Sum(classes, Length) / 2;
+  if n >= 2 ^ 31 then
+    ErrorNoReturn("Semigroups: Bipartition: usage,\n",
+                  "the maximum degree which is allowed for a bipartition ",
+                  "is 2 ^ 31 - 1,");
   fi;
 
   if not ForAll(classes, x -> ForAll(x, i -> IsPosInt(i) or IsNegInt(i))) then
@@ -160,7 +159,7 @@ function(blocks)
 
   if n >= 2 ^ 32 then
     ErrorNoReturn("Semigroups: BipartitionByIntRep: usage,\n",
-                  "the length of the argument <blocks> must not exceed",
+                  "the length of the argument <blocks> must not exceed ",
                   "2 ^ 32 - 1,");
   fi;
 

--- a/gap/elements/bipart.gi
+++ b/gap/elements/bipart.gi
@@ -93,7 +93,7 @@ InstallGlobalFunction(Bipartition,
 function(classes)
   local n, copy, i, j;
 
-  n := Sum(List(classes, Length)) / 2;
+  n := Sum(classes, Length) / 2;
 
   if n >= 2 ^ 31 then
     ErrorNoReturn("Semigroups: Bipartition: usage,\n",
@@ -262,7 +262,7 @@ InstallMethod(RandomBlockBijection, "for a random source and pos int",
 function(rs, n)
   local out, nrblocks, j, free, i;
 
-  if n >= 2^31 then
+  if n >= 2 ^ 31 then
     ErrorNoReturn("Semigroups: RandomBlockBipartition: usage,\n",
                   "the argument <n> must not exceed 2 ^ 31 - 1,");
   fi;

--- a/tst/standard/bipart.tst
+++ b/tst/standard/bipart.tst
@@ -484,8 +484,8 @@ gap> RightProjection(StarOp(x));
 
 # bipartition: Bipartition 1/3
 gap> Bipartition("test");
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Length' on 1 arguments
+Error, Semigroups: Bipartition: usage,
+the argument <classes> must consist of duplicate-free homogeneous lists,
 gap> Bipartition(["test"]);
 Error, Semigroups: Bipartition: usage,
 the argument <classes> must consist of duplicate-free homogeneous lists,
@@ -769,11 +769,10 @@ gap> enum := EnumeratorByFunctions(Integers,
 >                                  Length := x -> 2 ^ 33));;
 gap> Bipartition([enum]);
 Error, Semigroups: Bipartition: usage,
-the argument <classes> must be a list of lists whose unionhas length at most 2\
- ^ 31 - 1,
+the maximum degree which is allowed for a bipartition is 2 ^ 31 - 1,
 gap> BipartitionByIntRep(enum);
 Error, Semigroups: BipartitionByIntRep: usage,
-the length of the argument <blocks> must not exceed2 ^ 32 - 1,
+the length of the argument <blocks> must not exceed 2 ^ 32 - 1,
 gap> IdentityBipartition(2 ^ 31);
 Error, Semigroups: IdentityBipartition: usage,
 the argument <n> must not exceed 2 ^ 31 - 1,

--- a/tst/standard/bipart.tst
+++ b/tst/standard/bipart.tst
@@ -484,8 +484,8 @@ gap> RightProjection(StarOp(x));
 
 # bipartition: Bipartition 1/3
 gap> Bipartition("test");
-Error, Semigroups: Bipartition: usage,
-the argument <classes> must consist of duplicate-free homogeneous lists,
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Length' on 1 arguments
 gap> Bipartition(["test"]);
 Error, Semigroups: Bipartition: usage,
 the argument <classes> must consist of duplicate-free homogeneous lists,
@@ -524,12 +524,12 @@ the elements of the argument <blocks> must be positive integers,
 # bipartition: BipartitionByIntRep 3/5
 gap> BipartitionByIntRep([1, 2, 3, 5]);
 Error, Semigroups: BipartitionByIntRep: usage,
-expected 4 but found 5, in position 4
+expected 4 but found 5, in position 4,
 
 # bipartition: BipartitionByIntRep 4/5
 gap> BipartitionByIntRep([1, 3, 3, 5]);
 Error, Semigroups: BipartitionByIntRep: usage,
-expected 2 but found 3, in position 2
+expected 2 but found 3, in position 2,
 
 # bipartition: BipartitionByIntRep 5/5
 gap> BipartitionByIntRep([1, 2, 3, 1]);
@@ -759,6 +759,39 @@ gap> DomainOfBipartition(x);
 [ 1, 2, 3, 6, 4, 5 ]
 gap> CodomainOfBipartition(x);
 [ -1, -4, -2, -3, -5 ]
+
+#T# Test error messages for when creating a bipartition with degree too large.
+gap> Bipartition([[1 .. 2 ^ 32]]);
+Error, Semigroups: Bipartition: usage,
+the argument <classes> must be a list of lists whose unionhas length at most 2\
+ ^ 31 - 1,
+gap> BipartitionByIntRep([1 .. 2 ^ 32]);
+Error, Semigroups: BipartitionByIntRep: usage,
+the length of the argument <blocks> must not exceed2 ^ 32 - 1,
+gap> IdentityBipartition(2 ^ 31);
+Error, Semigroups: IdentityBipartition: usage,
+the argument <n> must not exceed 2 ^ 31 - 1,
+gap> RandomBipartition(2 ^ 31);
+Error, Semigroups: RandomBipartition: usage,
+the argument <n> must not exceed 2 ^ 31 - 1,
+gap> RandomBlockBijection(2 ^ 31);
+Error, Semigroups: RandomBlockBipartition: usage,
+the argument <n> must not exceed 2 ^ 31 - 1,
+gap> AsBipartition((), 2 ^ 31);
+Error, Semigroups: AsBipartition: usage,
+the argument <n> must not exceed 2 ^ 31 - 1,
+gap> AsBipartition(PartialPerm([]), 2 ^ 31);
+Error, Semigroups: AsBipartition: usage,
+the argument <n> must not exceed 2 ^ 31 - 1,
+gap> AsBipartition(Transformation([]), 2 ^ 31);
+Error, Semigroups: AsBipartition: usage,
+the argument <n> must not exceed 2 ^ 31 - 1,
+gap> AsBipartition(Bipartition([]), 2 ^ 31);
+Error, Semigroups: AsBipartition: usage,
+the argument <n> must not exceed 2 ^ 31 - 1,
+gap> AsBlockBijection(PartialPerm([]), 2 ^ 31);
+Error, Semigroups: AsBlockBijection: usage,
+the argument <n> must not exceed 2 ^ 31 - 1,
 
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(G);

--- a/tst/standard/bipart.tst
+++ b/tst/standard/bipart.tst
@@ -761,11 +761,17 @@ gap> CodomainOfBipartition(x);
 [ -1, -4, -2, -3, -5 ]
 
 #T# Test error messages for when creating a bipartition with degree too large.
-gap> Bipartition([[1 .. 2 ^ 32]]);
+# We create enum, as opposed to a range [1 .. 2 ^ 33] to allow this test to
+# work in the 32-bit version.
+gap> enum := EnumeratorByFunctions(Integers, 
+>                                  rec(ElementNumber := {enum, x} -> x,
+>                                  NumberElement := {enum, x} -> x,
+>                                  Length := x -> 2 ^ 33));;
+gap> Bipartition([enum]);
 Error, Semigroups: Bipartition: usage,
 the argument <classes> must be a list of lists whose unionhas length at most 2\
  ^ 31 - 1,
-gap> BipartitionByIntRep([1 .. 2 ^ 32]);
+gap> BipartitionByIntRep(enum);
 Error, Semigroups: BipartitionByIntRep: usage,
 the length of the argument <blocks> must not exceed2 ^ 32 - 1,
 gap> IdentityBipartition(2 ^ 31);


### PR DESCRIPTION
- Added two sentences to the doc explaining that bipartitions are capped at degree 2 ^ 31 yet are unlikely to work (due to memory constraints) for even smaller degrees.
- Added errors for methods within bipart.gi which bipartitions. These occur detect when the user attempts to create a bipartition of degree greater than or equal to 2 ^ 31.
- Covered these new error messages with new tests.