### PR TITLE
Make congruence poset object into a digraph

### DIFF
--- a/gap/congruences/conglatt.gd
+++ b/gap/congruences/conglatt.gd
@@ -16,7 +16,7 @@
 ## this file.
 ##
 
-DeclareCategory("IsCongruencePoset", IsList and IsAttributeStoringRep);
+DeclareCategory("IsCongruencePoset", IsDigraph);
 
 DeclareAttribute("CongruencesOfPoset", IsCongruencePoset);
 DeclareAttribute("UnderlyingSemigroupOfCongruencePoset", IsCongruencePoset);
@@ -45,5 +45,10 @@ DeclareOperation("PosetOfCongruences", [IsListOrCollection]);
 
 DeclareOperation("JoinSemilatticeOfCongruences",
                  [IsListOrCollection, IsFunction]);
+DeclareOperation("JoinSemilatticeOfCongruences",
+                 [IsCongruencePoset, IsFunction]);
 
 DeclareAttribute("MinimalCongruences", IsListOrCollection);
+DeclareAttribute("MinimalCongruences", IsCongruencePoset);
+
+DeclareAttribute("Size", IsCongruencePoset);

--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -22,40 +22,30 @@
 ## user as the list of out-neighbours of that digraph.
 ##
 
-InstallMethod(\[\],
-"for a congruence poset and a positive integer",
-[IsCongruencePoset, IsPosInt],
-function(poset, x)
-  return OutNeighboursOfVertex(poset!.po, x);
-end);
-
 InstallMethod(ViewObj,
 "for a congruence poset",
 [IsCongruencePoset],
 function(poset)
-  ViewObj(OutNeighbours(poset!.po));
+  if DigraphNrVertices(poset) = 0 then
+    Print("<empty congruence poset>");
+  else
+    Print("<poset of ", DigraphNrVertices(poset), " congruences over ");
+    ViewObj(UnderlyingSemigroupOfCongruencePoset(poset));
+    Print(">");
+  fi;
 end);
 
 InstallMethod(PrintObj,
 "for a congruence poset",
 [IsCongruencePoset],
 function(poset)
-  PrintObj(OutNeighbours(poset!.po));
+  Print("PosetOfCongruences( ", CongruencesOfPoset(poset), " )");
 end);
 
-InstallMethod(Length,
+InstallMethod(Size,
 "for a congruence poset",
 [IsCongruencePoset],
-function(poset)
-  return DigraphNrVertices(poset!.po);
-end);
-
-InstallMethod(IsBound\[\],
-"for a congruence poset and a positive integer",
-[IsCongruencePoset, IsPosInt],
-function(poset, x)
-  return x >= 1 and x <= Length(poset);
-end);
+DigraphNrVertices);
 
 SEMIGROUPS.PrincipalXCongruencePosetNC :=
   function(S,
@@ -63,7 +53,7 @@ SEMIGROUPS.PrincipalXCongruencePosetNC :=
            SemigroupXCongruence,
            GeneratingPairsOfXSemigroupCongruence)
   local report, pairs, total, congs, nrcongs, children, parents, last_collected,
-        nr, pair, badcong, newchildren, newparents, newcong, i, pair1, c, p, po,
+        nr, pair, badcong, newchildren, newparents, newcong, i, pair1, c, p,
         poset;
 
   # Suppress reporting
@@ -125,19 +115,19 @@ SEMIGROUPS.PrincipalXCongruencePosetNC :=
   SEMIGROUPS.OptionsRec(S).report := report;
 
   # We are done: make the object and return
-  po := Digraph(children);
-  SetInNeighbours(po, parents);
-  poset := Objectify(NewType(FamilyObj(children), IsCongruencePoset),
-                     rec(po := po));
+  poset := Digraph(children);
+  SetInNeighbours(poset, parents);
   SetCongruencesOfPoset(poset, congs);
