### PR TITLE
io: fix error messages

### DIFF
--- a/gap/tools/io.gi
+++ b/gap/tools/io.gi
@@ -63,7 +63,7 @@ function(arg)
     line_nr := arg[2];
   else
     ErrorNoReturn("Semigroups: ReadGenerators: usage,\n",
-                  "there should be at most 2 arguments,");
+                  "there should be 1 or 2 arguments,");
   fi;
 
   if IsString(name) then
@@ -71,7 +71,7 @@ function(arg)
     file := IO_CompressedFile(name, "r");
     if file = fail then
       ErrorNoReturn("Semigroups: ReadGenerators:\n",
-                    "could not open the file ", file, ",");
+                    "could not open the file ", name, ",");
     fi;
   elif IsFile(name) then
     file := name;
@@ -219,7 +219,7 @@ function(arg)
     line_nr := arg[2];
   else
     ErrorNoReturn("Semigroups: ReadOldGenerators: usage,\n",
-                  "there should be at most 2 arguments,");
+                  "there should be 1 or 2 arguments,");
   fi;
 
   if IsString(name) then
@@ -227,7 +227,7 @@ function(arg)
     file := IO_CompressedFile(name, "r");
     if file = fail then
       ErrorNoReturn("Semigroups: ReadOldGenerators:\n",
-                    "could not open the file ", file, ",");
+                    "could not open the file ", name, ",");
     fi;
   elif IsFile(name) then
     file := name;

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -52,10 +52,10 @@ gap> ReadGenerators(name, 2);
 [ <identity partial perm on [ 1, 3, 4 ]>, [1,2](3)(4) ]
 gap> ReadGenerators(name, 2, 3);
 Error, Semigroups: ReadGenerators: usage,
-there should be at most 2 arguments,
+there should be 1 or 2 arguments,
 gap> ReadGenerators("non-existant-file");
 Error, Semigroups: ReadGenerators:
-could not open the file fail,
+could not open the file non-existant-file,
 gap> file := IO_CompressedFile(name, "r");;
 gap> ReadGenerators(file, 2);
 [ <identity partial perm on [ 1, 3, 4 ]>, [1,2](3)(4) ]
@@ -110,10 +110,10 @@ gap> ReadOldGenerators(name, 4);
 [ IdentityTransformation ]
 gap> ReadOldGenerators(name, 2, 3);
 Error, Semigroups: ReadOldGenerators: usage,
-there should be at most 2 arguments,
+there should be 1 or 2 arguments,
 gap> ReadOldGenerators("non-existant-file");
 Error, Semigroups: ReadOldGenerators:
-could not open the file fail,
+could not open the file non-existant-file,
 gap> file := IO_CompressedFile(name, "r");;
 gap> ReadOldGenerators(file, 2);
 [ Transformation( [ 1, 1, 2 ] ) ]


### PR DESCRIPTION
For some reason, when a file couldn’t be opened fail was displayed in
the error rather than the filename, this commit fixes this, and adjusts the 
tests.