### PR TITLE
Make congruence poset object a digraph

### DIFF
--- a/doc/conglatt.xml
+++ b/doc/conglatt.xml
@@ -42,7 +42,7 @@ true
 gap> IsDigraph(poset);
 true
 gap> OutNeighbours(poset);
-[ [ 2 .. 4 ], [ 3, 4 ], [  ], [ 3 ] ]
+[ [ 1 .. 4 ], [ 2, 3, 4 ], [ 3 ], [ 3, 4 ] ]
 gap> T := FullTransformationMonoid(3);;
 gap> congs := PrincipalCongruencesOfSemigroup(T);;
 gap> poset := JoinSemilatticeOfCongruences(congs,
@@ -100,7 +100,7 @@ gap> LatticeOfRightCongruences(S);
 <poset of 5 congruences over <regular transformation monoid 
  of size 3, degree 2 with 2 generators>>
 gap> OutNeighbours(LatticeOfRightCongruences(S));
-[ [ 2 .. 5 ], [ 5 ], [ 5 ], [ 5 ], [  ] ]
+[ [ 1 .. 5 ], [ 2, 5 ], [ 3, 5 ], [ 4, 5 ], [ 5 ] ]
 gap> S := FullTransformationMonoid(4);;
 gap> restriction := [Transformation([1, 1, 1, 1]),
 >                    Transformation([1, 1, 1, 2]),
@@ -249,7 +249,7 @@ gap> poset := PosetOfCongruences(coll);
 <poset of 3 congruences over <regular transformation monoid of 
  degree 2 with 2 generators>>
 gap> OutNeighbours(poset);
-[ [  ], [  ], [ 1, 2 ] ]
+[ [ 1 ], [ 2 ], [ 1, 2, 3 ] ]
 ]]></Example>
     </Description>
   </ManSection>

--- a/doc/conglatt.xml
+++ b/doc/conglatt.xml
@@ -21,11 +21,12 @@
       <C>cong1</C> is a subrelation (a refinement) of <C>cong2</C>. The
       congruences in a congruence poset can be left, right, or two-sided. <P/>
 
-      A congruence poset is displayed as a list of lists, which describes the
-      partial order of its congruences: the integer <C>j</C> appears in list
-      <C>i</C> if and only if the congruence numbered <C>j</C> is a subrelation
-      of the congruence numbered <C>i</C>.  The list of congruences can be
-      obtained using <Ref Attr = "CongruencesOfPoset"/>.
+      A congruence poset is a digraph
+      (see <Ref Filt = "IsDigraph" BookName = "Digraphs"/>) with a vertex for
+      each congruence, and an edge from vertex <C>i</C> to vertex <C>j</C> if
+      and only if the congruence numbered <C>j</C> is a subrelation of the
+      congruence numbered <C>i</C>.  The list of congruences can be obtained
+      using <Ref Attr = "CongruencesOfPoset"/>. <P/>
 
       Congruence posets can be created using <Ref Oper = "PosetOfCongruences"/>,
       <Ref Oper = "JoinSemilatticeOfCongruences"
@@ -72,12 +73,10 @@ gap> Size(poset);
           Label = "for a semigroup and a multiplicative element collection"/>
     <Returns>A list of lists.</Returns>
     <Description>
-      If <A>S</A> is a semigroup, then <C>LatticeOfCongruences</C> gives a list
-      of lists showing how the congruences of <A>S</A> are contained in each
-      other.  The congruence numbered <M>i</M> is a subcongruence of the
-      congruence numbered <M>j</M> if and only if <M>i</M> is in the <M>j</M>th
-      list.  The numbering is according to the order in
-      <Ref Attr = "CongruencesOfPoset"/>. <P/>
+      If <A>S</A> is a semigroup, then <C>LatticeOfCongruences</C> gives a
+      congruence poset object containing all the congruences of <A>S</A> and
+      information about how they are contained in each other.
+      See <Ref Filt = "IsCongruencePoset"/> for more details. <P/>
 
       <C>LatticeOfLeftCongruences</C> and <C>LatticeOfRightCongruences</C> do
       the same thing for left and right congruences respectively. <P/>

--- a/doc/conglatt.xml
+++ b/doc/conglatt.xml
@@ -24,8 +24,8 @@
       A congruence poset is a digraph
       (see <Ref Filt = "IsDigraph" BookName = "Digraphs"/>) with a vertex for
       each congruence, and an edge from vertex <C>i</C> to vertex <C>j</C> if
-      and only if the congruence numbered <C>j</C> is a subrelation of the
-      congruence numbered <C>i</C>.  The list of congruences can be obtained
+      and only if the congruence numbered <C>i</C> is a subrelation of the
+      congruence numbered <C>j</C>.  The list of congruences can be obtained
       using <Ref Attr = "CongruencesOfPoset"/>. <P/>
 
       Congruence posets can be created using <Ref Oper = "PosetOfCongruences"/>,
@@ -42,7 +42,7 @@ true
 gap> IsDigraph(poset);
 true
 gap> OutNeighbours(poset);
-[ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ] ]
+[ [ 2 .. 4 ], [ 3, 4 ], [  ], [ 3 ] ]
 gap> T := FullTransformationMonoid(3);;
 gap> congs := PrincipalCongruencesOfSemigroup(T);;
 gap> poset := JoinSemilatticeOfCongruences(congs,
@@ -100,7 +100,7 @@ gap> LatticeOfRightCongruences(S);
 <poset of 5 congruences over <regular transformation monoid 
  of size 3, degree 2 with 2 generators>>
 gap> OutNeighbours(LatticeOfRightCongruences(S));
-[ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4 ] ]
+[ [ 2 .. 5 ], [ 5 ], [ 5 ], [ 5 ], [  ] ]
 gap> S := FullTransformationMonoid(4);;
 gap> restriction := [Transformation([1, 1, 1, 1]),
 >                    Transformation([1, 1, 1, 2]),
@@ -249,7 +249,7 @@ gap> poset := PosetOfCongruences(coll);
 <poset of 3 congruences over <regular transformation monoid of 
  degree 2 with 2 generators>>
 gap> OutNeighbours(poset);
-[ [ 3 ], [ 3 ], [  ] ]
+[ [  ], [  ], [ 1, 2 ] ]
 ]]></Example>
     </Description>
   </ManSection>

--- a/doc/conglatt.xml
+++ b/doc/conglatt.xml
@@ -35,20 +35,21 @@
       <Example><![CDATA[
 gap> S := SymmetricInverseMonoid(2);;
 gap> poset := LatticeOfCongruences(S);
-[ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ] ]
+<poset of 4 congruences over <symmetric inverse monoid of degree 2>>
 gap> IsCongruencePoset(poset);
 true
-gap> poset[3];
-[ 1, 2, 4 ]
+gap> IsDigraph(poset);
+true
+gap> OutNeighbours(poset);
+[ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ] ]
 gap> T := FullTransformationMonoid(3);;
 gap> congs := PrincipalCongruencesOfSemigroup(T);;
 gap> poset := JoinSemilatticeOfCongruences(congs,
 >                                          JoinSemigroupCongruences);
-[ [ 4, 6 ], [ 1, 3, 4, 5, 6 ], [ 1, 4, 5, 6 ], [ 6 ], [ 1, 4, 6 ], 
-  [  ] ]
+<poset of 6 congruences over <full transformation monoid of degree 3>>
 gap> IsCongruencePoset(poset);
 true
-gap> Length(poset);
+gap> Size(poset);
 6
 ]]></Example>
     </Description>
@@ -91,17 +92,22 @@ gap> Length(poset);
       <Example><![CDATA[
 gap> S := OrderEndomorphisms(2);;
 gap> LatticeOfCongruences(S);
-[ [  ], [ 1, 3 ], [ 1 ] ]
+<poset of 3 congruences over <regular transformation monoid 
+ of size 3, degree 2 with 2 generators>>
 gap> LatticeOfLeftCongruences(S);
-[ [  ], [ 1, 3 ], [ 1 ] ]
+<poset of 3 congruences over <regular transformation monoid 
+ of size 3, degree 2 with 2 generators>>
 gap> LatticeOfRightCongruences(S);
+<poset of 5 congruences over <regular transformation monoid 
+ of size 3, degree 2 with 2 generators>>
+gap> OutNeighbours(LatticeOfRightCongruences(S));
 [ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4 ] ]
 gap> S := FullTransformationMonoid(4);;
 gap> restriction := [Transformation([1, 1, 1, 1]),
 >                    Transformation([1, 1, 1, 2]),
 >                    Transformation([1, 1, 1, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
-[ [  ], [ 1 ] ]
+<poset of 2 congruences over <full transformation monoid of degree 4>>
 ]]></Example>
     </Description>
   </ManSection>
@@ -146,16 +152,17 @@ gap> latt := LatticeOfCongruences(S, restriction);
 gap> S := Semigroup([Transformation([1, 3, 1]),
 >                    Transformation([2, 3, 3])]);;
 gap> PosetOfPrincipalLeftCongruences(S);
-[ [ 8, 11 ], [  ], [ 1, 2, 8, 11, 12 ], [ 2, 7, 10, 11, 12 ], [ 2 ], 
-  [ 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12 ], [ 10, 12 ], [ 11 ], 
-  [ 2, 11, 12 ], [ 12 ], [  ], [  ] ]
+<poset of 12 congruences over <transformation semigroup of size 11, 
+ degree 3 with 2 generators>>
 gap> PosetOfPrincipalCongruences(S);
-[ [ 2, 3 ], [  ], [ 2 ] ]
+<poset of 3 congruences over <transformation semigroup of size 11, 
+ degree 3 with 2 generators>>
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
 >                    Transformation([2, 2, 2])];;
 gap> poset := PosetOfPrincipalRightCongruences(S, restriction);
-[ [ 2, 3 ], [  ], [  ] ]
+<poset of 3 congruences over <transformation semigroup of size 11, 
+ degree 3 with 2 generators>>
 ]]></Example>
     </Description>
   </ManSection>