+  SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
+  SetFilterObj(poset, IsCongruencePoset);
   return poset;
 end;
 
 InstallMethod(MinimalCongruences,
 "for a congruence poset",
 [IsCongruencePoset],
-poset -> CongruencesOfPoset(poset){DigraphSinks(poset!.po)});
+poset -> CongruencesOfPoset(poset){DigraphSinks(poset)});
 
 InstallMethod(MinimalCongruences,
 "for a list or collection",
@@ -150,7 +140,7 @@ InstallMethod(JoinSemilatticeOfCongruences,
 function(poset, join_func)
   local children, parents, congs, princ_congs, nrcongs, S, report, length,
         found, ignore, start, i, j, newcong, badcong, newchildren, newparents,
-        k, c, p, po;
+        k, c, p;
 
   # Trivial case
   if Size(poset) = 0 then
@@ -158,8 +148,8 @@ function(poset, join_func)
   fi;
 
   # Extract the info
-  children := OutNeighboursMutableCopy(poset!.po);
-  parents := InNeighboursMutableCopy(poset!.po);
+  children := OutNeighboursMutableCopy(poset);
+  parents := InNeighboursMutableCopy(poset);
   congs := ShallowCopy(CongruencesOfPoset(poset));
   princ_congs := ShallowCopy(congs);
   nrcongs := Length(congs);
@@ -220,12 +210,12 @@ function(poset, join_func)
   SEMIGROUPS.OptionsRec(S).report := report;
 
   # We are done: make the object and return
-  po := Digraph(children);
-  SetInNeighbours(po, parents);
-  poset := Objectify(NewType(FamilyObj(children), IsCongruencePoset),
-                     rec(po := po));
+  poset := Digraph(children);
+  SetInNeighbours(poset, parents);
   SetCongruencesOfPoset(poset, congs);
+  SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
+  SetFilterObj(poset, IsCongruencePoset);
   return poset;
 end);
 
@@ -239,11 +229,11 @@ function(coll, join_func)
 end);
 
 SEMIGROUPS.AddTrivialCongruence := function(poset, cong_func)
-  local S, children, parents, congs, nrcongs, i, po;
+  local S, children, parents, congs, nrcongs, i;
   # Extract the info
   S := UnderlyingSemigroupOfCongruencePoset(poset);
-  children := OutNeighboursMutableCopy(poset!.po);
-  parents := InNeighboursMutableCopy(poset!.po);
+  children := OutNeighboursMutableCopy(poset);
+  parents := InNeighboursMutableCopy(poset);
   congs := ShallowCopy(CongruencesOfPoset(poset));
 
   # Add the trivial congruence
@@ -256,12 +246,12 @@ SEMIGROUPS.AddTrivialCongruence := function(poset, cong_func)
   od;
 
   # Make the object and return
-  po := Digraph(children);
-  SetInNeighbours(po, parents);
-  poset := Objectify(NewType(FamilyObj(children), IsCongruencePoset),
-                     rec(po := po));
+  poset := Digraph(children);
+  SetInNeighbours(poset, parents);
   SetCongruencesOfPoset(poset, congs);
+  SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
+  SetFilterObj(poset, IsCongruencePoset);
   return poset;
 end;
 
@@ -269,7 +259,7 @@ InstallMethod(PosetOfCongruences,
 "for a list or collection",
 [IsListOrCollection],
 function(coll)
-  local congs, nrcongs, children, parents, i, ignore, j, po, poset;
+  local congs, nrcongs, children, parents, i, ignore, j, poset;
   congs := AsList(coll);
   nrcongs := Length(congs);
 
@@ -295,14 +285,14 @@ function(coll)
   od;
 
   # We are done: make the object and return
-  po := Digraph(children);
-  SetInNeighbours(po, parents);
-  poset := Objectify(NewType(FamilyObj(children), IsCongruencePoset),
-                     rec(po := po));
+  poset := Digraph(children);
+  SetInNeighbours(poset, parents);
   SetCongruencesOfPoset(poset, congs);
+  SetDigraphVertexLabels(poset, congs);
   if nrcongs > 0 then
     SetUnderlyingSemigroupOfCongruencePoset(poset, Range(congs[1]));
   fi;
+  SetFilterObj(poset, IsCongruencePoset);
   return poset;
 end);
 
