### PR TITLE
isorms: add checks to code, and document

### DIFF
--- a/doc/isorms.xml
+++ b/doc/isorms.xml
@@ -54,6 +54,70 @@
   </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="RMSIsoByTriple">
+  <ManSection>
+    <Oper Name = "RMSIsoByTriple" Arg = "R1, R2, triple"/>
+    <Oper Name = "RZMSIsoByTriple" Arg = "R1, R2, triple"/>
+    <Returns>An isomorphism.</Returns>
+    <Description>
+      If <A>R1</A> and <A>R2</A> are isomorphic regular Rees 0-matrix semigroups
+      whose underlying semigroups are groups then <C>RZMSIsoByTriple</C> returns
+      the isomorphism between <A>R1</A> and <A>R2</A> defined by <A>triple</A>,
+      which should be a list consisting of the following:
+
+      <List>
+        <Item>
+          <C><A>triple</A>[1]</C> should be a permutation describing an
+          isomorphism from the graph of <A>R1</A> to the graph of <A>R2</A>,
+          i.e. it should satisfy
+          <C>OnDigraphs(RZMSDigraph(<A>R1</A>), <A>triple</A>[1])
+             = RZMSDigraph(<A>R2</A>)</C>.
+        </Item>
+        <Item>
+          <C><A>triple</A>[2]</C> should be an isomorphism from the underlying
+          group of <A>R1</A> to the underlying group of <A>R2</A> (see
+          <Ref Attr="UnderlyingSemigroup"
+               Label="for a Rees 0-matrix semigroup"
+               BookName="ref"/>).
+        </Item>
+        <Item>
+          <C><A>triple</A>[3]</C> should be a list of elements from the
+          underlying group of <A>R2</A>.  If the
+          <Ref Attr="Matrix" BookName="ref"/> of <A>R1</A> has <M>m</M> columns
+          and <M>n</M> rows, then the list should have length <M>m + n</M>,
+          where the first <M>m</M> entries should correspond to the columns of
+          <A>R1</A>'s matrix, and the last <M>n</M> entries should correspond to
+          the rows.  These column and row entries should correspond to the
+          <M>u_i</M> and <M>v_\lambda</M> elements in Theorem 3.4.1 of
+          <Cite>Howie1995aa</Cite>.
+        </Item>
+      </List>
+
+      If <A>triple</A> describes a valid isomorphism from <A>R1</A> to <A>R2</A>
+      then this will return an object in the category
+      <Ref Filt="IsRZMSIsoByTriple"/>; otherwise an error will be returned. <P/>
+
+      If <A>R1</A> and <A>R2</A> are instead Rees matrix semigroups (without
+      zero) then <C>RMSIsoByTriple</C> should be used instead.  This operation
+      is used in the same way, but it should be noted that since an RMS's graph
+      is a complete bipartite graph, <C><A>triple</A>[1]</C> can be any
+      permutation on <C>[1 .. m + n]</C>, so long as no point in <C>[1 .. m]</C>
+      is mapped to a point in <C>[m + 1 .. m + n]</C>. <P/>
+
+      <Example><![CDATA[
+gap> g := SymmetricGroup(3);;
+gap> mat := [[0, 0, (1, 3)], [(1, 2, 3), (), (2, 3)], [0, 0, ()]];;
+gap> R := ReesZeroMatrixSemigroup(g, mat);;
+gap> id := IdentityMapping(g);;
+gap> g_elms_list := [(), (), (), (), (), ()];;
+gap> RZMSIsoByTriple(R, R, [(), id, g_elms_list]);
+((), IdentityMapping( SymmetricGroup( [ 1 .. 3 ] ) ), 
+[ (), (), (), (), (), () ])
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="ELM_LIST">
   <ManSection>
     <Oper Name = "ELM_LIST" Label = "for IsRMSIsoByTriple"

--- a/doc/z-chap17.xml
+++ b/doc/z-chap17.xml
@@ -29,20 +29,19 @@
       Isomorphisms of Rees (0-)matrix semigroups
     </Heading>
 
-    An isomorphism between two finite Rees matrix semigroups or two finite Rees
-    0-matrix semigroups can be associated to a triple which uniquely describes
-    the isomorphism in terms of the structure of the semigroups' matrices and
-    underlying groups.  An isomorphism described in this way can be constructed
+    An isomorphism between two regular finite Rees (0-)matrix semigroups whose
+    underlying semigroups are groups can be described by a triple defined in
+    terms of the matrices and underlying groups of the semigroups.  For a full
+    description of the theory involved, see Section 3.4 of
+    <Cite Key = "Howie1995aa"/>. <P/>
+
+    An isomorphism described in this way can be constructed
     using <Ref Oper="RMSIsoByTriple"/> or <Ref Oper="RZMSIsoByTriple"/>, and
     will satisfy the filter <Ref Filt="IsRMSIsoByTriple"/> or
-    <Ref Filt="IsRZMSIsoByTriple"/>.  On the whole, these isomorphisms can be
-    treated like any other isomorphism. <P/>
-
-    For more information on the structure of such an isomorphism, see
-    <Ref Filt="IsRMSIsoByTriple"/>.  For a full description of the theory
-    involved, see Section 3.4 of <Cite Key = "Howie1995aa"/>. <P/>
+    <Ref Filt="IsRZMSIsoByTriple"/>. <P/>
 
     <#Include Label = "IsRMSIsoByTriple">
+    <#Include Label = "RMSIsoByTriple">
     <#Include Label = "ELM_LIST">
     <#Include Label = "CompositionMapping2">
     <#Include Label = "ImagesElm">

--- a/doc/z-chap17.xml
+++ b/doc/z-chap17.xml
@@ -29,9 +29,19 @@
       Isomorphisms of Rees (0-)matrix semigroups
     </Heading>
 
-    PREAMBLE
-    <!-- TODO: Fill in this preamble, or remove it -->
- 
+    An isomorphism between two finite Rees matrix semigroups or two finite Rees
+    0-matrix semigroups can be associated to a triple which uniquely describes
+    the isomorphism in terms of the structure of the semigroups' matrices and
+    underlying groups.  An isomorphism described in this way can be constructed
+    using <Ref Oper="RMSIsoByTriple"/> or <Ref Oper="RZMSIsoByTriple"/>, and
+    will satisfy the filter <Ref Filt="IsRMSIsoByTriple"/> or
+    <Ref Filt="IsRZMSIsoByTriple"/>.  On the whole, these isomorphisms can be
+    treated like any other isomorphism. <P/>
+
+    For more information on the structure of such an isomorphism, see
+    <Ref Filt="IsRMSIsoByTriple"/>.  For a full description of the theory
+    involved, see Section 3.4 of <Cite Key = "Howie1995aa"/>. <P/>
+
     <#Include Label = "IsRMSIsoByTriple">
     <#Include Label = "ELM_LIST">
     <#Include Label = "CompositionMapping2">

--- a/doc/z-chap17.xml
+++ b/doc/z-chap17.xml
@@ -31,9 +31,14 @@
 
     PREAMBLE
     <!-- TODO: Fill in this preamble, or remove it -->
+ 
+    <#Include Label = "IsRMSIsoByTriple">
+    <#Include Label = "ELM_LIST">
+    <#Include Label = "CompositionMapping2">
+    <#Include Label = "ImagesElm">
 
     <!--********************************************************************-->
- 
+
     <Subsection Label =
      "Operators for isomorphisms of Rees (0-)matrix semigroup by triples">
 
@@ -98,13 +103,6 @@
       </List>
  
     </Subsection>
-
-    <#Include Label = "IsRMSIsoByTriple">
-    <#Include Label = "ELM_LIST">
-    <#Include Label = "CompositionMapping2">
-    <#Include Label = "ImagesElm">
-
-    <!--********************************************************************-->
 
   </Section>
  

--- a/gap/attributes/isorms.gd
+++ b/gap/attributes/isorms.gd
@@ -17,6 +17,13 @@ DeclareCategory("IsRZMSIsoByTriple", IsGeneralMapping and IsSPGeneralMapping
                                      IsInjective and IsSurjective and
                                      IsAttributeStoringRep);
 
+DeclareOperation("RMSIsoByTriple", [IsReesMatrixSemigroup,
+                                    IsReesMatrixSemigroup,
+                                    IsDenseList]);
+DeclareOperation("RZMSIsoByTriple", [IsReesZeroMatrixSemigroup,
+                                     IsReesZeroMatrixSemigroup,
+                                     IsDenseList]);
+
 DeclareOperation("RMSIsoByTripleNC", [IsReesMatrixSemigroup,
                                       IsReesMatrixSemigroup,
                                       IsDenseList]);

--- a/gap/attributes/isorms.gd
+++ b/gap/attributes/isorms.gd
@@ -17,8 +17,12 @@ DeclareCategory("IsRZMSIsoByTriple", IsGeneralMapping and IsSPGeneralMapping
                                      IsInjective and IsSurjective and
                                      IsAttributeStoringRep);
 
-DeclareGlobalFunction("RMSIsoByTriple");
-DeclareGlobalFunction("RZMSIsoByTriple");
+DeclareOperation("RMSIsoByTripleNC", [IsReesMatrixSemigroup,
+                                      IsReesMatrixSemigroup,
+                                      IsDenseList]);
+DeclareOperation("RZMSIsoByTripleNC", [IsReesZeroMatrixSemigroup,
+                                       IsReesZeroMatrixSemigroup,
+                                       IsDenseList]);
 
 DeclareOperation("ELM_LIST", [IsRMSIsoByTriple, IsPosInt]);
 DeclareOperation("ELM_LIST", [IsRZMSIsoByTriple, IsPosInt]);

--- a/gap/attributes/isorms.gi
+++ b/gap/attributes/isorms.gi
@@ -790,6 +790,133 @@ end);
 # 5. RMS/RZMSIsoByTriple
 #############################################################################
 
+InstallMethod(RMSIsoByTriple,
+"for two Rees matrix semigroups and a dense list",
+[IsReesMatrixSemigroup, IsReesMatrixSemigroup, IsDenseList],
+function(R1, R2, triple)
+  local graph_iso, group_iso, g2_elms_list, nrrows, nrcols, G1, G2;
+  graph_iso := triple[1];
+  group_iso := triple[2];
+  g2_elms_list := triple[3];
+
+  # Check number of rows and cols
+  nrcols := Length(Rows(R1));  # rows of R1 are cols of the matrix
+  nrrows := Length(Columns(R1));
+  if nrcols <> Length(Rows(R2)) or nrrows <> Length(Columns(R2)) then
+    ErrorNoReturn("Semigroups: RMSIsoByTriple:\n",
+                  "<R1> and <R2> are not isomorphic,");
+  fi;
+
+  # Check graph isomorphism
+  if not IsPerm(graph_iso) then
+    ErrorNoReturn("Semigroups: RMSIsoByTriple: usage,\n",
+                  "<triple>[1] should be a permutation,");
+  elif LargestMovedPoint(graph_iso) > nrrows + nrcols then
+    ErrorNoReturn("Semigroups: RMSIsoByTriple: usage,\n",
+                  "<triple>[1] should be a permutation on [1 .. ",
+                  nrrows + nrcols, "],");
+  elif ForAny([1 .. nrcols], x -> x ^ graph_iso > nrcols) then
+    ErrorNoReturn("Semigroups: RMSIsoByTriple: usage,\n",
+                  "<triple>[1] should not map columns to rows,");
+  fi;
+
+  # Check group isomorphism
+  G1 := UnderlyingSemigroup(R1);
+  G2 := UnderlyingSemigroup(R2);
+  if not (IsGroupHomomorphism(group_iso) and
+          IsBijective(group_iso) and
+          Source(group_iso) = G1 and
+          Range(group_iso) = G2) then
+    ErrorNoReturn("Semigroups: RMSIsoByTriple: usage,\n",
+                  "<triple>[2] should be an isomorphism from\n",
+                  "the underlying group of <R1> to that of <R2>,");
+  fi;
+
+  # Check map from rows and cols to H
+  if Length(g2_elms_list) <> nrrows + nrcols then
+    ErrorNoReturn("Semigroups: RMSIsoByTriple: usage,\n",
+                  "<triple>[3] should have length equal to\n",
+                  "the number of rows and columns of <R1>,");
+  elif not ForAll(g2_elms_list, x -> x in G2) then
+    ErrorNoReturn("Semigroups: RMSIsoByTriple: usage,\n",
+                  "<triple>[3] should only contain elements from ",
+                  "the underlying group of <R2>,");
+  fi;
+  if SEMIGROUPS.RMSInducedFunction(R1, R2, graph_iso, group_iso,
+                                   g2_elms_list[1]) <> g2_elms_list then
+    ErrorNoReturn("Semigroups: RMSIsoByTriple: usage,\n",
+                  "<triple>[3] does not define an isomorphism,");
+  fi;
+
+  return RMSIsoByTripleNC(R1, R2, triple);
+end);
+
+InstallMethod(RZMSIsoByTriple,
+"for two Rees 0-matrix semigroups and a dense list",
+[IsReesZeroMatrixSemigroup, IsReesZeroMatrixSemigroup, IsDenseList],
+function(R1, R2, triple)
+  local graph_iso, group_iso, g2_elms_list, nrrows, nrcols, graph1, graph2, G1,
+        G2, reps, map, rep;
+  graph_iso := triple[1];
+  group_iso := triple[2];
+  g2_elms_list := triple[3];
+
+  # Check number of rows and cols
+  nrrows := Length(Rows(R1));
+  nrcols := Length(Columns(R1));
+  if nrrows <> Length(Rows(R2)) or nrcols <> Length(Columns(R2)) then
+    ErrorNoReturn("Semigroups: RZMSIsoByTriple:\n",
+                  "<R1> and <R2> are not isomorphic,");
+  fi;
+
+  # Check graph isomorphism
+  graph1 := RZMSDigraph(R1);
+  graph2 := RZMSDigraph(R2);
+  if not IsPerm(graph_iso) then
+    ErrorNoReturn("Semigroups: RZMSIsoByTriple: usage,\n",
+                  "<triple>[1] should be a permutation,");
+  elif not OnDigraphs(graph1, graph_iso) = graph2 then
+    ErrorNoReturn("Semigroups: RZMSIsoByTriple: usage,\n",
+                  "<triple>[1] should act as an isomorphism from\n",
+                  "the graph of <R1> to the graph of <R2>,");
+  fi;
+
+  # Check group isomorphism
+  G1 := UnderlyingSemigroup(R1);
+  G2 := UnderlyingSemigroup(R2);
+  if not (IsGroupHomomorphism(group_iso) and
+          IsBijective(group_iso) and
+          Source(group_iso) = G1 and
+          Range(group_iso) = G2) then
+    ErrorNoReturn("Semigroups: RZMSIsoByTriple: usage,\n",
+                  "<triple>[2] should be an isomorphism from\n",
+                  "the underlying group of <R1> to that of <R2>,");
+  fi;
+
+  # Check map from rows and cols to H
+  if Length(g2_elms_list) <> nrrows + nrcols then
+    ErrorNoReturn("Semigroups: RZMSIsoByTriple: usage,\n",
+                  "<triple>[3] should have length equal to\n",
+                  "the number of rows and columns of <R1>,");
+  elif not ForAll(g2_elms_list, x -> x in G2) then
+    ErrorNoReturn("Semigroups: RZMSIsoByTriple: usage,\n",
+                  "<triple>[3] should only contain elements from ",
+                  "the underlying group of <R2>,");
+  fi;
+  reps := List(DigraphConnectedComponents(graph1).comps, Representative);
+  map := EmptyPlist(Length(reps));
+  for rep in reps do
+    map[rep] := g2_elms_list[rep];
+  od;
+  if SEMIGROUPS.RZMStoRZMSInducedFunction(R1, R2, graph_iso, group_iso, map)
+      <> g2_elms_list then
+    ErrorNoReturn("Semigroups: RZMSIsoByTriple: usage,\n",
+                  "<triple>[3] does not define an isomorphism,");
+  fi;
+
+  return RZMSIsoByTripleNC(R1, R2, triple);
+end);
+
 InstallMethod(RMSIsoByTripleNC,
 "for two Rees matrix semigroups and a dense list",
 [IsReesMatrixSemigroup, IsReesMatrixSemigroup, IsDenseList],

--- a/gap/attributes/isorms.gi
+++ b/gap/attributes/isorms.gi
@@ -396,7 +396,7 @@ function(R)
     od;
 
     if found then
-      AddSet(A, RZMSIsoByTriple(R, R, [x, y, tmp]));
+      AddSet(A, RZMSIsoByTripleNC(R, R, [x, y, tmp]));
     fi;
     return found;
   end;
@@ -443,7 +443,7 @@ function(R)
 
   # put B together
   for map in EnumeratorOfCartesianProduct(cart) do
-    x := RZMSIsoByTriple(R, R, [One(aut_graph), One(aut_group), Sum(map)]);
+    x := RZMSIsoByTripleNC(R, R, [One(aut_graph), One(aut_group), Sum(map)]);
     AddSet(A, x);
   od;
 
@@ -481,8 +481,8 @@ function(R)
     if IsEmpty(gens) then
       gens := [IdentityMapping(G)];
     fi;
-    A := Group(List(gens, x -> RMSIsoByTriple(R, R,
-                                              [(), x, [One(G), One(G)]])));
+    A := Group(List(gens, x -> RMSIsoByTripleNC(R, R,
+                                                [(), x, [One(G), One(G)]])));
     SetIsAutomorphismGroupOfRMSOrRZMS(A, true);
     SetIsFinite(A, true);
     return A;
@@ -556,7 +556,7 @@ function(R)
     for g in T do
       map := RMSInducedFunction(R, R, x, y, g);
       if map <> fail then
-        AddSet(A, RMSIsoByTriple(R, R, [x, y, map]));
+        AddSet(A, RMSIsoByTripleNC(R, R, [x, y, map]));
         return true;
       fi;
     od;
@@ -584,7 +584,7 @@ function(R)
                               One(aut_group),
                               g);
     if map <> fail then
-      AddSet(A, RMSIsoByTriple(R, R, [One(aut_graph), One(aut_group), map]));
+      AddSet(A, RMSIsoByTripleNC(R, R, [One(aut_graph), One(aut_group), map]));
     fi;
   od;
 
@@ -645,11 +645,11 @@ InstallMethod(IdentityMapping, "for a Rees matrix semigroup",
 function(R)
   local G;
   G := UnderlyingSemigroup(R);
-  return RMSIsoByTriple(R, R,
-                        [(),
-                         IdentityMapping(G),
-                         List([1 .. Length(Columns(R)) + Length(Rows(R))],
-                              x -> One(G))]);
+  return RMSIsoByTripleNC(R, R,
+                          [(),
+                           IdentityMapping(G),
+                           List([1 .. Length(Columns(R)) + Length(Rows(R))],
+                                x -> One(G))]);
 end);
 
 InstallMethod(IdentityMapping, "for a Rees 0-matrix semigroup",
@@ -658,7 +658,7 @@ function(R)
   local G, tup;
   G := UnderlyingSemigroup(R);
   tup := List([1 .. Length(Columns(R)) + Length(Rows(R))], x -> One(G));
-  return RZMSIsoByTriple(R, R, [(), IdentityMapping(G), tup]);
+  return RZMSIsoByTripleNC(R, R, [(), IdentityMapping(G), tup]);
 end);
 
 #############################################################################
@@ -680,9 +680,9 @@ function(R1, R2)
 
     if R1 = R2 then
       g := UnderlyingSemigroup(R1);
-      return RMSIsoByTriple(R1, R2, [(),
-                                     IdentityMapping(g),
-                                     List([1 .. m + n], x -> One(g))]);
+      return RMSIsoByTripleNC(R1, R2, [(),
+                                       IdentityMapping(g),
+                                       List([1 .. m + n], x -> One(g))]);
     else
       g1 := UnderlyingSemigroup(R1);
       g2 := UnderlyingSemigroup(R2);
@@ -703,7 +703,7 @@ function(R1, R2)
             for tup in Elements(g2) do
               map := RMSInducedFunction(R1, R2, l, g, tup);
               if map <> fail then
-                return RMSIsoByTriple(R1, R2, [l, g, map]);
+                return RMSIsoByTripleNC(R1, R2, [l, g, map]);
               fi;
             od;
           od;
@@ -741,9 +741,9 @@ function(R1, R2)
   n := Length(mat);
 
   if R1 = R2 then
-    return RZMSIsoByTriple(R1, R2, [(),
-                                    IdentityMapping(G1),
-                                    List([1 .. m + n], x -> One(G2))]);
+    return RZMSIsoByTripleNC(R1, R2, [(),
+                                      IdentityMapping(G1),
+                                      List([1 .. m + n], x -> One(G2))]);
   fi;
 
   # every isomorphism of the groups
@@ -778,7 +778,7 @@ function(R1, R2)
       for tup in tuples do #TODO it should be possible to cut this down
         map := RZMStoRZMSInducedFunction(R1, R2, l, g, tup);
         if map <> fail then
-          return RZMSIsoByTriple(R1, R2, [l, g, map]);
+          return RZMSIsoByTripleNC(R1, R2, [l, g, map]);
         fi;
       od;
     od;
@@ -790,23 +790,24 @@ end);
 # 5. RMS/RZMSIsoByTriple
 #############################################################################
 