@@ -177,7 +184,8 @@ gap> poset := PosetOfPrincipalRightCongruences(S, restriction);
       <Example><![CDATA[
 gap> S := OrderEndomorphisms(2);;
 gap> latt := LatticeOfRightCongruences(S);
-[ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4 ] ]
+<poset of 5 congruences over <regular transformation monoid 
+ of size 3, degree 2 with 2 generators>>
 gap> CongruencesOfPoset(latt);
 [ <right semigroup congruence over <regular transformation monoid 
      of size 3, degree 2 with 2 generators> with 0 generating pairs>, 
@@ -206,7 +214,8 @@ gap> CongruencesOfPoset(latt);
 gap> S := OrderEndomorphisms(2);
 <regular transformation monoid of degree 2 with 2 generators>
 gap> latt := LatticeOfRightCongruences(S);
-[ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4 ] ]
+<poset of 5 congruences over <regular transformation monoid 
+ of size 3, degree 2 with 2 generators>>
 gap> UnderlyingSemigroupOfCongruencePoset(latt) = S;
 true
 ]]></Example>
@@ -237,7 +246,10 @@ gap> pair2 := [IdentityTransformation, Transformation([2, 2])];;
 gap> coll := [RightSemigroupCongruence(S, pair1),
 >             RightSemigroupCongruence(S, pair2),
 >             RightSemigroupCongruence(S, [])];;
-gap> PosetOfCongruences(coll);
+gap> poset := PosetOfCongruences(coll);
+<poset of 3 congruences over <regular transformation monoid of 
+ degree 2 with 2 generators>>
+gap> OutNeighbours(poset);
 [ [ 3 ], [ 3 ], [  ] ]
 ]]></Example>
     </Description>
@@ -277,7 +289,7 @@ gap> coll := [RightSemigroupCongruence(S, pair1),
 >             RightSemigroupCongruence(S, pair2),
 >             RightSemigroupCongruence(S, pair3)];;
 gap> JoinSemilatticeOfCongruences(coll, JoinRightSemigroupCongruences);
-[ [  ], [  ], [ 1 ], [ 1, 2, 3 ] ]
+<poset of 4 congruences over <symmetric inverse monoid of degree 2>>
 ]]></Example>
     </Description>
   </ManSection>
@@ -321,7 +333,7 @@ gap> MinimalCongruences(coll);
   <right semigroup congruence over <symmetric inverse monoid of degree\
  2> with 1 generating pairs> ]
 gap> poset := LatticeOfCongruences(S);
-[ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ] ]
+<poset of 4 congruences over <symmetric inverse monoid of degree 2>>
 gap> MinimalCongruences(poset);
 [ <semigroup congruence over <symmetric inverse monoid of degree 2> wi\
 th 0 generating pairs> ]

--- a/gap/congruences/conglatt.gd
+++ b/gap/congruences/conglatt.gd
@@ -16,7 +16,7 @@
 ## this file.
 ##
 
-DeclareCategory("IsCongruencePoset", IsList and IsAttributeStoringRep);
+DeclareCategory("IsCongruencePoset", IsDigraph);
 
 DeclareAttribute("CongruencesOfPoset", IsCongruencePoset);
 DeclareAttribute("UnderlyingSemigroupOfCongruencePoset", IsCongruencePoset);
@@ -45,5 +45,10 @@ DeclareOperation("PosetOfCongruences", [IsListOrCollection]);
 
 DeclareOperation("JoinSemilatticeOfCongruences",
                  [IsListOrCollection, IsFunction]);
+DeclareOperation("JoinSemilatticeOfCongruences",
+                 [IsCongruencePoset, IsFunction]);
 
 DeclareAttribute("MinimalCongruences", IsListOrCollection);
+DeclareAttribute("MinimalCongruences", IsCongruencePoset);
+
+DeclareAttribute("Size", IsCongruencePoset);

--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -101,14 +101,16 @@ SEMIGROUPS.PrincipalXCongruencePosetNC :=
     if not badcong then
       nrcongs := nrcongs + 1;
       congs[nrcongs] := newcong;
-      children[nrcongs] := newchildren;
-      parents[nrcongs] := newparents;
       for c in newchildren do
         Add(parents[c], nrcongs);
       od;
       for p in newparents do
         Add(children[p], nrcongs);
       od;
+      Add(newchildren, nrcongs);  # Include loops (reflexive)
+      Add(newparents, nrcongs);
+      children[nrcongs] := newchildren;
+      parents[nrcongs] := newparents;
     fi;
   od;
 
@@ -127,7 +129,7 @@ end;
 InstallMethod(MinimalCongruences,
 "for a congruence poset",
 [IsCongruencePoset],
-poset -> CongruencesOfPoset(poset){Positions(InDegrees(poset), 0)});
+poset -> CongruencesOfPoset(poset){Positions(InDegrees(poset), 1)});
 
 InstallMethod(MinimalCongruences,
 "for a list or collection",
@@ -192,15 +194,17 @@ function(poset, join_func)
         if not badcong then
           nrcongs := nrcongs + 1;
           congs[nrcongs] := newcong;
-          children[nrcongs] := newchildren;
-          parents[nrcongs] := newparents;
-          ignore[nrcongs] := false;
           for c in newchildren do
             Add(parents[c], nrcongs);
           od;
           for p in newparents do
             Add(children[p], nrcongs);
           od;
+          Add(newchildren, nrcongs);  # Include loops (reflexive)
+          Add(newparents, nrcongs);
+          children[nrcongs] := newchildren;
+          parents[nrcongs] := newparents;
+          ignore[nrcongs] := false;
           found := true;
         fi;
       od;
@@ -240,8 +244,8 @@ SEMIGROUPS.AddTrivialCongruence := function(poset, cong_func)
   nrcongs := Length(congs) + 1;
   Add(congs, cong_func(S, []), 1);
   children := Concatenation([[]], children + 1);
-  parents := Concatenation([[2 .. nrcongs]], parents + 1);
-  for i in [2 .. nrcongs] do
+  parents := Concatenation([[1 .. nrcongs]], parents + 1);
+  for i in [1 .. nrcongs] do
     Add(children[i], 1, 1);
   od;
 
@@ -267,15 +271,14 @@ function(coll)
   children := [];
   parents := [];
   for i in [1 .. nrcongs] do
-    children[i] := Set([]);
-    parents[i] := Set([]);
+    children[i] := Set([i]);
+    parents[i] := Set([i]);
   od;
 
   # Find children of each cong in turn
   for i in [1 .. nrcongs] do
-    # Ignore self and known parents
+    # Ignore known parents
     ignore := BlistList([1 .. nrcongs], [parents[i]]);
-    ignore[i] := true;
     for j in [1 .. nrcongs] do
       if not ignore[j] and IsSubrelation(congs[i], congs[j]) then
         AddSet(children[i], j);

--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -22,40 +22,30 @@
 ## user as the list of out-neighbours of that digraph.
 ##
 
-InstallMethod(\[\],
-"for a congruence poset and a positive integer",
-[IsCongruencePoset, IsPosInt],
-function(poset, x)
-  return OutNeighboursOfVertex(poset!.po, x);
-end);
-
 InstallMethod(ViewObj,
 "for a congruence poset",
 [IsCongruencePoset],
 function(poset)
-  ViewObj(OutNeighbours(poset!.po));
+  if DigraphNrVertices(poset) = 0 then
+    Print("<empty congruence poset>");
+  else
+    Print("<poset of ", DigraphNrVertices(poset), " congruences over ");
+    ViewObj(UnderlyingSemigroupOfCongruencePoset(poset));
+    Print(">");
+  fi;
 end);
 
 InstallMethod(PrintObj,
 "for a congruence poset",
 [IsCongruencePoset],
 function(poset)
-  PrintObj(OutNeighbours(poset!.po));
+  Print("PosetOfCongruences( ", CongruencesOfPoset(poset), " )");
 end);
 
-InstallMethod(Length,
+InstallMethod(Size,
 "for a congruence poset",
 [IsCongruencePoset],
-function(poset)
-  return DigraphNrVertices(poset!.po);
-end);
-
-InstallMethod(IsBound\[\],
-"for a congruence poset and a positive integer",
-[IsCongruencePoset, IsPosInt],
-function(poset, x)
-  return x >= 1 and x <= Length(poset);
-end);
+DigraphNrVertices);
 
 SEMIGROUPS.PrincipalXCongruencePosetNC :=
   function(S,
@@ -63,7 +53,7 @@ SEMIGROUPS.PrincipalXCongruencePosetNC :=
            SemigroupXCongruence,
            GeneratingPairsOfXSemigroupCongruence)
   local report, pairs, total, congs, nrcongs, children, parents, last_collected,
-        nr, pair, badcong, newchildren, newparents, newcong, i, pair1, c, p, po,
+        nr, pair, badcong, newchildren, newparents, newcong, i, pair1, c, p,
         poset;
 
   # Suppress reporting
@@ -125,19 +115,19 @@ SEMIGROUPS.PrincipalXCongruencePosetNC :=
   SEMIGROUPS.OptionsRec(S).report := report;
 
   # We are done: make the object and return
-  po := Digraph(children);
-  SetInNeighbours(po, parents);
-  poset := Objectify(NewType(FamilyObj(children), IsCongruencePoset),
-                     rec(po := po));
+  poset := Digraph(children);
+  SetInNeighbours(poset, parents);
   SetCongruencesOfPoset(poset, congs);
+  SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
+  SetFilterObj(poset, IsCongruencePoset);
   return poset;
 end;
 
 InstallMethod(MinimalCongruences,
 "for a congruence poset",
 [IsCongruencePoset],
-poset -> CongruencesOfPoset(poset){DigraphSinks(poset!.po)});
+poset -> CongruencesOfPoset(poset){DigraphSinks(poset)});
 
 InstallMethod(MinimalCongruences,
 "for a list or collection",
@@ -150,7 +140,7 @@ InstallMethod(JoinSemilatticeOfCongruences,
 function(poset, join_func)
   local children, parents, congs, princ_congs, nrcongs, S, report, length,
         found, ignore, start, i, j, newcong, badcong, newchildren, newparents,
-        k, c, p, po;
+        k, c, p;
 
   # Trivial case
   if Size(poset) = 0 then
@@ -158,8 +148,8 @@ function(poset, join_func)
   fi;
 
   # Extract the info
-  children := OutNeighboursMutableCopy(poset!.po);
-  parents := InNeighboursMutableCopy(poset!.po);
+  children := OutNeighboursMutableCopy(poset);
+  parents := InNeighboursMutableCopy(poset);
   congs := ShallowCopy(CongruencesOfPoset(poset));
   princ_congs := ShallowCopy(congs);
   nrcongs := Length(congs);
@@ -220,12 +210,12 @@ function(poset, join_func)
   SEMIGROUPS.OptionsRec(S).report := report;
 
   # We are done: make the object and return
-  po := Digraph(children);
-  SetInNeighbours(po, parents);
-  poset := Objectify(NewType(FamilyObj(children), IsCongruencePoset),
-                     rec(po := po));
+  poset := Digraph(children);
+  SetInNeighbours(poset, parents);
   SetCongruencesOfPoset(poset, congs);
+  SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
+  SetFilterObj(poset, IsCongruencePoset);
   return poset;
 end);
 
@@ -239,11 +229,11 @@ function(coll, join_func)
 end);
 
 SEMIGROUPS.AddTrivialCongruence := function(poset, cong_func)
