### PR TITLE
Fix failing test in extreme/cong.tst

### DIFF
--- a/gap/congruences/congpairs.gi
+++ b/gap/congruences/congpairs.gi
@@ -404,22 +404,26 @@ InstallMethod(EquivalenceClasses,
 "for an fp semigroup congruence",
 [IsFpSemigroupCongruence],
 function(cong)
-  local part, enum, reps, classes, next, i;
-
-  part := CongruenceByGeneratingPairsPartition(cong);
+  local enum, nrclasses, classes, class_added, count, i, word, id;
   enum := Enumerator(Range(cong));
-  reps := List(part, x -> enum[x[1]]);
+  nrclasses := NrEquivalenceClasses(cong);
 
-  classes := EmptyPlist(Length(reps));
-  next := 1;
-
-  for i in [1 .. Length(reps)] do
-    classes[next] := EquivalenceClassOfElementNC(cong, reps[i]);
-    SetCongruenceClassByGeneratingPairsCosetId(classes[next], i);
-    SetSize(classes[next], Length(part[i]));
-
-    next := next + 1;
-  od;
+  # Add each class when we find a representative for it
+  classes := EmptyPlist(nrclasses);
+  class_added := BlistList([1 .. nrclasses], []);
+  count := 0;
+  i := 0;
+  repeat
+    i := i + 1;
+    word := SEMIGROUPS.ExtRepObjToWord(ExtRepOfObj(enum[i]));
+    id := CONG_PAIRS_ELM_COSET_ID(cong, word);
+    if not class_added[id] then
+      classes[id] := EquivalenceClassOfElementNC(cong, enum[i]);
+      SetCongruenceClassByGeneratingPairsCosetId(classes[id], id);
+      class_added[id] := true;
+      count := count + 1;
+    fi;
+  until count = nrclasses;
 
   return classes;
 end);

--- a/tst/extreme/cong.tst
+++ b/tst/extreme/cong.tst
@@ -89,24 +89,6 @@ gap> c := EquivalenceClasses(cong);;
 gap> Size(c) = 85;
 true
 
-#T# Free semigroups
-gap> F := FreeSemigroup(1);;
-gap> x := GeneratorsOfSemigroup(F)[1];;
-gap> pair := [x ^ 2, x ^ 4];;
-gap> cong := SemigroupCongruence(F, pair);
-<semigroup congruence over <free semigroup on the generators [ s1 ]> with 
-1 generating pairs>
-gap> pair in cong;
-true
-gap> EquivalenceRelationLookup(cong);
-Error, Semigroups: EquivalenceRelationLookup: usage,
-<cong> must be over a finite semigroup,
-gap> EquivalenceClasses(cong);
-[ <congruence class of s1>, <congruence class of s1^2>, 
-  <congruence class of s1^3> ]
-gap> NrCongruenceClasses(cong);
-3
-
 #T# PairsCongTest3: \= for two semigroup congruences
 gap> gens := [Transformation([2, 6, 7, 2, 6, 9, 9, 1, 1, 5])];;
 gap> s := Semigroup(Transformation([1]));;

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1595,6 +1595,24 @@ true
 gap> IsSynchronizingSemigroup(S, 9);
 true
 
+#T# Free semigroup congruence test from extreme/cong.tst
+gap> F := FreeSemigroup(1);;
+gap> x := GeneratorsOfSemigroup(F)[1];;
+gap> pair := [x ^ 2, x ^ 4];;
+gap> cong := SemigroupCongruence(F, pair);
+<semigroup congruence over <free semigroup on the generators [ s1 ]> with 
+1 generating pairs>
+gap> pair in cong;
+true
+gap> EquivalenceRelationLookup(cong);
+Error, Semigroups: EquivalenceRelationLookup: usage,
+<cong> must be over a finite semigroup,
+gap> EquivalenceClasses(cong);
+[ <congruence class of s1>, <congruence class of s1^2>, 
+  <congruence class of s1^3> ]
+gap> NrCongruenceClasses(cong);
+3
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(D);


### PR DESCRIPTION
This was caused by a naive assumption in `EquivalenceClasses` - namely that the fp semigroup in question is finite; in fact it might very well be infinite, but might have a finite number of equivalence classes.

This method could be improved further if we introduced a method in libsemigroups which returned a representative for a congruence class - just as we were discussing earlier!  James suggested that he and I might do that next week, and then an even better version of this method could perhaps go into Semigroups 3.1