### PR TITLE
Update for libsemigroups 0.4.0

### DIFF
--- a/gap/main/fropin.gi
+++ b/gap/main/fropin.gi
@@ -459,7 +459,7 @@ function(S)
   if not IsFinite(S) then
     TryNextMethod();
   fi;
-  return EnumeratorCanonical(S){EN_SEMI_IDEMPOTENTS(S)};
+  return EN_SEMI_IDEMPOTENTS(S);
 end);
 
 InstallMethod(PositionCanonical,

--- a/src/bipart.cc
+++ b/src/bipart.cc
@@ -176,14 +176,14 @@ Obj BIPART_EXT_REP(Obj self, Obj x) {
 
   for (size_t i = 0; i < 2 * n; i++) {
     Obj entry = INTOBJ_INT((i < n ? i + 1 : -(i - n) - 1));
-    if (ELM_PLIST(ext_rep, xx->block(i) + 1) == 0) {
+    if (ELM_PLIST(ext_rep, xx->at(i) + 1) == 0) {
       Obj block = NEW_PLIST(T_PLIST_CYC, 1);
       SET_LEN_PLIST(block, 1);
       SET_ELM_PLIST(block, 1, entry);
-      SET_ELM_PLIST(ext_rep, xx->block(i) + 1, block);
+      SET_ELM_PLIST(ext_rep, xx->at(i) + 1, block);
       CHANGED_BAG(ext_rep);
     } else {
-      Obj block = ELM_PLIST(ext_rep, xx->block(i) + 1);
+      Obj block = ELM_PLIST(ext_rep, xx->at(i) + 1);
       AssPlist(block, LEN_PLIST(block) + 1, entry);
     }
   }
@@ -204,7 +204,7 @@ Obj BIPART_INT_REP(Obj self, Obj x) {
   SET_LEN_PLIST(int_rep, (Int) 2 * n);
 
   for (size_t i = 0; i < 2 * n; i++) {
-    SET_ELM_PLIST(int_rep, i + 1, INTOBJ_INT(xx->block(i) + 1));
+    SET_ELM_PLIST(int_rep, i + 1, INTOBJ_INT(xx->at(i) + 1));
   }
   return int_rep;
 }
@@ -316,16 +316,16 @@ Obj BIPART_PERM_LEFT_QUO(Obj self, Obj x, Obj y) {
   _BUFFER_size_t.resize(2 * deg, -1);
 
   for (size_t i = deg; i < 2 * deg; i++) {
-    if (_BUFFER_size_t[xx->block(i)] == (size_t) -1) {
-      _BUFFER_size_t[xx->block(i)] = index;
+    if (_BUFFER_size_t[xx->at(i)] == (size_t) -1) {
+      _BUFFER_size_t[xx->at(i)] = index;
       index++;
     }
     ptrp[i - deg] = i - deg;
   }
 
   for (size_t i = deg; i < 2 * deg; i++) {
-    if (yy->block(i) < xx->nr_left_blocks()) {
-      ptrp[_BUFFER_size_t[yy->block(i)]] = _BUFFER_size_t[xx->block(i)];
+    if (yy->at(i) < xx->nr_left_blocks()) {
+      ptrp[_BUFFER_size_t[yy->at(i)]] = _BUFFER_size_t[xx->at(i)];
     }
   }
   return p;
@@ -350,13 +350,13 @@ Obj BIPART_LEFT_PROJ(Obj self, Obj x) {
   blocks->resize(2 * deg, -1);
 
   for (size_t i = 0; i < deg; i++) {
-    (*blocks)[i] = xx->block(i);
-    if (xx->is_transverse_block(xx->block(i))) {
-      (*blocks)[i + deg] = xx->block(i);
-    } else if (_BUFFER_size_t[xx->block(i)] != (size_t) -1) {
-      (*blocks)[i + deg] = _BUFFER_size_t[xx->block(i)];
+    (*blocks)[i] = xx->at(i);
+    if (xx->is_transverse_block(xx->at(i))) {
+      (*blocks)[i + deg] = xx->at(i);
+    } else if (_BUFFER_size_t[xx->at(i)] != (size_t) -1) {
+      (*blocks)[i + deg] = _BUFFER_size_t[xx->at(i)];
     } else {
-      _BUFFER_size_t[xx->block(i)] = next;
+      _BUFFER_size_t[xx->at(i)] = next;
       (*blocks)[i + deg]           = next;
       next++;
     }
@@ -387,16 +387,16 @@ Obj BIPART_RIGHT_PROJ(Obj self, Obj x) {
   blocks->resize(2 * deg, -1);
 
   for (size_t i = deg; i < 2 * deg; i++) {
-    if (buf2[xx->block(i)] == (size_t) -1) {
-      if (xx->is_transverse_block(xx->block(i))) {
-        buf2[xx->block(i)] = buf1[xx->block(i)] = l_block++;
+    if (buf2[xx->at(i)] == (size_t) -1) {
+      if (xx->is_transverse_block(xx->at(i))) {
+        buf2[xx->at(i)] = buf1[xx->at(i)] = l_block++;
       } else {
-        buf2[xx->block(i)] = r_block++;
-        buf1[xx->block(i)] = l_block++;
+        buf2[xx->at(i)] = r_block++;
+        buf1[xx->at(i)] = l_block++;
       }
     }
-    (*blocks)[i - deg] = buf1[xx->block(i)];
-    (*blocks)[i]       = buf2[xx->block(i)];
+    (*blocks)[i - deg] = buf1[xx->at(i)];
+    (*blocks)[i]       = buf2[xx->at(i)];
   }
 
   Bipartition* out = new Bipartition(blocks);
@@ -423,10 +423,10 @@ Obj BIPART_STAR(Obj self, Obj x) {
   size_t next = 0;
 
   for (size_t i = 0; i < deg; i++) {
-    if (_BUFFER_size_t[xx->block(i + deg)] != (size_t) -1) {
-      (*blocks)[i] = _BUFFER_size_t[xx->block(i + deg)];
+    if (_BUFFER_size_t[xx->at(i + deg)] != (size_t) -1) {
+      (*blocks)[i] = _BUFFER_size_t[xx->at(i + deg)];
     } else {
-      _BUFFER_size_t[xx->block(i + deg)] = next;
+      _BUFFER_size_t[xx->at(i + deg)] = next;
       (*blocks)[i]                       = next;
       next++;
     }
@@ -435,10 +435,10 @@ Obj BIPART_STAR(Obj self, Obj x) {
   size_t nr_left = next;
 
   for (size_t i = 0; i < deg; i++) {
-    if (_BUFFER_size_t[xx->block(i)] != (size_t) -1) {
-      (*blocks)[i + deg] = _BUFFER_size_t[xx->block(i)];
+    if (_BUFFER_size_t[xx->at(i)] != (size_t) -1) {
+      (*blocks)[i + deg] = _BUFFER_size_t[xx->at(i)];
     } else {
-      _BUFFER_size_t[xx->block(i)] = next;
+      _BUFFER_size_t[xx->at(i)] = next;
       (*blocks)[i + deg]           = next;
       next++;
     }
@@ -486,10 +486,10 @@ Obj BIPART_LAMBDA_CONJ(Obj self, Obj x, Obj y) {
   size_t next   = 0;
 
   for (size_t i = deg; i < 2 * deg; i++) {
-    if (!seen[yy->block(i)]) {
-      seen[yy->block(i)] = true;
-      if (yy->block(i) < nr_left_blocks) {  // connected block
-        lookup[yy->block(i)] = next;
+    if (!seen[yy->at(i)]) {
+      seen[yy->at(i)] = true;
+      if (yy->at(i) < nr_left_blocks) {  // connected block
+        lookup[yy->at(i)] = next;
       }
       next++;
     }
@@ -502,12 +502,12 @@ Obj BIPART_LAMBDA_CONJ(Obj self, Obj x, Obj y) {
   next        = 0;
 
   for (size_t i = deg; i < 2 * deg; i++) {
-    if (!seen[xx->block(i)]) {
-      seen[xx->block(i)] = true;
-      if (xx->block(i) < nr_left_blocks) {  // connected block
-        ptrp[next]                = lookup[xx->block(i)];
+    if (!seen[xx->at(i)]) {
+      seen[xx->at(i)] = true;
+      if (xx->at(i) < nr_left_blocks) {  // connected block
+        ptrp[next]                = lookup[xx->at(i)];
         src[next]                 = true;
-        dst[lookup[xx->block(i)]] = true;
+        dst[lookup[xx->at(i)]] = true;
       }
       next++;
     }
@@ -595,16 +595,16 @@ Obj BIPART_STAB_ACTION(Obj self, Obj x, Obj p) {
   size_t next = 0;
 
   for (size_t i = deg; i < 2 * deg; i++) {
-    if (tab1[xx->block(i)] == (size_t) -1) {
-      tab1[xx->block(i)] = q[next];
-      tab2[next]         = xx->block(i);
+    if (tab1[xx->at(i)] == (size_t) -1) {
+      tab1[xx->at(i)] = q[next];
+      tab2[next]         = xx->at(i);
       next++;
     }
   }
 
   for (size_t i = 0; i < deg; i++) {
-    (*blocks)[i]       = xx->block(i);
-    (*blocks)[i + deg] = tab2[tab1[xx->block(i + deg)]];
+    (*blocks)[i]       = xx->at(i);
+    (*blocks)[i + deg] = tab2[tab1[xx->at(i + deg)]];
   }
 
   return bipart_new_obj(new Bipartition(blocks));
@@ -982,7 +982,7 @@ Obj BLOCKS_LEFT_ACT(Obj self, Obj blocks_gap, Obj x_gap) {
   u_int32_t next = 0;
 
   for (u_int32_t i = 0; i < x->degree(); i++) {
-    u_int32_t j = fuse_it(x->block(i));
+    u_int32_t j = fuse_it(x->at(i));
     if (tab[j] == (size_t) -1) {
       tab[j] = next;
       next++;
@@ -1035,7 +1035,7 @@ Obj BLOCKS_RIGHT_ACT(Obj self, Obj blocks_gap, Obj x_gap) {
   u_int32_t next = 0;
 
   for (u_int32_t i = x->degree(); i < 2 * x->degree(); i++) {
-    u_int32_t j = fuse_it(x->block(i) + blocks->nr_blocks());
+    u_int32_t j = fuse_it(x->at(i) + blocks->nr_blocks());
     if (tab[j] == (size_t) -1) {
       tab[j] = next;
       next++;
@@ -1080,7 +1080,7 @@ Obj BLOCKS_INV_LEFT(Obj self, Obj blocks_gap, Obj x_gap) {
   // find the left blocks of the output
   for (u_int32_t i = 0; i < blocks->degree(); i++) {
     (*out_blocks)[i] = blocks->block(i);
-    u_int32_t j      = fuse_it(x->block(i) + blocks->nr_blocks());
+    u_int32_t j      = fuse_it(x->at(i) + blocks->nr_blocks());
     if (j > blocks->nr_blocks() || tab[j] == (size_t) -1) {
       (*out_blocks)[i + x->degree()] = blocks->nr_blocks();  // junk
     } else {
@@ -1168,8 +1168,8 @@ Obj BLOCKS_INV_RIGHT(Obj self, Obj blocks_gap, Obj x_gap) {
 
   // find the left blocks of the output
   for (u_int32_t i = 0; i < blocks->degree(); i++) {
-    if (x->block(i + x->degree()) < x->nr_left_blocks()) {
-      u_int32_t j = fuse_it(x->block(i + x->degree()) + blocks->nr_blocks());
+    if (x->at(i + x->degree()) < x->nr_left_blocks()) {
+      u_int32_t j = fuse_it(x->at(i + x->degree()) + blocks->nr_blocks());
       if (_BUFFER_bool[j]) {
         if (tab1[j] == (size_t) -1) {
           tab1[j] = next;

--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -572,15 +572,15 @@ gap_list_t EN_SEMI_AS_SET(Obj self, gap_semigroup_t so) {
   if (en_semi_get_type(es) != UNKNOWN) {
     Semigroup* semi_cpp = en_semi_get_semi_cpp(es);
     semi_cpp->set_report(semi_obj_get_report(so));
-    // FIXME
-    auto       pairs     = semi_cpp->sorted_elements();
     Converter* converter = en_semi_get_converter(es);
     // The T_PLIST_HOM_SSORTED makes a huge difference to performance!!
-    gap_list_t out = NEW_PLIST(T_PLIST_HOM_SSORT + IMMUTABLE, pairs->size());
-    SET_LEN_PLIST(out, pairs->size());
+    gap_list_t out = NEW_PLIST(T_PLIST_HOM_SSORT + IMMUTABLE, semi_cpp->size());
+    SET_LEN_PLIST(out, semi_cpp->size());
     size_t i = 1;
-    for (auto const& x : *pairs) {
-      SET_ELM_PLIST(out, i++, converter->unconvert(x.first));
+    auto it = semi_cpp->cbegin_sorted();
+    for (auto it = semi_cpp->cbegin_sorted(); it < semi_cpp->cend_sorted();
+         ++it) {
+      SET_ELM_PLIST(out, i++, converter->unconvert(*it));
       CHANGED_BAG(out);
     }
     return out;

--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -90,7 +90,8 @@ plist_to_vec(Converter* converter, gap_list_t elements, size_t degree) {
 }
 
 template <typename T>
-static inline gap_list_t iterator_to_plist(Converter* converter, T first, T last) {
+static inline gap_list_t
+iterator_to_plist(Converter* converter, T first, T last) {
   gap_list_t out =
       NEW_PLIST((first == last ? T_PLIST_EMPTY : T_PLIST_HOM), last - first);
   SET_LEN_PLIST(out, last - first);
@@ -556,8 +557,8 @@ gap_list_t EN_SEMI_AS_SET(Obj self, gap_semigroup_t so) {
     // The T_PLIST_HOM_SSORTED makes a huge difference to performance!!
     gap_list_t out = NEW_PLIST(T_PLIST_HOM_SSORT + IMMUTABLE, semi_cpp->size());
     SET_LEN_PLIST(out, semi_cpp->size());
-    size_t i = 1;
-    auto it = semi_cpp->cbegin_sorted();
+    size_t i  = 1;
+    auto   it = semi_cpp->cbegin_sorted();
     for (auto it = semi_cpp->cbegin_sorted(); it < semi_cpp->cend_sorted();
          ++it) {
       SET_ELM_PLIST(out, i++, converter->unconvert(*it));
@@ -677,7 +678,7 @@ gap_semigroup_t EN_SEMI_CLOSURE(Obj             self,
   gap_list_t gens = NEW_PLIST(T_PLIST_HOM, new_semi_cpp->nrgens());
 
   for (size_t i = 0; i < new_semi_cpp->nrgens(); i++) {
-    AssPlist(gens, i + 1, converter->unconvert((*new_semi_cpp->gens())[i]));
+    AssPlist(gens, i + 1, converter->unconvert(new_semi_cpp->gens(i)));
   }
   AssPRec(new_so, RNam_GeneratorsOfMagma, gens);
   CHANGED_BAG(new_so);
@@ -721,7 +722,7 @@ EN_SEMI_CLOSURE_DEST(Obj self, gap_semigroup_t so, gap_list_t plist) {
   gap_list_t gens = ElmPRec(so, RNam_GeneratorsOfMagma);
 
   for (size_t i = 0; i < semi_cpp->nrgens(); i++) {
-    AssPlist(gens, i + 1, converter->unconvert((*semi_cpp->gens())[i]));
+    AssPlist(gens, i + 1, converter->unconvert(semi_cpp->gens(i)));
   }
   CHANGED_BAG(so);
 
@@ -1058,14 +1059,15 @@ gap_list_t EN_SEMI_IDEMPOTENTS(Obj self, gap_semigroup_t so) {
   CHECK_SEMI_OBJ(so);
   en_semi_obj_t es = semi_obj_get_en_semi(so);
   if (en_semi_get_type(es) != UNKNOWN) {
-    Semigroup* semi_cpp = en_semi_get_semi_cpp(es);
+    Semigroup* semi_cpp  = en_semi_get_semi_cpp(es);
     Converter* converter = en_semi_get_converter(es);
 
     semi_cpp->set_report(semi_obj_get_report(so));
     semi_cpp->set_max_threads(semi_obj_get_nr_threads(so));
 
-    return iterator_to_plist(
-        converter, semi_cpp->cbegin_idempotents(), semi_cpp->cend_idempotents());
+    return iterator_to_plist(converter,
+                             semi_cpp->cbegin_idempotents(),
+                             semi_cpp->cend_idempotents());
   } else {
     gap_rec_t  fp     = fropin(so, INTOBJ_INT(-1), 0, False);
     gap_list_t left   = ElmPRec(fp, RNamName("left"));
@@ -1073,9 +1075,9 @@ gap_list_t EN_SEMI_IDEMPOTENTS(Obj self, gap_semigroup_t so) {
     gap_list_t prefix = ElmPRec(fp, RNamName("prefix"));
     gap_list_t elts   = ElmPRec(fp, RNamName("elts"));
 
-    size_t     size   = LEN_PLIST(left);
-    size_t     nr     = 0;
-    gap_list_t out    = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, 0);
+    size_t     size = LEN_PLIST(left);
+    size_t     nr   = 0;
+    gap_list_t out  = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, 0);
     // IMMUTABLE since it should not be altered on the GAP level
     SET_LEN_PLIST(out, 0);
     for (size_t pos = 1; pos <= size; pos++) {

--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -582,7 +582,7 @@ gap_list_t EN_SEMI_AS_SET(Obj self, gap_semigroup_t so) {
     Semigroup* semi_cpp = en_semi_get_semi_cpp(es);
     semi_cpp->set_report(semi_obj_get_report(so));
 
-    std::vector<std::pair<Element*, size_t>>* pairs =
+    std::vector<std::pair<Element*, Semigroup::element_index_t>>* pairs =
         semi_cpp->sorted_elements();
     Converter* converter = en_semi_get_converter(es);
     // The T_PLIST_HOM_SSORTED makes a huge difference to performance!!
@@ -1077,11 +1077,9 @@ gap_list_t EN_SEMI_IDEMPOTENTS(Obj self, gap_semigroup_t so) {
     Semigroup* semi_cpp = en_semi_get_semi_cpp(es);
     semi_cpp->set_report(semi_obj_get_report(so));
     semi_cpp->set_max_threads(semi_obj_get_nr_threads(so));
-    typename std::vector<size_t>::const_iterator cbegin =
-        semi_cpp->idempotents_cbegin();
-    typename std::vector<size_t>::const_iterator cend =
-        semi_cpp->idempotents_cend();
-    size_t nr = semi_cpp->nridempotents();
+    auto   cbegin = semi_cpp->idempotents_cbegin();
+    auto   cend   = semi_cpp->idempotents_cend();
+    size_t nr     = semi_cpp->nridempotents();
     assert(nr != 0);
 
     gap_list_t out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, nr);

--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -115,28 +115,6 @@ gap_list_t word_t_to_plist(word_t const& word) {
   return out;
 }
 
-gap_list_t cayley_graph_t_to_plist(cayley_graph_t* graph) {
-  assert(graph->nr_rows() != 0);
-  gap_list_t out = NEW_PLIST(T_PLIST_TAB_RECT, graph->nr_rows());
-  // this is intentionally not IMMUTABLE
-  SET_LEN_PLIST(out, graph->nr_rows());
-
-  for (size_t i = 0; i < graph->nr_rows(); i++) {
-    gap_list_t next = NEW_PLIST(T_PLIST_CYC, graph->nr_cols());
-    // this is intentionally not IMMUTABLE
-    SET_LEN_PLIST(next, graph->nr_cols());
-    assert(graph->nr_cols() != 0);
-    auto   end = graph->cend_row(i);
-    size_t j   = 1;
-    for (auto it = graph->cbegin_row(i); it != end; ++it) {
-      SET_ELM_PLIST(next, j++, INTOBJ_INT(*it + 1));
-    }
-    SET_ELM_PLIST(out, i + 1, next);
-    CHANGED_BAG(out);
-  }
-  return out;
-}
-
 // Semigroups
 
 gap_list_t semi_obj_get_gens(gap_semigroup_t so) {
@@ -1043,7 +1021,21 @@ gap_list_t EN_SEMI_LEFT_CAYLEY_GRAPH(Obj self, gap_semigroup_t so) {
   if (en_semi_get_type(es) != UNKNOWN) {
     Semigroup* semi_cpp = en_semi_get_semi_cpp(es);
     semi_cpp->set_report(semi_obj_get_report(so));
-    return cayley_graph_t_to_plist(semi_cpp->left_cayley_graph());
+    gap_list_t out = NEW_PLIST(T_PLIST_TAB_RECT, semi_cpp->size());
+    // this is intentionally not IMMUTABLE
+    SET_LEN_PLIST(out, semi_cpp->size());
+
+    for (size_t i = 0; i < semi_cpp->size(); ++i) {
+      gap_list_t next = NEW_PLIST(T_PLIST_CYC, semi_cpp->nrgens());
+      // this is intentionally not IMMUTABLE
+      SET_LEN_PLIST(next, semi_cpp->nrgens());
+      for (size_t j = 0; j < semi_cpp->nrgens(); ++j) {
+        SET_ELM_PLIST(next, j + 1, INTOBJ_INT(semi_cpp->left(i, j) + 1));
+      }
+      SET_ELM_PLIST(out, i + 1, next);
+      CHANGED_BAG(out);
+    }
+    return out;
   } else {
     return ElmPRec(fropin(so, INTOBJ_INT(-1), 0, False), RNam_left);
   }
@@ -1361,7 +1353,22 @@ gap_list_t EN_SEMI_RIGHT_CAYLEY_GRAPH(Obj self, gap_semigroup_t so) {
   if (en_semi_get_type(es) != UNKNOWN) {
     Semigroup* semi_cpp = en_semi_get_semi_cpp(es);
     semi_cpp->set_report(semi_obj_get_report(so));
-    return cayley_graph_t_to_plist(semi_cpp->right_cayley_graph());
+
+    gap_list_t out = NEW_PLIST(T_PLIST_TAB_RECT, semi_cpp->size());
+    // this is intentionally not IMMUTABLE
+    SET_LEN_PLIST(out, semi_cpp->size());
+
+    for (size_t i = 0; i < semi_cpp->size(); ++i) {
+      gap_list_t next = NEW_PLIST(T_PLIST_CYC, semi_cpp->nrgens());
+      // this is intentionally not IMMUTABLE
+      SET_LEN_PLIST(next, semi_cpp->nrgens());
+      for (size_t j = 0; j < semi_cpp->nrgens(); ++j) {
+        SET_ELM_PLIST(next, j + 1, INTOBJ_INT(semi_cpp->right(i, j) + 1));
+      }
+      SET_ELM_PLIST(out, i + 1, next);
+      CHANGED_BAG(out);
+    }
+    return out;
   } else {
     return ElmPRec(fropin(so, INTOBJ_INT(-1), 0, False), RNam_right);
   }
@@ -1375,7 +1382,7 @@ gap_int_t EN_SEMI_SIZE(Obj self, gap_semigroup_t so) {
   if (en_semi_get_type(es) != UNKNOWN) {
     Semigroup* semi_cpp = en_semi_get_semi_cpp(es);
     semi_cpp->set_report(semi_obj_get_report(so));
-    return INTOBJ_INT(en_semi_get_semi_cpp(es)->size());
+    return INTOBJ_INT(semi_cpp->size());
   } else {
     gap_rec_t fp = fropin(so, INTOBJ_INT(-1), 0, False);
     return INTOBJ_INT(LEN_PLIST(ElmPRec(fp, RNam_elts)));

--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -125,9 +125,9 @@ gap_list_t cayley_graph_t_to_plist(cayley_graph_t* graph) {
     // this is intentionally not IMMUTABLE
     SET_LEN_PLIST(next, graph->nr_cols());
     assert(graph->nr_cols() != 0);
-    typename std::vector<size_t>::const_iterator end = graph->row_cend(i);
-    size_t                                       j   = 1;
-    for (auto it = graph->row_cbegin(i); it != end; ++it) {
+    auto   end = graph->cend_row(i);
+    size_t j   = 1;
+    for (auto it = graph->cbegin_row(i); it != end; ++it) {
       SET_ELM_PLIST(next, j++, INTOBJ_INT(*it + 1));
     }
     SET_ELM_PLIST(out, i + 1, next);

--- a/tst/standard/fropin.tst
+++ b/tst/standard/fropin.tst
@@ -21,11 +21,11 @@ gap> S := FullTransformationSemigroup(6);
 gap> T := Semigroup(S.1, rec(acting := false));
 <commutative transformation semigroup of degree 6 with 1 generator>
 gap> EN_SEMI_IDEMPOTENTS(T);
-[ 6 ]
+[ IdentityTransformation ]
 gap> T := SEMIGROUPS.ClosureSemigroupDestructive(T, [S.2], T!.opts);
 <transformation semigroup of degree 6 with 2 generators>
 gap> EN_SEMI_IDEMPOTENTS(T);
-[ 6 ]
+[ IdentityTransformation ]
 gap> T := SEMIGROUPS.ClosureSemigroupDestructive(T, [S.3], T!.opts);
 <transformation semigroup of degree 6 with 3 generators>
 gap> EN_SEMI_IDEMPOTENTS(T);;


### PR DESCRIPTION
This PR updates Semigroups for the release of libsemigroups 0.4.0. The changes are internal only and in the kernel module, and are related to changes in the `Semigroup` object in libsemigroups. I am in the process of releasing libsemigroups 0.4.0 and this PR will probably fail (to compile) until libsemigroups 0.4.0 is actually released. 

The commits in this PR should be squashed when the time comes. 