-  local S, children, parents, congs, nrcongs, i, po;
+  local S, children, parents, congs, nrcongs, i;
   # Extract the info
   S := UnderlyingSemigroupOfCongruencePoset(poset);
-  children := OutNeighboursMutableCopy(poset!.po);
-  parents := InNeighboursMutableCopy(poset!.po);
+  children := OutNeighboursMutableCopy(poset);
+  parents := InNeighboursMutableCopy(poset);
   congs := ShallowCopy(CongruencesOfPoset(poset));
 
   # Add the trivial congruence
@@ -256,12 +246,12 @@ SEMIGROUPS.AddTrivialCongruence := function(poset, cong_func)
   od;
 
   # Make the object and return
-  po := Digraph(children);
-  SetInNeighbours(po, parents);
-  poset := Objectify(NewType(FamilyObj(children), IsCongruencePoset),
-                     rec(po := po));
+  poset := Digraph(children);
+  SetInNeighbours(poset, parents);
   SetCongruencesOfPoset(poset, congs);
+  SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
+  SetFilterObj(poset, IsCongruencePoset);
   return poset;
 end;
 
@@ -269,7 +259,7 @@ InstallMethod(PosetOfCongruences,
 "for a list or collection",
 [IsListOrCollection],
 function(coll)
-  local congs, nrcongs, children, parents, i, ignore, j, po, poset;
+  local congs, nrcongs, children, parents, i, ignore, j, poset;
   congs := AsList(coll);
   nrcongs := Length(congs);
 
@@ -295,14 +285,14 @@ function(coll)
   od;
 
   # We are done: make the object and return
-  po := Digraph(children);
-  SetInNeighbours(po, parents);
-  poset := Objectify(NewType(FamilyObj(children), IsCongruencePoset),
-                     rec(po := po));
+  poset := Digraph(children);
+  SetInNeighbours(poset, parents);
   SetCongruencesOfPoset(poset, congs);
+  SetDigraphVertexLabels(poset, congs);
   if nrcongs > 0 then
     SetUnderlyingSemigroupOfCongruencePoset(poset, Range(congs[1]));
   fi;
+  SetFilterObj(poset, IsCongruencePoset);
   return poset;
 end);
 
