### PR TITLE
Add immediate methods for regular monogenic semigroups

### DIFF
--- a/doc/attrinv.xml
+++ b/doc/attrinv.xml
@@ -441,18 +441,16 @@ gap> AsSet(SameMinorantsSubgroup(x));
 </ManSection>
 <Example><![CDATA[
 gap> S := InverseSemigroup(PartialPerm([2, 1, 4, 3, 6, 5, 8, 7]));
-<commutative inverse partial perm semigroup of rank 8 with 1 
- generator>
+<partial perm group of rank 8 with 1 generator>
 gap> Elements(S);
 [ <identity partial perm on [ 1, 2, 3, 4, 5, 6, 7, 8 ]>, 
   (1,2)(3,4)(5,6)(7,8) ]
 gap> T := SmallerDegreePartialPermRepresentation(S);
 MappingByFunction( <partial perm group of size 2, rank 8 with
-  1 generator>, <commutative inverse partial perm semigroup of rank 2 
-with 1 generator>, function( x ) ... end, function( x ) ... end )
+  1 generator>, <partial perm group of rank 2 with 1 generator>
+, function( x ) ... end, function( x ) ... end )
 gap> R := Range(T);
-<commutative inverse partial perm semigroup of rank 2 with 1 
- generator>
+<partial perm group of rank 2 with 1 generator>
 gap> Elements(R);
 [ <identity partial perm on [ 1, 2 ]>, (1,2) ]
 gap> S := DualSymmetricInverseMonoid(5);;

--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -89,3 +89,6 @@ InstallTrueMethod(IsTrivial,
 InstallTrueMethod(IsBand, IsRectangularBand);
 InstallTrueMethod(IsCompletelySimpleSemigroup, IsSimpleSemigroup and IsFinite);
 InstallTrueMethod(IsSemigroupWithAdjoinedZero, IsSemigroup and IsZeroGroup);
+InstallTrueMethod(IsFinite, IsMonogenicSemigroup and IsRegularSemigroup);
+InstallTrueMethod(IsGroupAsSemigroup,
+                  IsMonogenicSemigroup and IsRegularSemigroup);

--- a/tst/standard/properties.tst
+++ b/tst/standard/properties.tst
@@ -1866,6 +1866,23 @@ gap> IdempotentGeneratedSubsemigroup(S);;
 gap> IsSemigroupWithCommutingIdempotents(S);
 true
 
+#T# properties: true methods for IsMonogenicSemigroup and IsRegularSemigroup
+gap> S := Semigroup(Matrix(IsIntegerMatrix,
+>                   [[1, 0, 0], [0, 1, 0], [0, 0, 0]]));
+<commutative semigroup of 3x3 integer matrices with 1 generator>
+gap> IsMonogenicSemigroup(S);
+true
+gap> HasIsFinite(S) or HasIsGroupAsSemigroup(S);
+false
+gap> IsRegularSemigroup(S);
+true
+gap> HasIsFinite(S);
+true
+gap> HasIsGroupAsSemigroup(S);
+true
+gap> IsFinite(S) and IsGroupAsSemigroup(S);
+true
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(D);
 gap> Unbind(I);

--- a/tst/standard/semipperm.tst
+++ b/tst/standard/semipperm.tst
@@ -1662,8 +1662,7 @@ true
 gap> R := ReesMatrixSemigroup(Group([(1, 2)]), [[()]]);
 <Rees matrix semigroup 1x1 over Group([ (1,2) ])>
 gap> T := AsSemigroup(IsPartialPermSemigroup, R);
-<commutative inverse partial perm semigroup of size 2, rank 2 with 1 
- generator>
+<partial perm group of size 2, rank 2 with 1 generator>
 gap> Size(R) = Size(T);
 true
 gap> NrDClasses(R) = NrDClasses(T);


### PR DESCRIPTION
A monogenic semigroup is either the monogenic free semigroup, or a finite monogenic semigroup with index `m` and period `r`.

If `S` is monogenic and regular, then it is finite, and moreover it has index `1`. Therefore it is a cyclic group.

I've installed two true methods:
* `IsRegularSemigroup and IsMonogenicSemigroup` => `IsGroupAsSemigroup`
* `IsRegularSemigroup and IsMonogenicSemigroup` => `IsFinite`