### PR TITLE
Add internal functions for converting words to ext rep obj words and to strings

### DIFF
--- a/gap/semigroups/semifp.gi
+++ b/gap/semigroups/semifp.gi
@@ -464,6 +464,59 @@ SEMIGROUPS.ExtRepObjToWord := function(ext_rep_obj)
   return word;
 end;
 
+SEMIGROUPS.WordToExtRepObj := function(word)
+  local n, ext_rep_obj, i, j;
+  n           := Length(word);
+  ext_rep_obj := [];
+  i           := 1;
+  j           := 1;
+
+  while i <= Length(word) do
+    Add(ext_rep_obj, word[i]);
+    Add(ext_rep_obj, 1);
+    i := i + 1;
+    while i <= Length(word) and word[i] = ext_rep_obj[j] do
+      ext_rep_obj[j + 1] := ext_rep_obj[j + 1] + 1;
+      i := i + 1;
+    od;
+    j := j + 2;
+  od;
+  return ext_rep_obj;
+end;
+
+SEMIGROUPS.ExtRepObjToString := function(ext_rep_obj)
+  local alphabet, out, i;
+  alphabet := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  out := "";
+  for i in [1, 3 .. Length(ext_rep_obj) - 1] do
+    if ext_rep_obj[i] > Length(alphabet) then
+      ErrorNoReturn("SEMIGROUPS.ExtRepObjToString: the maximum value in an ",
+                    "odd position of the argument must be at most ",
+                    Length(alphabet), ",");
+    fi;
+    Add(out, alphabet[ext_rep_obj[i]]);
+    if ext_rep_obj[i + 1] > 1 then
+      Append(out, " ^ ");
+      Append(out, String(ext_rep_obj[i + 1]));
+    fi;
+  od;
+  return out;
+end;
+
+SEMIGROUPS.WordToString := function(word)
+  local alphabet, out, letter;
+  alphabet := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  out := "";
+  for letter in word do
+    if letter > Length(alphabet) then
+      ErrorNoReturn("SEMIGROUPS.WordToString: the maximum value in the",
+                    " argument be at most ", Length(alphabet), ",");
+    fi;
+    Add(out, alphabet[letter]);
+  od;
+  return out;
+end;
+
 ## The following method could disappear if there are methods for Green's
 ## relations etc so that the other method in attr.gi can be used.
 #

--- a/tst/standard/semifp.tst
+++ b/tst/standard/semifp.tst
@@ -1999,6 +1999,67 @@ gap> S := F / [[F.1, F.2 * F.1], [F.1, F.1 * F.2], [F.1 ^ 2, F.1]];;
 gap> MultiplicativeZero(S) = S.1;
 true
 
+# Test SEMIGROUPS.WordToExtRepWord
+gap> w := [1 .. 100] * 0 + 1;
+[ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+gap> SEMIGROUPS.WordToExtRepObj(w);
+[ 1, 100 ]
+gap> w := Concatenation(w, [1 .. 50] * 0 + 2);
+[ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ]
+gap> SEMIGROUPS.WordToExtRepObj(w);
+[ 1, 100, 2, 50 ]
+gap> w := Concatenation(w, [1] * 3);
+[ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 
+  3 ]
+gap> SEMIGROUPS.WordToExtRepObj(w);
+[ 1, 100, 2, 50, 3, 1 ]
+gap> w := Concatenation(w, [1 .. 4] * 0 + 1);
+[ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 
+  3, 1, 1, 1, 1 ]
+gap> SEMIGROUPS.WordToExtRepObj(w);
+[ 1, 100, 2, 50, 3, 1, 1, 4 ]
+
+# Test SEMIGROUPS.WordToString
+gap> w := [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+> 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+> 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 1,
+> 1, 1, 1, 1, 1, 1, 1];;
+gap> SEMIGROUPS.WordToString(w);
+"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcaaaa\
+aaaa"
+gap> SEMIGROUPS.WordToString([100]);
+Error, SEMIGROUPS.WordToString: the maximum value in the argument be at most 
+52,
+
+# Test SEMIGROUPS.ExtRepObjToString
+gap> SEMIGROUPS.ExtRepObjToString(SEMIGROUPS.WordToExtRepObj(w));
+"a ^ 100b ^ 50ca ^ 8"
+gap> SEMIGROUPS.ExtRepObjToString([100, 1]);
+Error, SEMIGROUPS.ExtRepObjToString: the maximum value in an odd position of t\
+he argument must be at most 52,
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);


### PR DESCRIPTION
The internal functions `SEMIGROUPS.WordToExtRepObj`,
`SEMIGROUPS.ExtRepObjToString`, and `SEMIGROUPS.WordToString` are introduced.