### PR TITLE
doc: add semigroup version of DirectProduct

### DIFF
--- a/doc/semitrans.xml
+++ b/doc/semitrans.xml
@@ -330,6 +330,41 @@ true]]></Example>
   </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DirectProduct">
+<ManSection>
+  <Func Name = "DirectProduct" Arg = "S[, T, ...]"/>
+  <Oper Name = "DirectProductOp" Arg = "list, S"/>
+  <Returns>A transformation semigroup.</Returns>
+  <Description>
+    The function <C>DirectProduct</C> takes an arbitrary positive number of
+    transformation semigroups and returns another transformation semigroup
+    isomorphic to their direct product.
+
+    The operation <C>DirectProductOp</C> is included for consistency with the
+    &GAP; library (see <Ref Oper="DirectProductOp" BookName="ref"/>).  It takes
+    exactly two arguments, namely a non-empty list <C>list</C> of transformation
+    semigroups and one of these semigroups, <C>S</C>. <P/>
+
+    <Example><![CDATA[
+gap> S := Semigroup(Transformation([2, 1]));;
+gap> T := Semigroup(Transformation([1, 2, 3, 3, 3]));;
+gap> DP := DirectProduct(S, T);
+<commutative transformation semigroup of degree 7 with 2 generators>
+gap> Elements(DP);
+[ Transformation( [ 1, 2, 3, 4, 5, 5, 5 ] ), 
+  Transformation( [ 2, 1, 3, 4, 5, 5, 5 ] ) ]
+gap> S := Monoid([Transformation([2, 4, 3, 4]),
+>                 Transformation([3, 3, 2, 3, 3])]);;
+gap> T := Semigroup([Transformation([3, 5, 4, 2, 6, 3])]);;
+gap> DP := DirectProduct(S, T);
+<transformation semigroup of degree 11 with 4 generators>
+gap> Size(DP);
+35
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="FixedPointsOfTransformationSemigroup">
   <ManSection>
     <Attr Name="FixedPointsOfTransformationSemigroup" Arg="S" Label="for a transformation semigroup"/>

--- a/doc/z-chap06.xml
+++ b/doc/z-chap06.xml
@@ -358,6 +358,7 @@ true]]></Log>
     <#Include Label = "ClosureSemigroup">
     <#Include Label = "SubsemigroupByProperty">
     <#Include Label = "InverseSubsemigroupByProperty">
+    <#Include Label = "DirectProduct">
   </Section>
  
    <Section Label = "Changing the representation of a semigroup">


### PR DESCRIPTION
Currently there is only the GAP library version, which only talks about groups.