@@ -510,14 +500,15 @@ InstallMethod(DotString,
 "for a congruence poset and a record",
 [IsCongruencePoset, IsRecord],
 function(poset, opts)
-  local congs, S, symbols, i, nr, rel, str, j, k;
+  local out_nbs, congs, S, symbols, i, nr, rel, str, j, k;
+  out_nbs := OutNeighbours(poset);
   # If the user wants info, then change the node labels
   if opts.info = true then
     # The congruences are stored inside the poset object
     congs := CongruencesOfPoset(poset);
     S := Range(congs[1]);
-    symbols := EmptyPlist(Length(poset));
-    for i in [1 .. Length(poset)] do
+    symbols := EmptyPlist(Length(out_nbs));
+    for i in [1 .. Length(out_nbs)] do
       nr := NrEquivalenceClasses(congs[i]);
       if nr = 1 then
         symbols[i] := "U";
@@ -530,10 +521,10 @@ function(poset, opts)
       fi;
     od;
   else
-    symbols := List([1 .. Length(poset)], String);
+    symbols := List([1 .. Length(out_nbs)], String);
   fi;
 
-  rel := List([1 .. Length(poset)], x -> Filtered(poset[x], y -> x <> y));
+  rel := List([1 .. Length(out_nbs)], x -> Filtered(out_nbs[x], y -> x <> y));
   str := "";
 
   if Length(rel) < 40 then

--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -17,8 +17,8 @@
 ##
 ## The list of congruences in the poset is stored as an attribute
 ## CongruencesOfPoset.  The partial order of the poset is stored as a digraph,
-## where an edge (i,j) is present if and only if congruence j is a subrelation
-## of congruence i.  When a congruence poset is displayed, it appears to the
+## where an edge (i,j) is present if and only if congruence i is a subrelation
+## of congruence j.  When a congruence poset is displayed, it appears to the
 ## user as the list of out-neighbours of that digraph.
 ##
 
@@ -115,8 +115,8 @@ SEMIGROUPS.PrincipalXCongruencePosetNC :=
   SEMIGROUPS.OptionsRec(S).report := report;
 
   # We are done: make the object and return
-  poset := Digraph(children);
-  SetInNeighbours(poset, parents);
+  poset := Digraph(parents);
+  SetInNeighbours(poset, children);
   SetCongruencesOfPoset(poset, congs);
   SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
@@ -127,7 +127,7 @@ end;
 InstallMethod(MinimalCongruences,
 "for a congruence poset",
 [IsCongruencePoset],
-poset -> CongruencesOfPoset(poset){DigraphSinks(poset)});
+poset -> CongruencesOfPoset(poset){Positions(InDegrees(poset), 0)});
 
 InstallMethod(MinimalCongruences,
 "for a list or collection",
@@ -148,8 +148,8 @@ function(poset, join_func)
   fi;
 
   # Extract the info
-  children := OutNeighboursMutableCopy(poset);
-  parents := InNeighboursMutableCopy(poset);
+  children := InNeighboursMutableCopy(poset);
+  parents := OutNeighboursMutableCopy(poset);
   congs := ShallowCopy(CongruencesOfPoset(poset));
   princ_congs := ShallowCopy(congs);
   nrcongs := Length(congs);
@@ -210,8 +210,8 @@ function(poset, join_func)
   SEMIGROUPS.OptionsRec(S).report := report;
 
   # We are done: make the object and return
-  poset := Digraph(children);
-  SetInNeighbours(poset, parents);
+  poset := Digraph(parents);
+  SetInNeighbours(poset, children);
   SetCongruencesOfPoset(poset, congs);
   SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
@@ -232,8 +232,8 @@ SEMIGROUPS.AddTrivialCongruence := function(poset, cong_func)
   local S, children, parents, congs, nrcongs, i;
   # Extract the info
   S := UnderlyingSemigroupOfCongruencePoset(poset);
-  children := OutNeighboursMutableCopy(poset);
-  parents := InNeighboursMutableCopy(poset);
+  children := InNeighboursMutableCopy(poset);
+  parents := OutNeighboursMutableCopy(poset);
   congs := ShallowCopy(CongruencesOfPoset(poset));
 
   # Add the trivial congruence
@@ -246,8 +246,8 @@ SEMIGROUPS.AddTrivialCongruence := function(poset, cong_func)
   od;
 
   # Make the object and return
-  poset := Digraph(children);
-  SetInNeighbours(poset, parents);
+  poset := Digraph(parents);
+  SetInNeighbours(poset, children);
   SetCongruencesOfPoset(poset, congs);
   SetDigraphVertexLabels(poset, congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, S);
@@ -285,8 +285,8 @@ function(coll)
   od;
 
   # We are done: make the object and return
-  poset := Digraph(children);
-  SetInNeighbours(poset, parents);
+  poset := Digraph(parents);
+  SetInNeighbours(poset, children);
   SetCongruencesOfPoset(poset, congs);
   SetDigraphVertexLabels(poset, congs);
   if nrcongs > 0 then
@@ -500,15 +500,15 @@ InstallMethod(DotString,
 "for a congruence poset and a record",
 [IsCongruencePoset, IsRecord],
 function(poset, opts)
-  local out_nbs, congs, S, symbols, i, nr, rel, str, j, k;
-  out_nbs := OutNeighbours(poset);
+  local nrcongs, congs, S, symbols, i, nr, in_nbs, rel, str, j, k;
+  nrcongs := Size(poset);
   # If the user wants info, then change the node labels
   if opts.info = true then
     # The congruences are stored inside the poset object
     congs := CongruencesOfPoset(poset);
     S := Range(congs[1]);
-    symbols := EmptyPlist(Length(out_nbs));
-    for i in [1 .. Length(out_nbs)] do
+    symbols := EmptyPlist(nrcongs);
+    for i in [1 .. nrcongs] do
       nr := NrEquivalenceClasses(congs[i]);
       if nr = 1 then
         symbols[i] := "U";
@@ -521,13 +521,14 @@ function(poset, opts)
       fi;
     od;
   else
-    symbols := List([1 .. Length(out_nbs)], String);
+    symbols := List([1 .. nrcongs], String);
   fi;
 
-  rel := List([1 .. Length(out_nbs)], x -> Filtered(out_nbs[x], y -> x <> y));
+  in_nbs := InNeighbours(poset);
+  rel := List([1 .. nrcongs], x -> Filtered(in_nbs[x], y -> x <> y));
   str := "";
 
-  if Length(rel) < 40 then
+  if nrcongs < 40 then
     Append(str, "//dot\ngraph graphname {\n     node [shape=circle]\n");
   else
     Append(str, "//dot\ngraph graphname {\n     node [shape=point]\n");

--- a/tst/standard/conglatt.tst
+++ b/tst/standard/conglatt.tst
@@ -31,7 +31,7 @@ gap> S := PartitionMonoid(2);;
 gap> l := LatticeOfCongruences(S);
 <poset of 13 congruences over <regular bipartition *-monoid of size 15, 
  degree 2 with 3 generators>>
-gap> OutNeighbours(l);
+gap> InNeighbours(l);
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ], [ 1, 3, 9 ], [ 1, 2, 3, 4, 5, 9, 10 ], 
   [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 ], [ 1, 3 ], [ 1 ], [ 1, 4, 9 ], 
   [ 1, 2, 3, 4, 8 ], [ 1, 3, 5, 8, 9 ], 
@@ -47,7 +47,7 @@ gap> CongruencesOfSemigroup(S);
 gap> l := LatticeOfCongruences(S);
 <poset of 3 congruences over <regular transformation monoid of size 3, 
  degree 2 with 2 generators>>
-gap> OutNeighbours(l);
+gap> InNeighbours(l);
 [ [  ], [ 1, 3 ], [ 1 ] ]
 gap> Print(l, "\n");
 PosetOfCongruences( 
@@ -69,7 +69,7 @@ gap> S := Semigroup([Transformation([1, 4, 3, 1, 4, 2]),
 gap> l := LatticeOfCongruences(S);
 <poset of 5 congruences over <transformation semigroup of size 48, degree 6 
  with 2 generators>>
-gap> OutNeighbours(l);
+gap> InNeighbours(l);
 [ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ], [ 1, 2, 3, 4 ] ]
 gap> DotString(l, rec(info := true)) = Concatenation("//dot\ngraph graphname",
 > " {\n     node [shape=circle]\nR2 -- T\nR3 -- 4\n4 -- R2\nU -- R3\n }");
@@ -104,7 +104,7 @@ gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
 gap> l := LatticeOfLeftCongruences(S);
 <poset of 21 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
-gap> OutNeighbours(l) =
+gap> InNeighbours(l) =
 > [[], [1, 9, 12], [1], [1, 2, 3, 9, 12, 13, 15, 17],
 >   [1, 3, 8, 11, 12, 13, 16, 17], [1, 3],
 >   [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
@@ -118,7 +118,7 @@ true
 gap> l := LatticeOfRightCongruences(S);
 <poset of 31 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
-gap> OutNeighbours(l) =
+gap> InNeighbours(l) =
 > [[], [1], [1], [1], [1], [1, 2, 5, 8, 14, 24],
 >   [1, 3, 5, 10, 12, 23], [1], [1, 4, 8, 10], [1], [1], [1],
 >   [1, 3, 8, 11], [1], [1, 2, 10, 11], [1, 2, 3, 4],
@@ -131,7 +131,7 @@ gap> OutNeighbours(l) =
 >   [1, 4, 5, 11, 12, 14, 20, 21, 22, 23, 24, 29, 31],
 >   [1, 5, 12, 14, 23, 24, 29]];
 true
-gap> OutNeighbours(LatticeOfCongruences(S));
+gap> InNeighbours(LatticeOfCongruences(S));
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1, 3 ] ]
 gap> Size(CongruencesOfSemigroup(S));
 4
@@ -144,7 +144,7 @@ gap> restriction := Subsemigroup(S, [Transformation([1, 1, 1]),
 gap> latt := LatticeOfLeftCongruences(S, restriction);
 <poset of 5 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4 ] ]
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
@@ -152,7 +152,7 @@ gap> restriction := [Transformation([3, 2, 3]),
 gap> latt := LatticeOfRightCongruences(S, restriction);
 <poset of 4 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ] ]
 gap> congs := CongruencesOfPoset(latt);;
 gap> Length(congs);
@@ -163,13 +163,13 @@ gap> restriction := [Transformation([3, 1, 3]), Transformation([3, 2, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
 <poset of 2 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [ [  ], [ 1 ] ]
 gap> restriction := [Transformation([3, 3, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
 <poset of 1 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [ [  ] ]
 
 #T# LatticeOf(Left/Right)Congruences with invalid restriction
@@ -197,7 +197,7 @@ gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
 gap> poset := PosetOfPrincipalLeftCongruences(S);
 <poset of 12 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
-gap> OutNeighbours(poset) =
+gap> InNeighbours(poset) =
 > [[8, 11], [], [1, 2, 8, 11, 12], [2, 7, 10, 11, 12], [2],
 >   [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12], [10, 12], [11], [2, 11, 12],
 >   [12], [], []];
@@ -205,7 +205,7 @@ true
 gap> poset := PosetOfPrincipalRightCongruences(S);
 <poset of 15 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
-gap> OutNeighbours(poset) =
+gap> InNeighbours(poset) =
 > [[], [], [], [], [1, 4, 7, 13], [2, 4, 9, 11], [],
 >   [3, 7, 9], [], [], [], [2, 7, 10], [], [1, 9, 10],
 >   [1, 2, 3]];
@@ -213,7 +213,7 @@ true
 gap> poset := PosetOfPrincipalCongruences(S);
 <poset of 3 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
-gap> OutNeighbours(poset);
+gap> InNeighbours(poset);
 [ [ 2, 3 ], [  ], [ 2 ] ]
 gap> Print(poset, "\n");
 PosetOfCongruences( 
@@ -237,7 +237,7 @@ gap> restriction := Subsemigroup(S, [Transformation([1, 1, 1]),
 gap> latt := PosetOfPrincipalLeftCongruences(S, restriction);
 <poset of 3 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [ [  ], [  ], [  ] ]
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
@@ -245,7 +245,7 @@ gap> restriction := [Transformation([3, 2, 3]),
 gap> latt := PosetOfPrincipalRightCongruences(S, restriction);
 <poset of 3 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [ [ 2, 3 ], [  ], [  ] ]
 gap> CongruencesOfPoset(latt);
 [ <right semigroup congruence over <transformation semigroup of degree 3 with 
@@ -257,12 +257,12 @@ gap> restriction := [Transformation([3, 1, 3]), Transformation([3, 2, 3])];;
 gap> latt := PosetOfPrincipalCongruences(S, restriction);
 <poset of 1 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [ [  ] ]
 gap> restriction := [Transformation([3, 3, 3])];;
 gap> latt := PosetOfPrincipalCongruences(S, restriction);
 <empty congruence poset>
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [  ]
 
 #T# PosetOfPrincipal(Left/Right)Congruences with invalid restriction
@@ -327,7 +327,7 @@ gap> congs := CongruencesOfSemigroup(S);
 gap> l := LatticeOfCongruences(S);
 <poset of 6 congruences over <transformation semigroup of size 13, degree 3 
  with 2 generators>>
-gap> OutNeighbours(l);
+gap> InNeighbours(l);
 [ [  ], [ 1, 5, 6 ], [ 1, 2, 4, 5, 6 ], [ 1, 2, 5, 6 ], [ 1, 6 ], [ 1 ] ]
 gap> minl := MinimalLeftCongruencesOfSemigroup(S);;
 gap> Size(minl);
@@ -362,7 +362,7 @@ gap> coll := [RightSemigroupCongruence(S, pair1),
 >             RightSemigroupCongruence(S, pair3)];;
 gap> l := JoinSemilatticeOfCongruences(coll, JoinRightSemigroupCongruences);
 <poset of 4 congruences over <symmetric inverse monoid of degree 2>>
-gap> OutNeighbours(l);
+gap> InNeighbours(l);
 [ [  ], [  ], [ 1 ], [ 1, 2, 3 ] ]
 gap> JoinSemilatticeOfCongruences(coll, JoinLeftSemigroupCongruences);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
@@ -383,7 +383,7 @@ gap> MinimalCongruences(PosetOfCongruences(coll)) = coll{[1, 2]};
 true
 gap> poset := LatticeOfCongruences(S);
 <poset of 4 congruences over <symmetric inverse monoid of degree 2>>
-gap> OutNeighbours(poset);
+gap> InNeighbours(poset);
 [ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ] ]
 gap> Print(l, "\n");
 PosetOfCongruences( 
@@ -417,7 +417,7 @@ gap> coll := [RightSemigroupCongruence(S, pair1),
 gap> poset := PosetOfCongruences(coll);
 <poset of 3 congruences over <regular transformation monoid of degree 2 with 
  2 generators>>
-gap> OutNeighbours(poset);
+gap> InNeighbours(poset);
 [ [ 3 ], [ 3 ], [  ] ]
 
 #T# Trivial poset
@@ -437,7 +437,7 @@ gap> S := Semigroup(Transformation([2, 1, 4, 3, 5, 2]),
 >                   Transformation([3, 4, 1, 2, 5, 3]),
 >                   Transformation([5, 5, 5, 5, 5, 5]));;
 gap> l := LatticeOfCongruences(S);;
-gap> OutNeighbours(l);
+gap> InNeighbours(l);
 [ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4, 6 ], [ 1, 2, 3, 4 ] ]
 
 #T# SEMIGROUPS_UnbindVariables

--- a/tst/standard/conglatt.tst
+++ b/tst/standard/conglatt.tst
@@ -32,10 +32,10 @@ gap> l := LatticeOfCongruences(S);
 <poset of 13 congruences over <regular bipartition *-monoid of size 15, 
  degree 2 with 3 generators>>
 gap> InNeighbours(l);
-[ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ], [ 1, 3, 9 ], [ 1, 2, 3, 4, 5, 9, 10 ], 
-  [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 ], [ 1, 3 ], [ 1 ], [ 1, 4, 9 ], 
-  [ 1, 2, 3, 4, 8 ], [ 1, 3, 5, 8, 9 ], 
-  [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12 ] ]
+[ [ 1 ], [ 1, 2, 3, 4 ], [ 1, 3 ], [ 1, 4 ], [ 1, 3, 5, 9 ], 
+  [ 1, 2, 3, 4, 5, 6, 9, 10 ], [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ], 
+  [ 1, 3, 8 ], [ 1, 9 ], [ 1, 4, 9, 10 ], [ 1, 2, 3, 4, 8, 11 ], 
+  [ 1, 3, 5, 8, 9, 12 ], [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 ] ]
 gap> S := OrderEndomorphisms(2);;
 gap> CongruencesOfSemigroup(S);
 [ <semigroup congruence over <regular transformation monoid of size 3, 
@@ -48,7 +48,9 @@ gap> l := LatticeOfCongruences(S);
 <poset of 3 congruences over <regular transformation monoid of size 3, 
  degree 2 with 2 generators>>
 gap> InNeighbours(l);
-[ [  ], [ 1, 3 ], [ 1 ] ]
+[ [ 1 ], [ 1, 2, 3 ], [ 1, 3 ] ]
+gap> OutNeighbours(l);
+[ [ 1 .. 3 ], [ 2 ], [ 2, 3 ] ]
 gap> Print(l, "\n");
 PosetOfCongruences( 
 [ 
@@ -70,7 +72,9 @@ gap> l := LatticeOfCongruences(S);
 <poset of 5 congruences over <transformation semigroup of size 48, degree 6 
  with 2 generators>>
 gap> InNeighbours(l);
-[ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ], [ 1, 2, 3, 4 ] ]
+[ [ 1 ], [ 1, 2 ], [ 1, 2, 3, 4 ], [ 1, 2, 4 ], [ 1, 2, 3, 4, 5 ] ]
+gap> OutNeighbours(l);
+[ [ 1 .. 5 ], [ 2, 3, 4, 5 ], [ 3, 5 ], [ 3, 4, 5 ], [ 5 ] ]
 gap> DotString(l, rec(info := true)) = Concatenation("//dot\ngraph graphname",
 > " {\n     node [shape=circle]\nR2 -- T\nR3 -- 4\n4 -- R2\nU -- R3\n }");
 true
@@ -91,6 +95,12 @@ gap> DotString(l) = Concatenation(
 > " -- 24\n37 -- 41\n38 -- 25\n38 -- 28\n38 -- 34\n39 -- 29\n39 -- 35\n39 -- 38",
 > "\n40 -- 30\n40 -- 31\n40 -- 39\n40 -- 41\n41 -- 32\n41 -- 33\n41 -- 35\n }");
 true
+gap> IsCongruencePoset(l);
+true
+gap> IsDigraph(l);
+true
+gap> IsPartialOrderDigraph(l);
+true
 
 #T# Left/RightCongruences (as a list)
 gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
@@ -105,36 +115,38 @@ gap> l := LatticeOfLeftCongruences(S);
 <poset of 21 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
 gap> InNeighbours(l) =
-> [[], [1, 9, 12], [1], [1, 2, 3, 9, 12, 13, 15, 17],
->   [1, 3, 8, 11, 12, 13, 16, 17], [1, 3],
->   [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
->   [1, 11, 13], [1, 12], [1, 3, 12, 13, 17], [1, 13], [1], [1],
->   [1, 2, 3, 4, 9, 11, 12, 13, 15, 16, 17, 21], [1, 3, 9, 12, 13, 17],
->   [1, 3, 11, 12, 13, 17], [1, 3, 12, 13],
->   [1, 3, 5, 8, 9, 11, 12, 13, 15, 16, 17, 21],
->   [1, 3, 6, 9, 10, 11, 12, 13, 15, 16, 17, 20, 21], [1, 3, 6, 12, 13, 17],
->   [1, 3, 9, 11, 12, 13, 15, 16, 17]];
+> [[1], [1, 2, 9, 12], [1, 3], [1, 2, 3, 4, 9, 12, 13, 15, 17],
+>   [1, 3, 5, 8, 11, 12, 13, 16, 17], [1, 3, 6], [1 .. 21],
+>   [1, 8, 11, 13], [1, 9, 12], [1, 3, 10, 12, 13, 17],
+>   [1, 11, 13], [1, 12], [1, 13],
+>   [1, 2, 3, 4, 9, 11, 12, 13, 14, 15, 16, 17, 21], [1, 3, 9, 12, 13, 15, 17],
+>   [1, 3, 11, 12, 13, 16, 17], [1, 3, 12, 13, 17],
+>   [1, 3, 5, 8, 9, 11, 12, 13, 15, 16, 17, 18, 21],
+>   [1, 3, 6, 9, 10, 11, 12, 13, 15, 16, 17, 19, 20, 21],
+>   [1, 3, 6, 12, 13, 17, 20],
+>   [1, 3, 9, 11, 12, 13, 15, 16, 17, 21]];
 true
 gap> l := LatticeOfRightCongruences(S);
 <poset of 31 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
 gap> InNeighbours(l) =
-> [[], [1], [1], [1], [1], [1, 2, 5, 8, 14, 24],
->   [1, 3, 5, 10, 12, 23], [1], [1, 4, 8, 10], [1], [1], [1],
->   [1, 3, 8, 11], [1], [1, 2, 10, 11], [1, 2, 3, 4],
->   [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21,
->       22, 23, 24, 25, 26, 27, 28, 29, 30, 31], [1, 2, 12], [1, 3, 14],
->   [1, 4, 5], [1, 4, 11, 12, 14, 29], [1, 5, 11], [1, 5, 12],
->   [1, 5, 14], [1, 2, 5, 6, 8, 12, 14, 18, 23, 24, 27, 29, 31],
->   [1, 3, 5, 7, 10, 12, 14, 19, 23, 24, 28, 29, 31], [1, 8, 12],
->   [1, 10, 14], [1, 12, 14],
->   [1, 4, 5, 11, 12, 14, 20, 21, 22, 23, 24, 29, 31],
->   [1, 5, 12, 14, 23, 24, 29]];
+> [[1], [1, 2], [1, 3], [1, 4], [1, 5], [1, 2, 5, 6, 8, 14, 24],
+>   [1, 3, 5, 7, 10, 12, 23], [1, 8], [1, 4, 8, 9, 10], [1, 10], [1, 11],
+>   [1, 12], [1, 3, 8, 11, 13], [1, 14], [1, 2, 10, 11, 15], [1, 2, 3, 4, 16],
+>   [1 .. 31], [1, 2, 12, 18], [1, 3, 14, 19],
+>   [1, 4, 5, 20], [1, 4, 11, 12, 14, 21, 29], [1, 5, 11, 22], [1, 5, 12, 23],
+>   [1, 5, 14, 24], [1, 2, 5, 6, 8, 12, 14, 18, 23, 24, 25, 27, 29, 31],
+>   [1, 3, 5, 7, 10, 12, 14, 19, 23, 24, 26, 28, 29, 31], [1, 8, 12, 27],
+>   [1, 10, 14, 28], [1, 12, 14, 29],
+>   [1, 4, 5, 11, 12, 14, 20, 21, 22, 23, 24, 29, 30, 31],
+>   [1, 5, 12, 14, 23, 24, 29, 31]];
 true
 gap> InNeighbours(LatticeOfCongruences(S));
-[ [  ], [ 1, 3, 4 ], [ 1 ], [ 1, 3 ] ]
+[ [ 1 ], [ 1, 2, 3, 4 ], [ 1, 3 ], [ 1, 3, 4 ] ]
 gap> Size(CongruencesOfSemigroup(S));
 4
+gap> IsPartialOrderDigraph(l);
+true
 
 #T# LatticeOfLeft/RightCongruences with restriction
 gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
@@ -145,7 +157,9 @@ gap> latt := LatticeOfLeftCongruences(S, restriction);
 <poset of 5 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
 gap> InNeighbours(latt);
-[ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4 ] ]
+[ [ 1 ], [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 2, 3, 4, 5 ] ]
+gap> OutNeighbours(latt);
+[ [ 1 .. 5 ], [ 2, 5 ], [ 3, 5 ], [ 4, 5 ], [ 5 ] ]
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
 >                    Transformation([2, 2, 2])];;
@@ -153,7 +167,7 @@ gap> latt := LatticeOfRightCongruences(S, restriction);
 <poset of 4 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
 gap> InNeighbours(latt);
-[ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ] ]
+[ [ 1 ], [ 1, 2, 3, 4 ], [ 1, 3 ], [ 1, 4 ] ]
 gap> congs := CongruencesOfPoset(latt);;
 gap> Length(congs);
 4
@@ -164,13 +178,13 @@ gap> latt := LatticeOfCongruences(S, restriction);
 <poset of 2 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
 gap> InNeighbours(latt);
-[ [  ], [ 1 ] ]
+[ [ 1 ], [ 1, 2 ] ]
 gap> restriction := [Transformation([3, 3, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
 <poset of 1 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
 gap> InNeighbours(latt);
-[ [  ] ]
+[ [ 1 ] ]
 
 #T# LatticeOf(Left/Right)Congruences with invalid restriction
 gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
@@ -198,23 +212,23 @@ gap> poset := PosetOfPrincipalLeftCongruences(S);
 <poset of 12 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
 gap> InNeighbours(poset) =
-> [[8, 11], [], [1, 2, 8, 11, 12], [2, 7, 10, 11, 12], [2],
->   [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12], [10, 12], [11], [2, 11, 12],
->   [12], [], []];
+> [[1, 8, 11], [2], [1, 2, 3, 8, 11, 12], [2, 4, 7, 10, 11, 12], [2, 5],
+>   [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], [7, 10, 12], [8, 11],
+>   [2, 9, 11, 12], [10, 12], [11], [12]];
 true
 gap> poset := PosetOfPrincipalRightCongruences(S);
 <poset of 15 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
 gap> InNeighbours(poset) =
-> [[], [], [], [], [1, 4, 7, 13], [2, 4, 9, 11], [],
->   [3, 7, 9], [], [], [], [2, 7, 10], [], [1, 9, 10],
->   [1, 2, 3]];
+> [[1], [2], [3], [4], [1, 4, 5, 7, 13], [2, 4, 6, 9, 11], [7],
+>   [3, 7, 8, 9], [9], [10], [11], [2, 7, 10, 12], [13], [1, 9, 10, 14],
+>   [1, 2, 3, 15]];
 true
 gap> poset := PosetOfPrincipalCongruences(S);
 <poset of 3 congruences over <transformation semigroup of size 11, degree 3 
  with 2 generators>>
 gap> InNeighbours(poset);
-[ [ 2, 3 ], [  ], [ 2 ] ]
+[ [ 1, 2, 3 ], [ 2 ], [ 2, 3 ] ]
 gap> Print(poset, "\n");
 PosetOfCongruences( 
 [ SemigroupCongruence( Semigroup( [ Transformation( [ 1, 3, 1 ] ), 
@@ -238,7 +252,7 @@ gap> latt := PosetOfPrincipalLeftCongruences(S, restriction);
 <poset of 3 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
 gap> InNeighbours(latt);
-[ [  ], [  ], [  ] ]
+[ [ 1 ], [ 2 ], [ 3 ] ]
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
 >                    Transformation([2, 2, 2])];;
@@ -246,7 +260,7 @@ gap> latt := PosetOfPrincipalRightCongruences(S, restriction);
 <poset of 3 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
 gap> InNeighbours(latt);
-[ [ 2, 3 ], [  ], [  ] ]
+[ [ 1, 2, 3 ], [ 2 ], [ 3 ] ]
 gap> CongruencesOfPoset(latt);
 [ <right semigroup congruence over <transformation semigroup of degree 3 with 
      2 generators> with 1 generating pairs>, <right semigroup congruence over 
@@ -258,12 +272,14 @@ gap> latt := PosetOfPrincipalCongruences(S, restriction);
 <poset of 1 congruences over <transformation semigroup of degree 3 with 2 
  generators>>
 gap> InNeighbours(latt);
-[ [  ] ]
+[ [ 1 ] ]
 gap> restriction := [Transformation([3, 3, 3])];;
 gap> latt := PosetOfPrincipalCongruences(S, restriction);
 <empty congruence poset>
 gap> InNeighbours(latt);
 [  ]
+gap> IsPartialOrderDigraph(latt);
+true
 
 #T# PosetOfPrincipal(Left/Right)Congruences with invalid restriction
 gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
@@ -328,7 +344,8 @@ gap> l := LatticeOfCongruences(S);
 <poset of 6 congruences over <transformation semigroup of size 13, degree 3 
  with 2 generators>>
 gap> InNeighbours(l);
-[ [  ], [ 1, 5, 6 ], [ 1, 2, 4, 5, 6 ], [ 1, 2, 5, 6 ], [ 1, 6 ], [ 1 ] ]
+[ [ 1 ], [ 1, 2, 5, 6 ], [ 1, 2, 3, 4, 5, 6 ], [ 1, 2, 4, 5, 6 ], 
+  [ 1, 5, 6 ], [ 1, 6 ] ]
 gap> minl := MinimalLeftCongruencesOfSemigroup(S);;
 gap> Size(minl);
 3
@@ -363,7 +380,7 @@ gap> coll := [RightSemigroupCongruence(S, pair1),
 gap> l := JoinSemilatticeOfCongruences(coll, JoinRightSemigroupCongruences);
 <poset of 4 congruences over <symmetric inverse monoid of degree 2>>
 gap> InNeighbours(l);
-[ [  ], [  ], [ 1 ], [ 1, 2, 3 ] ]
+[ [ 1 ], [ 2 ], [ 1, 3 ], [ 1, 2, 3, 4 ] ]
 gap> JoinSemilatticeOfCongruences(coll, JoinLeftSemigroupCongruences);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `JoinLeftSemigroupCongruences' on 2 argu\
@@ -384,7 +401,7 @@ true
 gap> poset := LatticeOfCongruences(S);
 <poset of 4 congruences over <symmetric inverse monoid of degree 2>>
 gap> InNeighbours(poset);
-[ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ] ]
+[ [ 1 ], [ 1, 2 ], [ 1, 2, 3, 4 ], [ 1, 2, 4 ] ]
 gap> Print(l, "\n");
 PosetOfCongruences( 
 [ RightSemigroupCongruence( InverseMonoid( 
@@ -418,7 +435,7 @@ gap> poset := PosetOfCongruences(coll);
 <poset of 3 congruences over <regular transformation monoid of degree 2 with 
  2 generators>>
 gap> InNeighbours(poset);
-[ [ 3 ], [ 3 ], [  ] ]
+[ [ 1, 3 ], [ 2, 3 ], [ 3 ] ]
 
 #T# Trivial poset
 gap> poset := PosetOfCongruences([]);
@@ -438,7 +455,8 @@ gap> S := Semigroup(Transformation([2, 1, 4, 3, 5, 2]),
 >                   Transformation([5, 5, 5, 5, 5, 5]));;
 gap> l := LatticeOfCongruences(S);;
 gap> InNeighbours(l);
-[ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4, 6 ], [ 1, 2, 3, 4 ] ]
+[ [ 1 ], [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 2, 3, 4, 5, 6 ], 
+  [ 1, 2, 3, 4, 6 ] ]
 
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(S);

--- a/tst/standard/conglatt.tst
+++ b/tst/standard/conglatt.tst
@@ -29,19 +29,13 @@ first argument <S> must be an enumerable finite semigroup,
 #T# LatticeOfCongruences
 gap> S := PartitionMonoid(2);;
 gap> l := LatticeOfCongruences(S);
+<poset of 13 congruences over <regular bipartition *-monoid of size 15, 
+ degree 2 with 3 generators>>
+gap> OutNeighbours(l);
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ], [ 1, 3, 9 ], [ 1, 2, 3, 4, 5, 9, 10 ], 
   [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 ], [ 1, 3 ], [ 1 ], [ 1, 4, 9 ], 
   [ 1, 2, 3, 4, 8 ], [ 1, 3, 5, 8, 9 ], 
   [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12 ] ]
-gap> Print(l, "\n");
-[ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ], [ 1, 3, 9 ], [ 1, 2, 3, 4, 5, 9, 10 ], 
-  [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 ], [ 1, 3 ], [ 1 ], [ 1, 4, 9 ], 
-  [ 1, 2, 3, 4, 8 ], [ 1, 3, 5, 8, 9 ], 
-  [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12 ] ]
-gap> IsBound(l[4]);
-true
-gap> l[4];
-[ 1 ]
 gap> S := OrderEndomorphisms(2);;
 gap> CongruencesOfSemigroup(S);
 [ <semigroup congruence over <regular transformation monoid of size 3, 
@@ -51,7 +45,21 @@ gap> CongruencesOfSemigroup(S);
   <semigroup congruence over <regular transformation monoid of size 3, 
      degree 2 with 2 generators> with 1 generating pairs> ]
 gap> l := LatticeOfCongruences(S);
+<poset of 3 congruences over <regular transformation monoid of size 3, 
+ degree 2 with 2 generators>>
+gap> OutNeighbours(l);
 [ [  ], [ 1, 3 ], [ 1 ] ]
+gap> Print(l, "\n");
+PosetOfCongruences( 
+[ 
+  SemigroupCongruence( Monoid( 
+    [ Transformation( [ 1, 1 ] ), Transformation( [ 2, 2 ] ) ] ), [  ] ), 
+  SemigroupCongruence( Monoid( 
+    [ Transformation( [ 1, 1 ] ), Transformation( [ 2, 2 ] ) ] ), 
+    [ [ Transformation( [ 1, 1 ] ), IdentityTransformation ] ] ), 
+  SemigroupCongruence( Monoid( 
+    [ Transformation( [ 1, 1 ] ), Transformation( [ 2, 2 ] ) ] ), 
+    [ [ Transformation( [ 1, 1 ] ), Transformation( [ 2, 2 ] ) ] ] ) ] )
 gap> CongruencesOfPoset(l) = CongruencesOfSemigroup(S);
 true
 gap> DotString(l);
@@ -59,6 +67,9 @@ gap> DotString(l);
 gap> S := Semigroup([Transformation([1, 4, 3, 1, 4, 2]),
 >                    Transformation([1, 6, 6, 3, 6, 6])]);;
 gap> l := LatticeOfCongruences(S);
+<poset of 5 congruences over <transformation semigroup of size 48, degree 6 
+ with 2 generators>>
+gap> OutNeighbours(l);
 [ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ], [ 1, 2, 3, 4 ] ]
 gap> DotString(l, rec(info := true)) = Concatenation("//dot\ngraph graphname",
 > " {\n     node [shape=circle]\nR2 -- T\nR3 -- 4\n4 -- R2\nU -- R3\n }");
@@ -90,29 +101,37 @@ gap> Size(RightCongruencesOfSemigroup(S));
 
 #T# LatticeOfLeft/RightCongruences
 gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
-gap> LatticeOfLeftCongruences(S);
-[ [  ], [ 1, 9, 12 ], [ 1 ], [ 1, 2, 3, 9, 12, 13, 15, 17 ], 
-  [ 1, 3, 8, 11, 12, 13, 16, 17 ], [ 1, 3 ], 
-  [ 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 ], 
-  [ 1, 11, 13 ], [ 1, 12 ], [ 1, 3, 12, 13, 17 ], [ 1, 13 ], [ 1 ], [ 1 ], 
-  [ 1, 2, 3, 4, 9, 11, 12, 13, 15, 16, 17, 21 ], [ 1, 3, 9, 12, 13, 17 ], 
-  [ 1, 3, 11, 12, 13, 17 ], [ 1, 3, 12, 13 ], 
-  [ 1, 3, 5, 8, 9, 11, 12, 13, 15, 16, 17, 21 ], 
-  [ 1, 3, 6, 9, 10, 11, 12, 13, 15, 16, 17, 20, 21 ], [ 1, 3, 6, 12, 13, 17 ],
-  [ 1, 3, 9, 11, 12, 13, 15, 16, 17 ] ]
-gap> LatticeOfRightCongruences(S);
-[ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 5, 8, 14, 24 ], 
-  [ 1, 3, 5, 10, 12, 23 ], [ 1 ], [ 1, 4, 8, 10 ], [ 1 ], [ 1 ], [ 1 ], 
-  [ 1, 3, 8, 11 ], [ 1 ], [ 1, 2, 10, 11 ], [ 1, 2, 3, 4 ], 
-  [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 
-      22, 23, 24, 25, 26, 27, 28, 29, 30, 31 ], [ 1, 2, 12 ], [ 1, 3, 14 ], 
-  [ 1, 4, 5 ], [ 1, 4, 11, 12, 14, 29 ], [ 1, 5, 11 ], [ 1, 5, 12 ], 
-  [ 1, 5, 14 ], [ 1, 2, 5, 6, 8, 12, 14, 18, 23, 24, 27, 29, 31 ], 
-  [ 1, 3, 5, 7, 10, 12, 14, 19, 23, 24, 28, 29, 31 ], [ 1, 8, 12 ], 
-  [ 1, 10, 14 ], [ 1, 12, 14 ], 
-  [ 1, 4, 5, 11, 12, 14, 20, 21, 22, 23, 24, 29, 31 ], 
-  [ 1, 5, 12, 14, 23, 24, 29 ] ]
-gap> LatticeOfCongruences(S);
+gap> l := LatticeOfLeftCongruences(S);
+<poset of 21 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(l) =
+> [[], [1, 9, 12], [1], [1, 2, 3, 9, 12, 13, 15, 17],
+>   [1, 3, 8, 11, 12, 13, 16, 17], [1, 3],
+>   [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+>   [1, 11, 13], [1, 12], [1, 3, 12, 13, 17], [1, 13], [1], [1],
+>   [1, 2, 3, 4, 9, 11, 12, 13, 15, 16, 17, 21], [1, 3, 9, 12, 13, 17],
+>   [1, 3, 11, 12, 13, 17], [1, 3, 12, 13],
+>   [1, 3, 5, 8, 9, 11, 12, 13, 15, 16, 17, 21],
+>   [1, 3, 6, 9, 10, 11, 12, 13, 15, 16, 17, 20, 21], [1, 3, 6, 12, 13, 17],
+>   [1, 3, 9, 11, 12, 13, 15, 16, 17]];
+true
+gap> l := LatticeOfRightCongruences(S);
+<poset of 31 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(l) =
+> [[], [1], [1], [1], [1], [1, 2, 5, 8, 14, 24],
+>   [1, 3, 5, 10, 12, 23], [1], [1, 4, 8, 10], [1], [1], [1],
+>   [1, 3, 8, 11], [1], [1, 2, 10, 11], [1, 2, 3, 4],
+>   [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21,
+>       22, 23, 24, 25, 26, 27, 28, 29, 30, 31], [1, 2, 12], [1, 3, 14],
+>   [1, 4, 5], [1, 4, 11, 12, 14, 29], [1, 5, 11], [1, 5, 12],
+>   [1, 5, 14], [1, 2, 5, 6, 8, 12, 14, 18, 23, 24, 27, 29, 31],
+>   [1, 3, 5, 7, 10, 12, 14, 19, 23, 24, 28, 29, 31], [1, 8, 12],
+>   [1, 10, 14], [1, 12, 14],
+>   [1, 4, 5, 11, 12, 14, 20, 21, 22, 23, 24, 29, 31],
+>   [1, 5, 12, 14, 23, 24, 29]];
+true
+gap> OutNeighbours(LatticeOfCongruences(S));
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1, 3 ] ]
 gap> Size(CongruencesOfSemigroup(S));
 4
@@ -123,11 +142,17 @@ gap> restriction := Subsemigroup(S, [Transformation([1, 1, 1]),
 >                                    Transformation([2, 2, 2]),
 >                                    Transformation([3, 3, 3])]);;
 gap> latt := LatticeOfLeftCongruences(S, restriction);
+<poset of 5 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4 ] ]
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
 >                    Transformation([2, 2, 2])];;
 gap> latt := LatticeOfRightCongruences(S, restriction);
+<poset of 4 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ], [ 1, 3, 4 ], [ 1 ], [ 1 ] ]
 gap> congs := CongruencesOfPoset(latt);;
 gap> Length(congs);
@@ -136,9 +161,15 @@ gap> IsDuplicateFreeList(congs);
 true
 gap> restriction := [Transformation([3, 1, 3]), Transformation([3, 2, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
+<poset of 2 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ], [ 1 ] ]
 gap> restriction := [Transformation([3, 3, 3])];;
 gap> latt := LatticeOfCongruences(S, restriction);
+<poset of 1 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ] ]
 
 #T# LatticeOf(Left/Right)Congruences with invalid restriction
@@ -163,16 +194,38 @@ gap> Size(RightCongruencesOfSemigroup(S));
 
 #T# PosetOfPrincipalLeft/RightCongruences
 gap> S := Semigroup([Transformation([1, 3, 1]), Transformation([2, 3, 3])]);;
-gap> PosetOfPrincipalLeftCongruences(S);
-[ [ 8, 11 ], [  ], [ 1, 2, 8, 11, 12 ], [ 2, 7, 10, 11, 12 ], [ 2 ], 
-  [ 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12 ], [ 10, 12 ], [ 11 ], [ 2, 11, 12 ], 
-  [ 12 ], [  ], [  ] ]
-gap> PosetOfPrincipalRightCongruences(S);
-[ [  ], [  ], [  ], [  ], [ 1, 4, 7, 13 ], [ 2, 4, 9, 11 ], [  ], 
-  [ 3, 7, 9 ], [  ], [  ], [  ], [ 2, 7, 10 ], [  ], [ 1, 9, 10 ], 
-  [ 1, 2, 3 ] ]
-gap> PosetOfPrincipalCongruences(S);
+gap> poset := PosetOfPrincipalLeftCongruences(S);
+<poset of 12 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(poset) =
+> [[8, 11], [], [1, 2, 8, 11, 12], [2, 7, 10, 11, 12], [2],
+>   [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12], [10, 12], [11], [2, 11, 12],
+>   [12], [], []];
+true
+gap> poset := PosetOfPrincipalRightCongruences(S);
+<poset of 15 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(poset) =
+> [[], [], [], [], [1, 4, 7, 13], [2, 4, 9, 11], [],
+>   [3, 7, 9], [], [], [], [2, 7, 10], [], [1, 9, 10],
+>   [1, 2, 3]];
+true
+gap> poset := PosetOfPrincipalCongruences(S);
+<poset of 3 congruences over <transformation semigroup of size 11, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(poset);
 [ [ 2, 3 ], [  ], [ 2 ] ]
+gap> Print(poset, "\n");
+PosetOfCongruences( 
+[ SemigroupCongruence( Semigroup( [ Transformation( [ 1, 3, 1 ] ), 
+      Transformation( [ 2, 3, 3 ] ) ] ), 
+    [ [ Transformation( [ 1, 1, 1 ] ), Transformation( [ 1, 3, 1 ] ) ] ] ), 
+  SemigroupCongruence( Semigroup( [ Transformation( [ 1, 3, 1 ] ), 
+      Transformation( [ 2, 3, 3 ] ) ] ), 
+    [ [ Transformation( [ 1, 1, 1 ] ), Transformation( [ 2, 2, 2 ] ) ] ] ), 
+  SemigroupCongruence( Semigroup( [ Transformation( [ 1, 3, 1 ] ), 
+      Transformation( [ 2, 3, 3 ] ) ] ), 
+    [ [ Transformation( [ 1, 3, 3 ] ), Transformation( [ 3, 1, 1 ] ) ] ] ) ] )
 gap> Size(PrincipalCongruencesOfSemigroup(S));
 3
 
@@ -182,11 +235,17 @@ gap> restriction := Subsemigroup(S, [Transformation([1, 1, 1]),
 >                                    Transformation([2, 2, 2]),
 >                                    Transformation([3, 3, 3])]);;
 gap> latt := PosetOfPrincipalLeftCongruences(S, restriction);
+<poset of 3 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ], [  ], [  ] ]
 gap> restriction := [Transformation([3, 2, 3]),
 >                    Transformation([3, 1, 3]),
 >                    Transformation([2, 2, 2])];;
 gap> latt := PosetOfPrincipalRightCongruences(S, restriction);
+<poset of 3 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [ 2, 3 ], [  ], [  ] ]
 gap> CongruencesOfPoset(latt);
 [ <right semigroup congruence over <transformation semigroup of degree 3 with 
@@ -196,9 +255,14 @@ gap> CongruencesOfPoset(latt);
      semigroup of degree 3 with 2 generators> with 1 generating pairs> ]
 gap> restriction := [Transformation([3, 1, 3]), Transformation([3, 2, 3])];;
 gap> latt := PosetOfPrincipalCongruences(S, restriction);
+<poset of 1 congruences over <transformation semigroup of degree 3 with 2 
+ generators>>
+gap> OutNeighbours(latt);
 [ [  ] ]
 gap> restriction := [Transformation([3, 3, 3])];;
 gap> latt := PosetOfPrincipalCongruences(S, restriction);
+<empty congruence poset>
+gap> OutNeighbours(latt);
 [  ]
 
 #T# PosetOfPrincipal(Left/Right)Congruences with invalid restriction
@@ -261,9 +325,10 @@ gap> congs := CongruencesOfSemigroup(S);
   <semigroup congruence over <transformation semigroup of size 13, degree 3 
      with 2 generators> with 1 generating pairs> ]
 gap> l := LatticeOfCongruences(S);
+<poset of 6 congruences over <transformation semigroup of size 13, degree 3 
+ with 2 generators>>
+gap> OutNeighbours(l);
 [ [  ], [ 1, 5, 6 ], [ 1, 2, 4, 5, 6 ], [ 1, 2, 5, 6 ], [ 1, 6 ], [ 1 ] ]
-gap> Position(congs, min[1]) = Position(l, [1]);
-true
 gap> minl := MinimalLeftCongruencesOfSemigroup(S);;
 gap> Size(minl);
 3
@@ -295,7 +360,9 @@ gap> pair3 := [PartialPerm([1, 2], [1, 2]), PartialPerm([1, 2], [2, 1])];;
 gap> coll := [RightSemigroupCongruence(S, pair1),
 >             RightSemigroupCongruence(S, pair2),
 >             RightSemigroupCongruence(S, pair3)];;
-gap> JoinSemilatticeOfCongruences(coll, JoinRightSemigroupCongruences);
+gap> l := JoinSemilatticeOfCongruences(coll, JoinRightSemigroupCongruences);
+<poset of 4 congruences over <symmetric inverse monoid of degree 2>>
+gap> OutNeighbours(l);
 [ [  ], [  ], [ 1 ], [ 1, 2, 3 ] ]
 gap> JoinSemilatticeOfCongruences(coll, JoinLeftSemigroupCongruences);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
@@ -315,7 +382,25 @@ true
 gap> MinimalCongruences(PosetOfCongruences(coll)) = coll{[1, 2]};
 true
 gap> poset := LatticeOfCongruences(S);
+<poset of 4 congruences over <symmetric inverse monoid of degree 2>>
+gap> OutNeighbours(poset);
 [ [  ], [ 1 ], [ 1, 2, 4 ], [ 1, 2 ] ]
+gap> Print(l, "\n");
+PosetOfCongruences( 
+[ RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 2 ], [ 1 ] ) ] ] ), 
+  RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 1, 2 ], [ 1, 2 ] ) ] ] ), 
+  RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1, 2 ], [ 1, 2 ] ), PartialPerm( [ 1, 2 ], [ 2, 1 ] ) 
+         ] ] ), RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 2 ], [ 1 ] ) ], 
+      [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 1, 2 ], [ 1, 2 ] ) ] ] ) 
+ ] )
 gap> MinimalCongruences(poset);
 [ <semigroup congruence over <symmetric inverse monoid of degree 2> with 
     0 generating pairs> ]
@@ -329,18 +414,21 @@ gap> pair2 := [IdentityTransformation, Transformation([2, 2])];;
 gap> coll := [RightSemigroupCongruence(S, pair1),
 >             RightSemigroupCongruence(S, pair2),
 >             RightSemigroupCongruence(S, [])];;
-gap> PosetOfCongruences(coll);
+gap> poset := PosetOfCongruences(coll);
+<poset of 3 congruences over <regular transformation monoid of degree 2 with 
+ 2 generators>>
+gap> OutNeighbours(poset);
 [ [ 3 ], [ 3 ], [  ] ]
 
 #T# Trivial poset
 gap> poset := PosetOfCongruences([]);
-[  ]
+<empty congruence poset>
 gap> CongruencesOfPoset(poset);
 [  ]
 gap> Size(poset);
 0
 gap> JoinSemilatticeOfCongruences(poset, JoinSemigroupCongruences);
-[  ]
+<empty congruence poset>
 gap> MinimalCongruences(poset);
 [  ]
 
@@ -348,7 +436,8 @@ gap> MinimalCongruences(poset);
 gap> S := Semigroup(Transformation([2, 1, 4, 3, 5, 2]),
 >                   Transformation([3, 4, 1, 2, 5, 3]),
 >                   Transformation([5, 5, 5, 5, 5, 5]));;
-gap> LatticeOfCongruences(S);
+gap> l := LatticeOfCongruences(S);;
+gap> OutNeighbours(l);
 [ [  ], [ 1 ], [ 1 ], [ 1 ], [ 1, 2, 3, 4, 6 ], [ 1, 2, 3, 4 ] ]
 
 #T# SEMIGROUPS_UnbindVariables

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1365,7 +1365,8 @@ gap> AsList(JonesMonoid(1));
 
 #T# Kernel-trace methods should only be selected for semigroups with inverse op
 gap> S := HallMonoid(2);;
-gap> latt := LatticeOfCongruences(S);
+gap> latt := LatticeOfCongruences(S);;
+gap> OutNeighbours(latt);
 [ [  ], [ 1, 3, 4 ], [ 1, 4 ], [ 1 ] ]
 
 # Test bug in \in for high degree transformation semigroup

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1367,7 +1367,9 @@ gap> AsList(JonesMonoid(1));
 gap> S := HallMonoid(2);;
 gap> latt := LatticeOfCongruences(S);;
 gap> InNeighbours(latt);
-[ [  ], [ 1, 3, 4 ], [ 1, 4 ], [ 1 ] ]
+[ [ 1 ], [ 1, 2, 3, 4 ], [ 1, 3, 4 ], [ 1, 4 ] ]
+gap> IsPartialOrderDigraph(latt);
+true
 
 # Test bug in \in for high degree transformation semigroup
 gap> S := Semigroup(Transformation([4, 3, 2, 1]),

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1366,7 +1366,7 @@ gap> AsList(JonesMonoid(1));
 #T# Kernel-trace methods should only be selected for semigroups with inverse op
 gap> S := HallMonoid(2);;
 gap> latt := LatticeOfCongruences(S);;
-gap> OutNeighbours(latt);
+gap> InNeighbours(latt);
 [ [  ], [ 1, 3, 4 ], [ 1, 4 ], [ 1 ] ]
 
 # Test bug in \in for high degree transformation semigroup


### PR DESCRIPTION
This probably should've been the case when the object was first created.  A poset of semigroup congruences is a digraph with vertices labelled by the congruences themselves.  An edge `i -> j` exists if congruence ~~`i`~~ `j` is a subrelation (a refinement) of congruence ~~`j`~~ `i`.

This is in reference to Issue #369.

**EDIT:** `i` and `j` reversed.