@@ -510,14 +500,15 @@ InstallMethod(DotString,
 "for a congruence poset and a record",
 [IsCongruencePoset, IsRecord],
 function(poset, opts)
-  local congs, S, symbols, i, nr, rel, str, j, k;
+  local out_nbs, congs, S, symbols, i, nr, rel, str, j, k;
+  out_nbs := OutNeighbours(poset);
   # If the user wants info, then change the node labels
   if opts.info = true then
     # The congruences are stored inside the poset object
     congs := CongruencesOfPoset(poset);
     S := Range(congs[1]);
-    symbols := EmptyPlist(Length(poset));
-    for i in [1 .. Length(poset)] do
+    symbols := EmptyPlist(Length(out_nbs));
+    for i in [1 .. Length(out_nbs)] do
       nr := NrEquivalenceClasses(congs[i]);
       if nr = 1 then
         symbols[i] := "U";
@@ -530,10 +521,10 @@ function(poset, opts)
       fi;
     od;
   else
-    symbols := List([1 .. Length(poset)], String);
+    symbols := List([1 .. Length(out_nbs)], String);
   fi;
 
-  rel := List([1 .. Length(poset)], x -> Filtered(poset[x], y -> x <> y));
+  rel := List([1 .. Length(out_nbs)], x -> Filtered(out_nbs[x], y -> x <> y));
   str := "";
 
   if Length(rel) < 40 then

--- a/tst/standard/conglatt.tst
+++ b/tst/standard/conglatt.tst
@@ -29,19 +29,13 @@ first argument <S> must be an enumerable finite semigroup,
 #T# LatticeOfCongruences
 gap> S := PartitionMonoid(2);;
 gap> l := LatticeOfCongruences(S);
+<poset of 13 congruences over <regular bipartition *-monoid of size 15, 
+ degree 2 with 3 generators>>
+gap> OutNeighbours(l);
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ], [ 1, 3, 9 ], [ 1, 2, 3, 4, 5, 9, 10 ], 
   [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 ], [ 1, 3 ], [ 1 ], [ 1, 4, 9 ], 
   [ 1, 2, 3, 4, 8 ], [ 1, 3, 5, 8, 9 ], 
   [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12 ] ]
-gap> Print(l, "\n");
-[ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ], [ 1, 3, 9 ], [ 1, 2, 3, 4, 5, 9, 10 ], 
-  [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 ], [ 1, 3 ], [ 1 ], [ 1, 4, 9 ], 
-  [ 1, 2, 3, 4, 8 ], [ 1, 3, 5, 8, 9 ], 
-  [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12 ] ]
-gap> IsBound(l[4]);
-true
-gap> l[4];
-[ 1 ]
 gap> S := OrderEndomorphisms(2);;
 gap> CongruencesOfSemigroup(S);
 [ <semigroup congruence over <regular transformation monoid of size 3, 
@@ -51,7 +45,21 @@ gap> CongruencesOfSemigroup(S);
   <semigroup congruence over <regular transformation monoid of size 3, 
      degree 2 with 2 generators> with 1 generating pairs> ]
 gap> l := LatticeOfCongruences(S);
+<poset of 3 congruences over <regular transformation monoid of size 3, 
+ degree 2 with 2 generators>>
+gap> OutNeighbours(l);
 [ [  ], [ 1, 3 ], [ 1 ] ]
+gap> Print(l, "\n");
+PosetOfCongruences( 
+[ 
+  SemigroupCongruence( Monoid( 
+    [ Transformation( [ 1, 1 ] ), Transformation( [ 2, 2 ] ) ] ), [  ] ), 
+  SemigroupCongruence( Monoid( 
+    [ Transformation( [ 1, 1 ] ), Transformation( [ 2, 2 ] ) ] ), 
+    [ [ Transformation( [ 1, 1 ] ), IdentityTransformation ] ] ), 
+  SemigroupCongruence( Monoid( 
+    [ Transformation( [ 1, 1 ] ), Transformation( [ 2, 2 ] ) ] ), 
+    [ [ Transformation( [ 1, 1 ] ), Transformation( [ 2, 2 ] ) ] ] ) ] )
 gap> CongruencesOfPoset(l) = CongruencesOfSemigroup(S);
 true
 gap> DotString(l);
