### PR TITLE
properties: fix IsEUnitaryInverseSemigroup

### DIFF
--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -35,7 +35,7 @@ DeclareProperty("IsSemigroupWithCommutingIdempotents", IsSemigroup);
 DeclareProperty("IsUnitRegularMonoid", IsSemigroup);
 DeclareProperty("IsZeroRectangularBand", IsSemigroup);
 DeclareProperty("IsCongruenceFreeSemigroup", IsSemigroup);
-DeclareProperty("IsEUnitaryInverseSemigroup", IsInverseSemigroup);
+DeclareProperty("IsEUnitaryInverseSemigroup", IsSemigroup);
 DeclareProperty("IsSemigroupWithAdjoinedZero", IsSemigroup);
 
 DeclareSynonymAttr("IsRectangularGroup",

--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -334,11 +334,13 @@ function(S)
   return IsMajorantlyClosed(S, IdempotentGeneratedSubsemigroup(S));
 end);
 
-InstallMethod(IsEUnitaryInverseSemigroup, "for an inverse semigroup",
-[IsInverseSemigroup],
+InstallMethod(IsEUnitaryInverseSemigroup, "for a semigroup",
+[IsSemigroup],
 function(S)
   if not IsFinite(S) then
     TryNextMethod();
+  elif not IsInverseSemigroup(S) then
+    return false;
   fi;
   return IsEUnitaryInverseSemigroup(AsSemigroup(IsPartialPermSemigroup, S));
 end);


### PR DESCRIPTION
`IsEUnitaryInverseSemigroup` does not work for some semigroups which don't satisfy
`IsInverseSemigroup`. For example:

```
gap> S := Semigroup([Transformation([2, 2]), Transformation([2, 1, 2]),
> Transformation([3, 3, 2])]);;
gap> IsEUnitaryInverseSemigroup(S);
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 2nd choice method found for `IsEUnitaryInverseSemigroup' on 1
arguments at /Users/crussell/gap/lib/methsel2.g:241 called from
<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
called from read-eval loop at *stdin*:3
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
brk> quit;
gap> IsInverseSemigroup(S);
false
```