### PR TITLE
Modify AutomorphismGroup for R(Z)MS to accommodate AutPGrp package

### DIFF
--- a/gap/attributes/isorms.gi
+++ b/gap/attributes/isorms.gi
@@ -333,10 +333,19 @@ function(R)
   # automorphism group of the group
   stab_aut_group := SEMIGROUPS.StabOfRMSEntries(aut_group, R);
 
+  # The following mathematically unnecessary separation of cases is needed to
+  # support the AutPGrp package, whose method for `AutomorphismGroup` for the
+  # trivial group does not set `InnerAutomorphismsAutomorphismGroup` at
+  # creation, and no method is installed to calculate it.
+
   # homomorphism from Aut(G) to a perm rep of Aut(G) / Inn(G)
-  hom := NaturalHomomorphismByNormalSubgroupNC(aut_group,
-           InnerAutomorphismsAutomorphismGroup(aut_group));
-  hom := CompositionMapping(IsomorphismPermGroup(ImagesSource(hom)), hom);
+  if IsTrivial(G) then
+    hom := IsomorphismPermGroup(aut_group);
+  else
+    hom := NaturalHomomorphismByNormalSubgroupNC(aut_group,
+             InnerAutomorphismsAutomorphismGroup(aut_group));
+    hom := CompositionMapping(IsomorphismPermGroup(ImagesSource(hom)), hom);
+  fi;
 
   # V is isomorphic to Aut(Gamma) x (Aut(G) / Inn(G))
   # U is a subgroup of V contained in the subgroup we are looking for.
@@ -518,10 +527,19 @@ function(R)
   # automorphism group of the group
   stab_aut_group := SEMIGROUPS.StabOfRMSEntries(aut_group, R);
 
+  # The following mathematically unnecessary separation of cases is needed to
+  # support the AutPGrp package, whose method for `AutomorphismGroup` for the
+  # trivial group does not set `InnerAutomorphismsAutomorphismGroup` at
+  # creation, and no method is installed to calculate it.
+
   # homomorphism from Aut(G) to a perm rep of Aut(G) / Inn(G)
-  hom := NaturalHomomorphismByNormalSubgroupNC(aut_group,
-           InnerAutomorphismsAutomorphismGroup(aut_group));
-  hom := CompositionMapping(IsomorphismPermGroup(ImagesSource(hom)), hom);
+  if IsTrivial(G) then
+    hom := IsomorphismPermGroup(aut_group);
+  else
+    hom := NaturalHomomorphismByNormalSubgroupNC(aut_group,
+             InnerAutomorphismsAutomorphismGroup(aut_group));
+    hom := CompositionMapping(IsomorphismPermGroup(ImagesSource(hom)), hom);
+  fi;
 
   # V is isomorphic to Aut(Gamma) x (Aut(G) / Inn(G))
   # U is a subgroup of V contained in the subgroup we are looking for.


### PR DESCRIPTION
When the package `AutPGrp` (which is used to calculate automorphisms of p-groups) is loaded, the Semigroups package tests fail. I will explain why in a minute. `AutPGrp` is required by `polycyclic`; it seems reasonable to have this package loaded as well as the Semigroups package, so I think we should do what we can to fix this problem.

In the code for `AutomorphismGroup` of a Rees (0-)matrix semigroup `R` in the Semigroups package, the following happens. The group `aut_group := AutomorphismGroup(G)` is created, where `G` is the underlying semigroup of `R`. Then:
```
hom := NaturalHomomorphismByNormalSubgroupNC(aut_group,
         InnerAutomorphismsAutomorphismGroup(aut_group));
```
Without `AutPGrp` loaded, this all works perfectly. However, when `AutPGrp` is loaded, the method for `AutomorphismGroup` for `G` may be different (i.e. when it is trivial or a p-group). In particular, when `G` is trivial,  this new method from `AutPGrp` has a special case. The returned `aut_group` is trivial, but does not have its attribute `InnerAutomorphismsAutomorphismGroup` set; moreover, there is no method installed to calculate this. Thus the following error happens:
```
gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);
gap> AutomorphismGroup(R);
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 2nd choice method found for `InnerAutomorphismsAutomorphismGroup' on 1 argu\
ments at /Users/Wilf/GAP/lib/methsel2.g:241 called from
InnerAutomorphismsAutomorphismGroup( aut_group
 ) at /Users/Wilf/GAP/pkg/semigroups/gap/attributes/isorms.gi:338 called from
<function "unknown">( <arguments> )
```
This is arguably a bug in `AutPGrp`, and should probably be reported to the package maintainers.

However, in the mean time, I think we should merge this PR. It's a simple workaround.