@@ -59,6 +67,9 @@ gap> DotString(l);
 gap> S := Semigroup([Transformation([1, 4, 3, 1, 4, 2]),
 >                    Transformation([1, 6, 6, 3, 6, 6])]);;
 gap> l := LatticeOfCongruences(S);
+<poset of 5 congruences over <transformation semigroup of size 48, degree 6 
+ with 2 generators>>
+gap> OutNeighbours(l);
 [ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ], [ 1, 2, 3, 4 ] ]
 gap> DotString(l, rec(info := true)) = Concatenation("//dot\ngraph graphname",
 > " {\n     node [shape=circle]\nR2 -- T\nR3 -- 4\n4 -- R2\nU -- R3\n }");
@@ -90,29 +101,37 @@ gap> Size(RightCongruencesOfSemigroup(S));
 
 #T# LatticeOfLeft/RightCongruences
 gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
-gap> LatticeOfLeftCongruences(S);
-[ [  ], [ 1, 9, 12 ], [ 1 ], [ 1, 2, 3, 9, 12, 13, 15, 17 ], 
-  [ 1, 3, 8, 11, 12, 13, 16, 17 ], [ 1, 3 ], 
-  [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 ], 
-  [ 1, 11, 13 ], [ 1, 12 ], [ 1, 3, 12, 13, 17 ], [ 1, 13 ], [ 1 ], [ 1 ], 
-  [ 1, 2, 3, 4, 9, 11, 12, 13, 15, 16, 17, 21 ], [ 1, 3, 9, 12, 13, 17 ], 
-  [ 1, 3, 11, 12, 13, 17 ], [ 1, 3, 12, 13 ], 
-  [ 1, 3, 5, 8, 9, 11, 12, 13, 15, 16, 17, 21 ], 
-  [ 1, 3, 6, 9, 10, 11, 12, 13, 15, 16, 17, 20, 21 ], [ 1, 3, 6, 12, 13, 17 ],
-  [ 1, 3, 9, 11, 12, 13, 15, 16, 17 ] ]
-gap> LatticeOfRightCongruences(S);
-[ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 5, 8, 14, 24 ], 
-  [ 1, 3, 5, 10, 12, 23 ], [ 1 ], [ 1, 4, 8, 10 ], [ 1 ], [ 1 ], [ 1 ], 
-  [ 1, 3, 8, 11 ], [ 1 ], [ 1, 2, 10, 11 ], [ 1, 2, 3, 4 ], 
-  [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 
-      22, 23, 24, 25, 26, 27, 28, 29, 30, 31 ], [ 1, 2, 12 ], [ 1, 3, 14 ], 
-  [ 1, 4, 5 ], [ 1, 4, 11, 12, 14, 29 ], [ 1, 5, 11 ], [ 1, 5, 12 ], 
-  [ 1, 5, 14 ], [ 1, 2, 5, 6, 8, 12, 14, 18, 23, 24, 27, 29, 31 ], 
-  [ 1, 3, 5, 7, 10, 12, 14, 19, 23, 24, 28, 29, 31 ], [ 1, 8, 12 ], 
-  [ 1, 10, 14 ], [ 1, 12, 14 ], 
-  [ 1, 4, 5, 11, 12, 14, 20, 21, 22, 23, 24, 29, 31 ], 
-  [ 1, 5, 12, 14, 23, 24, 29 ] ]
-gap> LatticeOfCongruences(S);
+gap> l := LatticeOfLeftCongruences(S);
+<poset of 21 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(l) =
+> [[], [1, 9, 12], [1], [1, 2, 3, 9, 12, 13, 15, 17],
+>   [1, 3, 8, 11, 12, 13, 16, 17], [1, 3],
+>   [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+>   [1, 11, 13], [1, 12], [1, 3, 12, 13, 17], [1, 13], [1], [1],
+>   [1, 2, 3, 4, 9, 11, 12, 13, 15, 16, 17, 21], [1, 3, 9, 12, 13, 17],
+>   [1, 3, 11, 12, 13, 17], [1, 3, 12, 13],
+>   [1, 3, 5, 8, 9, 11, 12, 13, 15, 16, 17, 21],
+>   [1, 3, 6, 9, 10, 11, 12, 13, 15, 16, 17, 20, 21], [1, 3, 6, 12, 13, 17],
+>   [1, 3, 9, 11, 12, 13, 15, 16, 17]];
+true
+gap> l := LatticeOfRightCongruences(S);
+<poset of 31 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(l) =
+> [[], [1], [1], [1], [1], [1, 2, 5, 8, 14, 24],
+>   [1, 3, 5, 10, 12, 23], [1], [1, 4, 8, 10], [1], [1], [1],
+>   [1, 3, 8, 11], [1], [1, 2, 10, 11], [1, 2, 3, 4],
+>   [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21,
+>       22, 23, 24, 25, 26, 27, 28, 29, 30, 31], [1, 2, 12], [1, 3, 14],
+>   [1, 4, 5], [1, 4, 11, 12, 14, 29], [1, 5, 11], [1, 5, 12],
+>   [1, 5, 14], [1, 2, 5, 6, 8, 12, 14, 18, 23, 24, 27, 29, 31],
+>   [1, 3, 5, 7, 10, 12, 14, 19, 23, 24, 28, 29, 31], [1, 8, 12],
+>   [1, 10, 14], [1, 12, 14],
+>   [1, 4, 5, 11, 12, 14, 20, 21, 22, 23, 24, 29, 31],
+>   [1, 5, 12, 14, 23, 24, 29]];
+true
+gap> OutNeighbours(LatticeOfCongruences(S));
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1, 3 ] ]
 gap> Size(CongruencesOfSemigroup(S));
 4
