### PR TITLE
Fix MultiplicativeNeutralElement for ideals

### DIFF
--- a/gap/attributes/attract.gi
+++ b/gap/attributes/attract.gi
@@ -256,8 +256,9 @@ function(S)
 
   r := GreensRClassOfElementNC(S, rep);
 
-  if not NrIdempotents(r) = 1 then
-    Info(InfoSemigroups, 2, "the number of idempotents in the R-class of the",
+  if NrIdempotents(r) <> 1
+      or NrIdempotents(GreensDClassOfElementNC(S, rep)) <> 1 then
+    Info(InfoSemigroups, 2, "the number of idempotents in the D-class of the",
          " first maximum rank");
     Info(InfoSemigroups, 2, " generator is not 1");
     return fail;
@@ -265,11 +266,11 @@ function(S)
 
   e := Idempotents(r)[1];
 
-  if ForAll(gens, x -> x * e = x and e * x = x) then
+  if ForAll(GeneratorsOfSemigroup(S), x -> x * e = x and e * x = x) then
     return e;
   fi;
 
-  Info(InfoSemigroups, 2, "the unique idempotent in the R-class of the first",
+  Info(InfoSemigroups, 2, "the unique idempotent in the D-class of the first",
                           " maximum rank");
   Info(InfoSemigroups, 2, " generator is not the identity");
   return fail;

--- a/tst/standard/attract.tst
+++ b/tst/standard/attract.tst
@@ -240,6 +240,23 @@ gap> S := Semigroup(Transformation([1, 1, 3]), Transformation([2, 2, 3]));
 gap> MultiplicativeNeutralElement(S);
 fail
 
+#T# attract: MultiplicativeNeutralElement, 5
+gap> S := SingularFactorisableDualSymmetricInverseMonoid(3);
+<inverse bipartition semigroup ideal of degree 3 with 1 generator>
+gap> IsMonoidAsSemigroup(S);
+false
+
+#T# attract: MultiplicativeNeutralElement, 5
+gap> S := Semigroup([Transformation([3, 2, 3]),
+>                    Transformation([3, 4, 2, 5, 5])]);
+<transformation semigroup of degree 5 with 2 generators>
+gap> MultiplicativeNeutralElement(S);
+fail
+gap> S := SemigroupIdeal(S, S.1);
+<non-regular transformation semigroup ideal of degree 5 with 1 generator>
+gap> MultiplicativeNeutralElement(S);
+fail
+
 #T# attract: RepresentativeOfMinimalIdeal, 1/3
 gap> S := Semigroup(Transformation([1, 2, 1]), Transformation([2, 2, 3]));;
 gap> RepresentativeOfMinimalIdeal(S);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1650,6 +1650,12 @@ CompositionMapping( ((), GroupHomomorphismByImages( Group( [ () ] ), Group(
 <Rees matrix semigroup 1x1 over Group(())>, <Rees matrix semigroup 1x1 over 
   Group(())>, function( u ) ... end, function( v ) ... end ) )
 
+#T# Issue 363: MultiplicativeNeutralElement, for an ideal
+gap> S := SingularFactorisableDualSymmetricInverseMonoid(3);
+<inverse bipartition semigroup ideal of degree 3 with 1 generator>
+gap> IsMonoidAsSemigroup(S);
+false
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(D);


### PR DESCRIPTION
This PR resolves issue #363.

Suppose that we suspect that `e` is the multiplicative neutral element of `S`. The bug was caused by testing whether `e` acts as the identity for all `Generators(S)`. However this isn't sufficient when `S` is an ideal. We need to use `GeneratorsOfSemigroup(S)` instead. I also add a more thorough check before calling `GeneratorsOfSemigroup(S)`, so that we avoid doing it for ideals if we can.