### PR TITLE
kernel: use reserve when size is known

### DIFF
--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -394,6 +394,10 @@ Semigroup* en_semi_init_semigroup(en_semi_obj_t es) {
   really_delete_cont(gens);
   ADDR_OBJ(es)[5] = reinterpret_cast<Obj>(semi_cpp);
 
+  if (IsbPRec(so, RNam_Size)) {
+    semi_cpp->reserve(INT_INTOBJ(ElmPRec(so, RNam_Size)));
+  }
+
   return semi_cpp;
 }
 


### PR DESCRIPTION
This allows us to reserve enough memory in the C++ semigroup
associated to a GAP semigroup.