@@ -123,11 +142,17 @@ gap> restriction := Subsemigroup(S, [Transformation([1, 1, 1]),
 >                                    Transformation([2, 2, 2]),
 >                                    Transformation([3, 3, 3])]);;
 gap> latt := LatticeOfLeftCongruences(S, restriction);
+<poset of 5 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4 ] ]
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
 >                    Transformation([2, 2, 2])];;
 gap> latt := LatticeOfRightCongruences(S, restriction);
+<poset of 4 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ] ]
 gap> congs := CongruencesOfPoset(latt);;
 gap> Length(congs);
@@ -136,9 +161,15 @@ gap> IsDuplicateFreeList(congs);
 true
 gap> restriction := [Transformation([3, 1, 3]), Transformation([3, 2, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
+<poset of 2 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ], [ 1 ] ]
 gap> restriction := [Transformation([3, 3, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
+<poset of 1 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ] ]
 
 #T# LatticeOf(Left/Right)Congruences with invalid restriction
@@ -163,16 +194,38 @@ gap> Size(RightCongruencesOfSemigroup(S));
 
 #T# PosetOfPrincipalLeft/RightCongruences
 gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
-gap> PosetOfPrincipalLeftCongruences(S);
-[ [ 8, 11 ], [  ], [ 1, 2, 8, 11, 12 ], [ 2, 7, 10, 11, 12 ], [ 2 ], 
-  [ 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12 ], [ 10, 12 ], [ 11 ], [ 2, 11, 12 ], 
-  [ 12 ], [  ], [  ] ]
-gap> PosetOfPrincipalRightCongruences(S);
-[ [  ], [  ], [  ], [  ], [ 1, 4, 7, 13 ], [ 2, 4, 9, 11 ], [  ], 
-  [ 3, 7, 9 ], [  ], [  ], [  ], [ 2, 7, 10 ], [  ], [ 1, 9, 10 ], 
-  [ 1, 2, 3 ] ]
-gap> PosetOfPrincipalCongruences(S);
+gap> poset := PosetOfPrincipalLeftCongruences(S);
+<poset of 12 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(poset) =
+> [[8, 11], [], [1, 2, 8, 11, 12], [2, 7, 10, 11, 12], [2],
+>   [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12], [10, 12], [11], [2, 11, 12],
+>   [12], [], []];
+true
+gap> poset := PosetOfPrincipalRightCongruences(S);
+<poset of 15 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(poset) =
+> [[], [], [], [], [1, 4, 7, 13], [2, 4, 9, 11], [],
+>   [3, 7, 9], [], [], [], [2, 7, 10], [], [1, 9, 10],
+>   [1, 2, 3]];
+true
+gap> poset := PosetOfPrincipalCongruences(S);
+<poset of 3 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(poset);
 [ [ 2, 3 ], [  ], [ 2 ] ]
+gap> Print(poset, "\n");
+PosetOfCongruences( 
+[ SemigroupCongruence( Semigroup( [ Transformation( [ 1, 3, 1 ] ), 
+      Transformation( [ 2, 3, 3 ] ) ] ), 
+    [ [ Transformation( [ 1, 1, 1 ] ), Transformation( [ 1, 3, 1 ] ) ] ] ), 
+  SemigroupCongruence( Semigroup( [ Transformation( [ 1, 3, 1 ] ), 
+      Transformation( [ 2, 3, 3 ] ) ] ), 
+    [ [ Transformation( [ 1, 1, 1 ] ), Transformation( [ 2, 2, 2 ] ) ] ] ), 
+  SemigroupCongruence( Semigroup( [ Transformation( [ 1, 3, 1 ] ), 
+      Transformation( [ 2, 3, 3 ] ) ] ), 
+    [ [ Transformation( [ 1, 3, 3 ] ), Transformation( [ 3, 1, 1 ] ) ] ] ) ] )
 gap> Size(PrincipalCongruencesOfSemigroup(S));
 3
 
@@ -182,11 +235,17 @@ gap> restriction := Subsemigroup(S, [Transformation([1, 1, 1]),
 >                                    Transformation([2, 2, 2]),
 >                                    Transformation([3, 3, 3])]);;
 gap> latt := PosetOfPrincipalLeftCongruences(S, restriction);
+<poset of 3 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ], [  ], [  ] ]
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
 >                    Transformation([2, 2, 2])];;
 gap> latt := PosetOfPrincipalRightCongruences(S, restriction);
