### PR TITLE
Install specific IsIdempotentGenerated methods for RMS/RZMS

### DIFF
--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -555,6 +555,79 @@ function(S)
   return out;
 end);
 
+InstallMethod(IdempotentGeneratedSubsemigroup,
+"for a Rees matrix subsemigroup",
+[IsReesMatrixSubsemigroup],
+function(R)
+  local mat, I, J, nrrows, nrcols, min, max, gens, out, i;
+
+  if not IsFinite(R) or not IsReesMatrixSemigroup(R)
+      or not IsGroup(UnderlyingSemigroup(R)) then
+    TryNextMethod();
+  fi;
+
+  mat := Matrix(R);
+  I := Rows(R);
+  J := Columns(R);
+  nrrows := Length(I);
+  nrcols := Length(J);
+
+  min := Minimum(nrrows, nrcols);
+  max := Maximum(nrrows, nrcols);
+  gens := EmptyPlist(max);
+  for i in [1 .. min] do
+    Add(gens, RMSElement(R, I[i], mat[J[i]][I[i]] ^ -1, J[i]));
+  od;
+  for i in [min + 1 .. nrrows] do
+    Add(gens, RMSElement(R, I[i], mat[J[1]][I[i]] ^ -1, J[1]));
+  od;
+  for i in [min + 1 .. nrcols] do
+    Add(gens, RMSElement(R, I[1], mat[J[i]][I[1]] ^ -1, J[i]));
+  od;
+  out := Semigroup(gens);
+  SetIsRegularSemigroup(out, true);
+  SetIsIdempotentGenerated(out, true);
+  SetIsSimpleSemigroup(out, true);
+  return out;
+end);
+
+InstallMethod(IdempotentGeneratedSubsemigroup,
+"for a Rees 0-matrix subsemigroup",
+[IsReesZeroMatrixSubsemigroup],
+function(R)
+  local mat, gr, gens, I, J, nrrows, k, out, i, j;
+
+  if not IsFinite(R) or not IsReesZeroMatrixSemigroup(R)
+      or not IsGroup(UnderlyingSemigroup(R)) then
+    TryNextMethod();
+  fi;
+
+  mat := Matrix(R);
+  gr := RZMSDigraph(R);
+  gens := [];
+
+  if IsCompleteBipartiteDigraph(ReducedDigraph(gr)) or IsEmptyDigraph(gr) then
+    Add(gens, MultiplicativeZero(R));
+  fi;
+
+  gr := OutNeighbours(UndirectedSpanningForest(gr));
+  I := Rows(R);
+  J := Columns(R);
+  nrrows := Length(I);
+
+  for i in [1 .. nrrows] do
+    for j in gr[i] do
+      k := J[j - nrrows];
+      Add(gens, RMSElement(R, I[i], mat[k][I[i]] ^ -1, k));
+    od;
+  od;
+
+  out := Semigroup(gens);
+  SetIsRegularSemigroup(out, true);
+  SetIsIdempotentGenerated(out, true);
+  return out;
+end);
+
 InstallMethod(InjectionPrincipalFactor, "for a Green's D-class (Semigroups)",
 [IsGreensDClass],
 function(D)

--- a/gap/attributes/maximal.gi
+++ b/gap/attributes/maximal.gi
@@ -1061,10 +1061,13 @@ function(R, opts)
     if not failed and not opts.number then
       Info(InfoSemigroups, 2, "...creating these maximal subsemigroups.");
 
-      # TODO only need generating set for idempotents - don't not *every* idem
-      idems := ShallowCopy(Idempotents(R));
+      idems := GeneratorsOfSemigroup(IdempotentGeneratedSubsemigroup(R));
+      idems := ShallowCopy(idems);
       if not opts.zero or not IsCompleteBipartiteDigraph(RZMSDigraph(R_n)) then
-        Remove(idems, Position(idems, zero));
+        x := Position(idems, zero);
+        if x <> fail then
+          Remove(idems, x);
+        fi;
       fi;
 
       # Max subsemigroup arising from <max[i]> <--> Transversal of <results[i]>

--- a/tst/extreme/maximal.tst
+++ b/tst/extreme/maximal.tst
@@ -281,7 +281,7 @@ gap> max := MaximalSubsemigroups(R1);
   <subsemigroup of 5x5 Rees 0-matrix semigroup with 10 generators>, 
   <subsemigroup of 5x5 Rees 0-matrix semigroup with 10 generators>, 
   <subsemigroup of 5x5 Rees 0-matrix semigroup with 10 generators>, 
-  <subsemigroup of 5x5 Rees 0-matrix semigroup with 11 generators> ]
+  <subsemigroup of 5x5 Rees 0-matrix semigroup with 10 generators> ]
 gap> NrMaximalSubsemigroups(R1);
 26
 

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1400,6 +1400,268 @@ Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 2nd choice method found for `InversesOfSemigroupElementNC' on 2 argu\
 ments
 
+#T# attr: IdempotentGeneratedSubsemigroup, 2
+gap> S := FullTransformationMonoid(3);;
+gap> I := IdempotentGeneratedSubsemigroup(S);;
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+
+#T# attr: IdempotentGeneratedSubsemigroup, for an Rees matrix semigroup, 1
+# TryNextMethod()
+
+# Error: infinite
+gap> S := FreeSemigroup(1);
+<free semigroup on the generators [ s1 ]>
+gap> R := ReesMatrixSemigroup(S, [[S.1]]);
+<Rees matrix semigroup 1x1 over <free semigroup on the generators [ s1 ]>>
+gap> IdempotentGeneratedSubsemigroup(R);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 4th choice method found for `IdempotentGeneratedSubsemigroup' on 1 a\
+rguments
+
+# not a Rees matrix semigroup
+gap> x := Transformation([2, 2]);;
+gap> R := ReesMatrixSemigroup(FullTransformationMonoid(2),
+>                             [[IdentityTransformation, x],
+>                              [x, x]]);
+<Rees matrix semigroup 2x2 over <full transformation monoid of degree 2>>
+gap> S := Semigroup(RMSElement(R, 1, IdentityTransformation, 1),
+>                   RMSElement(R, 2, IdentityTransformation, 2));
+<subsemigroup of 2x2 Rees matrix semigroup with 2 generators>
+gap> IsReesMatrixSubsemigroup(S);
+true
+gap> IsReesMatrixSemigroup(S);
+false
+gap> I := IdempotentGeneratedSubsemigroup(S);;
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+gap> Size(I) = 5;
+true
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+
+# not over a group
+gap> x := Transformation([2, 2]);;
+gap> R := ReesMatrixSemigroup(FullTransformationMonoid(2),
+>                             [[IdentityTransformation, x],
+>                              [x, x]]);
+<Rees matrix semigroup 2x2 over <full transformation monoid of degree 2>>
+gap> I := IdempotentGeneratedSubsemigroup(R);;
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+gap> Size(I) = 9;
+true
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+
+#T# attr: IdempotentGeneratedSubsemigroup, for an Rees matrix semigroup, 2
+
+# Rectangular bands
+gap> R := RectangularBand(IsReesMatrixSemigroup, 1, 1);
+<Rees matrix semigroup 1x1 over Group(())>
+gap> I := IdempotentGeneratedSubsemigroup(R);
+<subsemigroup of 1x1 Rees matrix semigroup with 1 generator>
+gap> I = R;
+true
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> R := RectangularBand(IsReesMatrixSemigroup, 3, 1);
+<Rees matrix semigroup 3x1 over Group(())>
+gap> I := IdempotentGeneratedSubsemigroup(R);
+<subsemigroup of 3x1 Rees matrix semigroup with 3 generators>
+gap> I = R;
+true
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> R := RectangularBand(IsReesMatrixSemigroup, 1, 3);
+<Rees matrix semigroup 1x3 over Group(())>
+gap> I := IdempotentGeneratedSubsemigroup(R);
+<subsemigroup of 1x3 Rees matrix semigroup with 3 generators>
+gap> I = R;
+true
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> R := RectangularBand(IsReesMatrixSemigroup, 2, 2);
+<Rees matrix semigroup 2x2 over Group(())>
+gap> I := IdempotentGeneratedSubsemigroup(R);
+<subsemigroup of 2x2 Rees matrix semigroup with 2 generators>
+gap> I = R;
+true
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+
+# Subsemigroup, giving non-standard matrix
+gap> x := [[(2, 3, 5), (1, 2, 4)(3, 5), (1, 3, 5, 2, 4)],
+>          [(1, 3, 5, 4), (2, 3, 5, 4), (1, 3, 5)(2, 4)],
+>          [(2, 3, 5), (1, 5, 4, 3, 2), ()],
+>          [(1, 4, 2, 5), (1, 2)(3, 5), (1, 5, 3, 2, 4)],
+>          [(1, 4)(2, 3, 5), (1, 2)(4, 5), (1, 3, 4, 2, 5)]];;
+gap> G := SymmetricGroup(5);;
+gap> R := ReesMatrixSemigroup(G, x);
+<Rees matrix semigroup 3x5 over Sym( [ 1 .. 5 ] )>
+gap> S := ReesMatrixSubsemigroup(R, [2], G, [4]);
+<Rees matrix semigroup 1x1 over Sym( [ 1 .. 5 ] )>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 3x5 Rees matrix semigroup with 1 generator>
+gap> GeneratorsOfSemigroup(I);
+[ (2,(1,2)(3,5),4) ]
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> S := ReesMatrixSubsemigroup(R, [2], G, [3, 4, 5]);
+<Rees matrix semigroup 1x3 over Sym( [ 1 .. 5 ] )>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 3x5 Rees matrix semigroup with 3 generators>
+gap> GeneratorsOfSemigroup(I);
+[ (2,(1,2,3,4,5),3), (2,(1,2)(3,5),4), (2,(1,2)(4,5),5) ]
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> S := ReesMatrixSubsemigroup(R, [2, 3], G, [4]);
+<Rees matrix semigroup 2x1 over Sym( [ 1 .. 5 ] )>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 3x5 Rees matrix semigroup with 2 generators>
+gap> GeneratorsOfSemigroup(I);
+[ (2,(1,2)(3,5),4), (3,(1,4,2,3,5),4) ]
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> S := ReesMatrixSubsemigroup(R, [2, 3], G, [4, 5]);
+<Rees matrix semigroup 2x2 over Sym( [ 1 .. 5 ] )>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 3x5 Rees matrix semigroup with 2 generators>
+gap> GeneratorsOfSemigroup(I);
+[ (2,(1,2)(3,5),4), (3,(1,5,2,4,3),5) ]
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+
+#T# attr: IdempotentGeneratedSubsemigroup, for an Rees 0-matrix semigroup, 1
+# TryNextMethod()
+
+# Error: infinite
+gap> S := FreeSemigroup(1);
+<free semigroup on the generators [ s1 ]>
+gap> R := ReesZeroMatrixSemigroup(S, [[S.1]]);
+<Rees 0-matrix semigroup 1x1 over <free semigroup on the generators [ s1 ]>>
+gap> IdempotentGeneratedSubsemigroup(R);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 4th choice method found for `IdempotentGeneratedSubsemigroup' on 1 a\
+rguments
+
+# not a Rees matrix semigroup
+gap> x := Transformation([2, 2]);;
+gap> R := ReesZeroMatrixSemigroup(FullTransformationMonoid(2),
+>                                 [[IdentityTransformation, 0],
+>                                  [0, x]]);
+<Rees 0-matrix semigroup 2x2 over <full transformation monoid of degree 2>>
+gap> S := Semigroup(RMSElement(R, 1, IdentityTransformation, 1),
+>                   RMSElement(R, 2, IdentityTransformation, 2));
+<subsemigroup of 2x2 Rees 0-matrix semigroup with 2 generators>
+gap> IsReesZeroMatrixSubsemigroup(S);
+true
+gap> IsReesZeroMatrixSemigroup(S);
+false
+gap> I := IdempotentGeneratedSubsemigroup(S);;
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+gap> Size(I) = 3;
+true
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+
+# not over a group
+gap> x := Transformation([2, 2]);;
+gap> R := ReesZeroMatrixSemigroup(FullTransformationMonoid(2),
+>                                 [[IdentityTransformation, 0],
+>                                  [x, x]]);
+<Rees 0-matrix semigroup 2x2 over <full transformation monoid of degree 2>>
+gap> I := IdempotentGeneratedSubsemigroup(R);;
+gap> HasIsIdempotentGenerated(I);
+true
+gap> IsIdempotentGenerated(I);
+true
+gap> Size(I) = 10;
+true
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+
+#T# attr: IdempotentGeneratedSubsemigroup, for an Rees 0-matrix semigroup, 2
+
+# Subsemigroup, giving non-standard matrix, 1
+gap> R := ReesZeroMatrixSemigroup(Group(()), [[(), ()], [(), ()]]);
+<Rees 0-matrix semigroup 2x2 over Group(())>
+gap> S := Semigroup(RMSElement(R, 2, (), 2), MultiplicativeZero(R));
+<subsemigroup of 2x2 Rees 0-matrix semigroup with 2 generators>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 2x2 Rees 0-matrix semigroup with 2 generators>
+gap> I = S;
+true
+gap> Elements(I);
+[ 0, (2,(),2) ]
+
+# Subsemigroup, giving non-standard matrix, 2
+gap> x := [[(1, 3, 5)(2, 4), (1, 4, 3, 2, 5), (1, 3, 5)(2, 4)],
+>          [(2, 4, 5, 3), 0, (1, 4, 5, 3)],
+>          [(3, 5, 4), 0, (1, 4, 5)(2, 3)],
+>          [0, 0, (1, 3, 4, 2)],
+>          [(2, 3, 4), (1, 2, 5, 4, 3), (1, 5, 3)(2, 4)]];;
+gap> G := SymmetricGroup(5);;
+gap> R := ReesZeroMatrixSemigroup(G, x);
+<Rees 0-matrix semigroup 3x5 over Sym( [ 1 .. 5 ] )>
+gap> S := ReesZeroMatrixSubsemigroup(R, [2], G, [4]);
+<Rees 0-matrix semigroup 1x1 over Sym( [ 1 .. 5 ] )>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 3x5 Rees 0-matrix semigroup with 1 generator>
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> I = Semigroup(Idempotents(S));
+true
+gap> S := ReesZeroMatrixSubsemigroup(R, [2], G, [3, 4, 5]);
+<Rees 0-matrix semigroup 1x3 over Sym( [ 1 .. 5 ] )>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 3x5 Rees 0-matrix semigroup with 2 generators>
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> I = Semigroup(Idempotents(S));
+true
+gap> S := ReesZeroMatrixSubsemigroup(R, [2, 3], G, [4]);
+<Rees 0-matrix semigroup 2x1 over Sym( [ 1 .. 5 ] )>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 3x5 Rees 0-matrix semigroup with 2 generators>
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> I = Semigroup(Idempotents(S));
+true
+gap> S := ReesZeroMatrixSubsemigroup(R, [2, 3], G, [4, 5]);
+<Rees 0-matrix semigroup 2x2 over Sym( [ 1 .. 5 ] )>
+gap> I := IdempotentGeneratedSubsemigroup(S);
+<subsemigroup of 3x5 Rees 0-matrix semigroup with 3 generators>
+gap> ForAll(GeneratorsOfSemigroup(I), IsIdempotent);
+true
+gap> I = Semigroup(Idempotents(S));
+true
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(D);
 gap> Unbind(G);

--- a/tst/standard/maximal.tst
+++ b/tst/standard/maximal.tst
@@ -348,10 +348,10 @@ gap> MaximalSubsemigroups(R);
   <Rees 0-matrix semigroup 2x1 over Group([ (2,3), (1,2) ])>, 
   <Rees 0-matrix semigroup 1x2 over Group([ (2,3), (1,2) ])>, 
   <Rees 0-matrix semigroup 1x2 over Group([ (2,3), (1,2) ])>, 
-  <subsemigroup of 2x2 Rees 0-matrix semigroup with 6 generators>, 
-  <subsemigroup of 2x2 Rees 0-matrix semigroup with 6 generators>, 
-  <subsemigroup of 2x2 Rees 0-matrix semigroup with 6 generators>, 
-  <subsemigroup of 2x2 Rees 0-matrix semigroup with 6 generators> ]
+  <subsemigroup of 2x2 Rees 0-matrix semigroup with 5 generators>, 
+  <subsemigroup of 2x2 Rees 0-matrix semigroup with 5 generators>, 
+  <subsemigroup of 2x2 Rees 0-matrix semigroup with 5 generators>, 
+  <subsemigroup of 2x2 Rees 0-matrix semigroup with 5 generators> ]
 
 # Easy example, 1x1
 gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[()]]);
@@ -524,7 +524,7 @@ gap> MaximalSubsemigroups(R, rec(contain := [x]));
 [ <subsemigroup of 2x2 Rees 0-matrix semigroup with 4 generators>, 
   <Rees 0-matrix semigroup 2x1 over Group([ (3,4), (1,2) ])>, 
   <Rees 0-matrix semigroup 1x2 over Group([ (3,4), (1,2) ])>, 
-  <subsemigroup of 2x2 Rees 0-matrix semigroup with 6 generators> ]
+  <subsemigroup of 2x2 Rees 0-matrix semigroup with 5 generators> ]
 gap> MaximalSubsemigroups(R, rec(D := DClass(R, x), number := true));
 7
 gap> MaximalSubsemigroups(R, rec(D := DClass(R, MultiplicativeZero(R)),
@@ -556,6 +556,14 @@ gap> MaximalSubsemigroups(R, rec(types := [5, 6],
 >                                contain := [MultiplicativeZero(R),
 >                                            RMSElement(R, 2, (), 1)]));
 [ <subsemigroup of 2x2 Rees 0-matrix semigroup with 3 generators>, 
+  <subsemigroup of 2x2 Rees 0-matrix semigroup with 4 generators> ]
+
+#T# maximal: MaximalSubsemigroups, for a Rees 0-matrix semigroup, 13
+gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[(), 0], [0, ()]]);
+<Rees 0-matrix semigroup 2x2 over Sym( [ 1 .. 2 ] )>
+gap> SetIdempotentGeneratedSubsemigroup(R, Semigroup(Idempotents(R)));
+gap> MaximalSubsemigroups(R, rec(types := [6]));
+[ <subsemigroup of 2x2 Rees 0-matrix semigroup with 4 generators>, 
   <subsemigroup of 2x2 Rees 0-matrix semigroup with 4 generators> ]
 
 #T# maximal: MaximalSubsemigroups, for Rees 0-matrix subsemigroup, 1
@@ -590,7 +598,7 @@ gap> MaximalSubsemigroups(U);
   <Rees 0-matrix semigroup 2x2 over Group([ (2,3), (1,2) ])>, 
   <Rees 0-matrix semigroup 1x3 over Group([ (2,3), (1,2) ])>, 
   <subsemigroup of 3x4 Rees 0-matrix semigroup with 5 generators>, 
-  <subsemigroup of 3x4 Rees 0-matrix semigroup with 6 generators> ]
+  <subsemigroup of 3x4 Rees 0-matrix semigroup with 5 generators> ]
 
 #T# maximal: MaximalSubsemigroups, for a permutation group, 1
 gap> MaximalSubsemigroups(SymmetricGroup(3));


### PR DESCRIPTION
For a regular Rees (0-)matrix semigroup over a group, it's easy to say write down a fairly small generating set for the idempotent generated subsemigroup. For Rees matrix semigroups, I think the method gives a minimal generating set (it's certainly irredundant). For Rees 0-matrix semigroups, the code now makes use of my recent addition to Digraphs called `UndirectedSpanningForest`. A spanning forest of the `RZMSDigraph` corresponds to a generating set for the idempotent generated subsemigroup. Whilst this certainly does not return a irredundant generating set in general, it has the potential to return a much smaller generating set that was obtained previously.

Additionally, this PR allows me to address a long-standing TODO from my maximal subsemigroups code. At a certain part in those algorithms, to specify the generating set of a maximal subsemigroup, we require the set of idempotents of a particular Rees (0-)matrix semigroup. However, we only actually require a generating set for these idempotents. Since there is a special method installed for this now, we may as well use this.