### PR TITLE
Add One to GeneratorsOfMagma if needed in MonoidByGenerators

### DIFF
--- a/gap/semigroups/semigrp.gi
+++ b/gap/semigroups/semigrp.gi
@@ -277,7 +277,7 @@ function(gens, opts)
 
   S := Objectify(NewType(FamilyObj(gens), filts), rec(opts := opts));
 
-  if CanEasilyCompareElements(gens) and not One(gens) in gens then
+  if not CanEasilyCompareElements(gens) or not One(gens) in gens then
     SetGeneratorsOfMagma(S, Concatenation([One(gens)], gens));
   else
     SetGeneratorsOfMagma(S, AsList(gens));

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1673,6 +1673,17 @@ gap> S := Semigroup([
 gap> IsInverseSemigroup(S);
 false
 
+#T# Issue 371: GeneratorsOfSemigroup for a monoid
+gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
+gap> S := MonoidByAdjoiningIdentity(R);
+<commutative monoid with 1 generator>
+gap> GeneratorsOfSemigroup(S);
+[ ONE, (1,(),1) ]
+gap> Size(S);
+2
+gap> Elements(S);
+[ ONE, (1,(),1) ]
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(D);


### PR DESCRIPTION
The `One` of a monoid needs to be in its `GeneratorsOfMagma`, since we don't know (without further work) whether the other elements generate (as a semigroup) the `One`.

Previously this was only done if the generators satisfy `CanEasilyCompareElements` and the `One` isn't already in there. If we can't easily compare elements, we still need to add the `One` if needed. Since it's too expensive to work out whether the `One` is already one of the generators, we should add the `One` regardless.

This resolves #371