+<poset of 3 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [ 2, 3 ], [  ], [  ] ]
 gap> CongruencesOfPoset(latt);
 [ <right semigroup congruence over <transformation semigroup of degree 3 with 
@@ -196,9 +255,14 @@ gap> CongruencesOfPoset(latt);
      semigroup of degree 3 with 2 generators> with 1 generating pairs> ]
 gap> restriction := [Transformation([3, 1, 3]), Transformation([3, 2, 3])];;
 gap> latt := PosetOfPrincipalCongruences(S, restriction);
+<poset of 1 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ] ]
 gap> restriction := [Transformation([3, 3, 3])];;
 gap> latt := PosetOfPrincipalCongruences(S, restriction);
+<empty congruence poset>
+gap> OutNeighbours(latt);
 [  ]
 
 #T# PosetOfPrincipal(Left/Right)Congruences with invalid restriction
@@ -261,9 +325,10 @@ gap> congs := CongruencesOfSemigroup(S);
   <semigroup congruence over <transformation semigroup of size 13, degree 3 
      with 2 generators> with 1 generating pairs> ]
 gap> l := LatticeOfCongruences(S);
+<poset of 6 congruences over <transformation semigroup of size 13, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(l);
 [ [  ], [ 1, 5, 6 ], [ 1, 2, 4, 5, 6 ], [ 1, 2, 5, 6 ], [ 1, 6 ], [ 1 ] ]
