### PR TITLE
semieunit: fix IsMcAlisterTripleSemigroupElementRep declaration

### DIFF
--- a/gap/semigroups/semieunit.gd
+++ b/gap/semigroups/semieunit.gd
@@ -14,18 +14,18 @@ DeclareCategory("IsMcAlisterTripleSemigroupElement",
 # This is a representation for McAlister triple semigroup elements, which are
 # created via the function McAlisterTripleSemigroupElement.
 #
-# The components are:
+# If x belongs to the representation IsMcAlisterTripleElementRep, then the
+# components are:
 #
-#   Parent:   A McAlister triple semigroup of which this is an element
+#   x![1]:   The McAlister triple semigroup which this element belongs to
 #
-#   Vertex:   A vertex of the McAlisterTripleSemigroupSemilattice of the Parent
+#   x![2]:   A vertex of the McAlisterTripleSemigroupSemilattice of x![1]
 #
-#   Group element:  An element of the McAlisterTripleSemigroupGroup of the
-#                   Parent
+#   x![3]:   An element of the McAlisterTripleSemigroupGroup of x![1]
 
 DeclareRepresentation("IsMcAlisterTripleSemigroupElementRep",
                       IsMcAlisterTripleSemigroupElement
-                      and IsPositionalObjectRep, 2);
+                      and IsPositionalObjectRep, 3);
 
 DeclareCategoryCollections("IsMcAlisterTripleSemigroupElement");
 DeclareSynonym("IsMTSE", IsMcAlisterTripleSemigroupElement);

--- a/gap/semigroups/semieunit.gi
+++ b/gap/semigroups/semieunit.gi
@@ -143,23 +143,6 @@ end);
 #############################################################################
 # Methods for McAlister triple semigroups
 #############################################################################
-# InstallMethod(\=, "for two McAlister triple semigroups",
-# IsIdenticalObj,
-# [IsMcAlisterTripleSemigroup, IsMcAlisterTripleSemigroup],
-# function(x, y)
-#   local G, X, Y;
-#   G := McAlisterTripleSemigroupGroup(x);
-#   X := McAlisterTripleSemigroupPartialOrder(x);
-#   Y := McAlisterTripleSemigroupSemilattice(x);
-#   if G = McAlisterTripleSemigroupGroup(y)
-#       and X = McAlisterTripleSemigroupPartialOrder(y)
-#       and Y = McAlisterTripleSemigroupSemilattice(y) then
-#     if IsIsomorphicSemigroup(x, y) then
-#       return true;
-#     fi;
-#   fi;
-#   return false;
-# end);
 
 InstallMethod(OneImmutable, "for a McAlister triple semigroup",
 [IsMcAlisterTripleSemigroup],


### PR DESCRIPTION
There is also a change to the comments describing this representation
and a commented out method has been removed in semieunit.gi