-InstallGlobalFunction(RMSIsoByTriple,
+InstallMethod(RMSIsoByTripleNC,
+"for two Rees matrix semigroups and a dense list",
+[IsReesMatrixSemigroup, IsReesMatrixSemigroup, IsDenseList],
 function(R1, R2, triple)
   local fam, out;
-
   fam := GeneralMappingsFamily(ElementsFamily(FamilyObj(R1)),
                                ElementsFamily(FamilyObj(R2)));
   out := Objectify(NewType(fam, IsRMSIsoByTriple), rec(triple := triple));
   SetSource(out, R1);
   SetRange(out, R2);
-
   return out;
 end);
 
-InstallGlobalFunction(RZMSIsoByTriple,
+InstallMethod(RZMSIsoByTripleNC,
+"for two Rees 0-matrix semigroups and a dense list",
+[IsReesZeroMatrixSemigroup, IsReesZeroMatrixSemigroup, IsDenseList],
 function(R1, R2, triple)
   local fam, out;
-
   fam := GeneralMappingsFamily(ElementsFamily(FamilyObj(R1)),
                                ElementsFamily(FamilyObj(R2)));
   out := Objectify(NewType(fam, IsRZMSIsoByTriple), rec(triple := triple));
@@ -886,13 +887,13 @@ InstallMethod(CompositionMapping2, "for objects in `IsRMSIsoByTriple'",
 function(map2, map1)
   local n;
   n := Length(Rows(Source(map2))) + Length(Columns(Source(map2)));
-  return RMSIsoByTriple(Source(map1),
-                        Range(map2),
-                        [map1[1] * map2[1],
-                         map1[2] * map2[2],
-                         List([1 .. n],
-                              i -> map2[3][i ^ map1[1]] * map1[3][i] ^
-                                                          map2[2])]);
+  return RMSIsoByTripleNC(Source(map1),
+                          Range(map2),
+                          [map1[1] * map2[1],
+                           map1[2] * map2[2],
+                           List([1 .. n],
+                                i -> map2[3][i ^ map1[1]] * map1[3][i] ^
+                                                            map2[2])]);
 end);
 
 InstallMethod(CompositionMapping2, "for objects in `IsRZMSIsoByTriple'",
@@ -900,13 +901,13 @@ IsIdenticalObj, [IsRZMSIsoByTriple, IsRZMSIsoByTriple],
 function(map2, map1)
   local n;
   n := Length(Rows(Source(map1))) + Length(Columns(Source(map1)));
-  return RZMSIsoByTriple(Source(map1),
-                         Range(map2),
-                         [map1[1] * map2[1],
-                          map1[2] * map2[2],
-                          List([1 .. n],
-                               i -> map2[3][i ^ map1[1]] * map1[3][i] ^
-                                                           map2[2])]);
+  return RZMSIsoByTripleNC(Source(map1),
+                           Range(map2),
+                           [map1[1] * map2[1],
+                            map1[2] * map2[2],
+                            List([1 .. n],
+                                 i -> map2[3][i ^ map1[1]] * map1[3][i] ^
+                                                             map2[2])]);
 end);
 
 InstallMethod(ImagesElm, "for an RMS element under a mapping by a triple",
@@ -956,13 +957,13 @@ function(map)
   local n, inv;
   n := Length(Rows(Source(map))) + Length(Columns(Source(map)));
   inv := InverseGeneralMapping(map[2]);
-  return RMSIsoByTriple(Range(map),
-                        Source(map),
-                        [map[1] ^ -1,
-                         inv,
-                         List([1 .. n],
-                              i -> ((map[3][i ^ (map[1] ^ -1)] ^ inv) ^ -1))]);
-
+  return RMSIsoByTripleNC(Range(map),
+                          Source(map),
+                          [map[1] ^ -1,
+                           inv,
+                           List([1 .. n],
+                                i -> ((map[3][i ^ (map[1] ^ -1)] ^ inv)
+                                      ^ -1))]);
 end);
 
 InstallMethod(InverseGeneralMapping, "for objects in `IsRMSIsoByTriple'",
@@ -974,12 +975,12 @@ function(map)
   local n, inv;
   n := Length(Rows(Source(map))) + Length(Columns(Source(map)));
   inv := InverseGeneralMapping(map[2]);
-  return RZMSIsoByTriple(Range(map),
-                         Source(map),
-                         [map[1] ^ -1,
-                          inv,
-                          List([1 .. n],
-                               i -> (map[3][i ^ (map[1] ^ -1)] ^ inv) ^ -1)]);
+  return RZMSIsoByTripleNC(Range(map),
+                           Source(map),
+                           [map[1] ^ -1,
+                            inv,
+                            List([1 .. n],
+                                 i -> (map[3][i ^ (map[1] ^ -1)] ^ inv) ^ -1)]);
 end);
 
 InstallMethod(IsOne, "for objects in `IsRMSIsoByTriple'",

--- a/tst/standard/isorms.tst
+++ b/tst/standard/isorms.tst
@@ -566,17 +566,120 @@ true
 gap> ForAll(A, BruteForceInverseCheck);
 true
 
+#T# Errors in checked version of RMSIsoByTriple
+gap> g := SymmetricGroup(4);;
+gap> mat := [[(1, 3), (1, 2)(3, 4)],
+>            [(1, 4, 3, 2), ()],
+>            [(1, 3)(2, 4), (1, 3, 4, 2)]];;
+gap> R := ReesMatrixSemigroup(g, mat);;
+gap> S := ReesMatrixSemigroup(Group((1, 2)), [[()]]);;
+gap> auto := IdentityMapping(g);;
+gap> g_elms_list := [(), (1, 3), (), (), ()];;
+gap> RMSIsoByTriple(R, S, [(), auto, g_elms_list]);
+Error, Semigroups: RMSIsoByTriple:
+<R1> and <R2> are not isomorphic,
+gap> RMSIsoByTriple(R, R, [42, auto, g_elms_list]);
+Error, Semigroups: RMSIsoByTriple: usage,
+<triple>[1] should be a permutation,
+gap> RMSIsoByTriple(R, R, [(1, 7), auto, g_elms_list]);
+Error, Semigroups: RMSIsoByTriple: usage,
+<triple>[1] should be a permutation on [1 .. 5],
+gap> RMSIsoByTriple(R, R, [(1, 4), auto, g_elms_list]);
+Error, Semigroups: RMSIsoByTriple: usage,
+<triple>[1] should not map columns to rows,
+gap> RMSIsoByTriple(R, R, [(), fail, g_elms_list]);
+Error, Semigroups: RMSIsoByTriple: usage,
+<triple>[2] should be an isomorphism from
+the underlying group of <R1> to that of <R2>,
+gap> RMSIsoByTriple(R, R, [(), auto, [(), (), ()]]);
+Error, Semigroups: RMSIsoByTriple: usage,
+<triple>[3] should have length equal to
+the number of rows and columns of <R1>,
+gap> RMSIsoByTriple(R, R, [(), auto, [42, 43, 44, 45, 46]]);
+Error, Semigroups: RMSIsoByTriple: usage,
+<triple>[3] should only contain elements from the underlying group of <R2>,
+gap> RMSIsoByTriple(R, R, [(), auto, g_elms_list]);
+Error, Semigroups: RMSIsoByTriple: usage,
+<triple>[3] does not define an isomorphism,
+gap> iso := RMSIsoByTripleNC(R, R, [(), auto, g_elms_list]);;
+gap> BruteForceIsoCheck(iso);
+false
+gap> g_elms_list := [(), (), (), (), ()];;
+gap> iso := RMSIsoByTriple(R, R, [(), auto, g_elms_list]);
+((), IdentityMapping( SymmetricGroup( [ 1 .. 4 ] ) ), [ (), (), (), (), () ])
+gap> BruteForceIsoCheck(iso);
+true
+
+#T# Errors in checked version of RZMSIsoByTriple
+gap> g := SymmetricGroup(3);;
+gap> mat := [[0, 0, (1, 3)], [(1, 2, 3), (), (2, 3)], [0, 0, ()]];;
+gap> R := ReesZeroMatrixSemigroup(g, mat);;
+gap> S := ReesZeroMatrixSemigroup(Group((1, 2)), [[()]]);;
+gap> auto := IdentityMapping(g);;
+gap> g_elms_list := [(), (1, 3), (), (), (), ()];;
+gap> RZMSIsoByTriple(R, S, [(), auto, g_elms_list]);
+Error, Semigroups: RZMSIsoByTriple:
+<R1> and <R2> are not isomorphic,
+gap> RZMSIsoByTriple(R, R, [42, auto, g_elms_list]);
+Error, Semigroups: RZMSIsoByTriple: usage,
+<triple>[1] should be a permutation,
+gap> RZMSIsoByTriple(R, R, [(1, 3), auto, g_elms_list]);
+Error, Semigroups: RZMSIsoByTriple: usage,
+<triple>[1] should act as an isomorphism from
+the graph of <R1> to the graph of <R2>,
+gap> RZMSIsoByTriple(R, R, [(), fail, g_elms_list]);
+Error, Semigroups: RZMSIsoByTriple: usage,
+<triple>[2] should be an isomorphism from
+the underlying group of <R1> to that of <R2>,
+gap> RZMSIsoByTriple(R, R, [(), auto, [(), (), ()]]);
+Error, Semigroups: RZMSIsoByTriple: usage,
+<triple>[3] should have length equal to
+the number of rows and columns of <R1>,
+gap> RZMSIsoByTriple(R, R, [(), auto, [41, 42, 43, 44, 45, 46]]);
+Error, Semigroups: RZMSIsoByTriple: usage,
+<triple>[3] should only contain elements from the underlying group of <R2>,
+gap> RZMSIsoByTriple(R, R, [(), auto, g_elms_list]);
+Error, Semigroups: RZMSIsoByTriple: usage,
+<triple>[3] does not define an isomorphism,
+gap> iso := RZMSIsoByTripleNC(R, R, [(), auto, g_elms_list]);;
+gap> BruteForceIsoCheck(iso);
+false
+gap> g_elms_list := [(), (), (), (), (), ()];;
+gap> iso := RZMSIsoByTriple(R, R, [(), auto, g_elms_list]);
+((), IdentityMapping( SymmetricGroup( [ 1 .. 3 ] ) ), 
+[ (), (), (), (), (), () ])
+gap> BruteForceIsoCheck(iso);
+true
+
 #T# SEMIGROUPS_UnbindVariables
+gap> Unbind(A);
+gap> Unbind(BruteForceInverseCheck);
+gap> Unbind(BruteForceIsoCheck);
 gap> Unbind(G);
+gap> Unbind(G1);
+gap> Unbind(G2);
 gap> Unbind(H);
 gap> Unbind(I);
 gap> Unbind(R);
 gap> Unbind(R1);
 gap> Unbind(R2);
 gap> Unbind(S);
+gap> Unbind(W);
+gap> Unbind(WW);
+gap> Unbind(auto);
+gap> Unbind(comp);
 gap> Unbind(func);
+gap> Unbind(g);
+gap> Unbind(inv);
+gap> Unbind(iso);
+gap> Unbind(list);
+gap> Unbind(map);
 gap> Unbind(mat);
 gap> Unbind(mat1);
+gap> Unbind(mat2);
+gap> Unbind(norm);
+gap> Unbind(x);
+gap> Unbind(y);
 
 #E#
 gap> SEMIGROUPS.StopTest();


### PR DESCRIPTION
This adds documentation for the actual constructors `R(Z)MSIsoByTriple` and also adds checks to them to make them safe (there's also an `NC` version).