-gap> Position(congs, min[1]) = Position(l, [1]);
-true
 gap> minl := MinimalLeftCongruencesOfSemigroup(S);;
 gap> Size(minl);
 3
@@ -295,7 +360,9 @@ gap> pair3 := [PartialPerm([1, 2], [1, 2]), PartialPerm([1, 2], [2, 1])];;
 gap> coll := [RightSemigroupCongruence(S, pair1),
 >             RightSemigroupCongruence(S, pair2),
 >             RightSemigroupCongruence(S, pair3)];;
-gap> JoinSemilatticeOfCongruences(coll, JoinRightSemigroupCongruences);
+gap> l := JoinSemilatticeOfCongruences(coll, JoinRightSemigroupCongruences);
+<poset of 4 congruences over <symmetric inverse monoid of degree 2>>
+gap> OutNeighbours(l);
 [ [  ], [  ], [ 1 ], [ 1, 2, 3 ] ]
 gap> JoinSemilatticeOfCongruences(coll, JoinLeftSemigroupCongruences);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
@@ -315,7 +382,25 @@ true
 gap> MinimalCongruences(PosetOfCongruences(coll)) = coll{[1, 2]};
 true
 gap> poset := LatticeOfCongruences(S);
+<poset of 4 congruences over <symmetric inverse monoid of degree 2>>
+gap> OutNeighbours(poset);
 [ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ] ]
+gap> Print(l, "\n");
+PosetOfCongruences( 
+[ RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 2 ], [ 1 ] ) ] ] ), 
+  RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 1, 2 ], [ 1, 2 ] ) ] ] ), 
+  RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1, 2 ], [ 1, 2 ] ), PartialPerm( [ 1, 2 ], [ 2, 1 ] ) 
+         ] ] ), RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 2 ], [ 1 ] ) ], 
+      [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 1, 2 ], [ 1, 2 ] ) ] ] ) 
+ ] )
 gap> MinimalCongruences(poset);
 [ <semigroup congruence over <symmetric inverse monoid of degree 2> with 
     0 generating pairs> ]
@@ -329,18 +414,21 @@ gap> pair2 := [IdentityTransformation, Transformation([2, 2])];;
 gap> coll := [RightSemigroupCongruence(S, pair1),
 >             RightSemigroupCongruence(S, pair2),
 >             RightSemigroupCongruence(S, [])];;
-gap> PosetOfCongruences(coll);
+gap> poset := PosetOfCongruences(coll);
+<poset of 3 congruences over <regular transformation monoid of degree 2 with 
+ 2 generators>>
+gap> OutNeighbours(poset);
 [ [ 3 ], [ 3 ], [  ] ]
 
 #T# Trivial poset
 gap> poset := PosetOfCongruences([]);
-[  ]
+<empty congruence poset>
 gap> CongruencesOfPoset(poset);
 [  ]
 gap> Size(poset);
 0
 gap> JoinSemilatticeOfCongruences(poset, JoinSemigroupCongruences);
-[  ]
+<empty congruence poset>
 gap> MinimalCongruences(poset);
 [  ]
 
@@ -348,7 +436,8 @@ gap> MinimalCongruences(poset);
 gap> S := Semigroup(Transformation([2, 1, 4, 3, 5, 2]),
 >                   Transformation([3, 4, 1, 2, 5, 3]),
 >                   Transformation([5, 5, 5, 5, 5, 5]));;
-gap> LatticeOfCongruences(S);
+gap> l := LatticeOfCongruences(S);;
+gap> OutNeighbours(l);
 [ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4, 6 ], [ 1, 2, 3, 4 ] ]
 
 #T# SEMIGROUPS_UnbindVariables


### PR DESCRIPTION
This probably should've been the case when the object was first created.  A poset of semigroup congruences is a digraph with vertices labelled by the congruences themselves.  An edge `i -> j` exists if congruence `i` is a subrelation (a refinement) of congruence `j`.

This is in reference to Issue #369.