### PR TITLE
Set `IdempotentGeneratedSubsemigroup` to be a semilattice, if possible

### DIFF
--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -557,6 +557,10 @@ function(S)
   fi;
   out := Semigroup(Idempotents(S), rec(small := true));
   SetIsIdempotentGenerated(out, true);
+  if HasIsSemigroupWithCommutingIdempotents(S)
+      and IsSemigroupWithCommutingIdempotents(S) then
+    SetIsSemigroupWithCommutingIdempotents(out, true);
+  fi;
   return out;
 end);
 

--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -74,6 +74,8 @@ InstallTrueMethod(IsRightSimple, IsInverseSemigroup and IsGroupAsSemigroup);
 InstallTrueMethod(IsRTrivial, IsInverseSemigroup and IsLTrivial);
 InstallTrueMethod(IsRTrivial, IsDTrivial);
 InstallTrueMethod(IsSemilattice, IsDTrivial and IsInverseSemigroup);
+InstallTrueMethod(IsSemilattice, IsIdempotentGenerated and
+                                 IsSemigroupWithCommutingIdempotents);
 InstallTrueMethod(IsMonogenicInverseSemigroup,
                   IsInverseSemigroup and IsMonogenicSemigroup);
 InstallTrueMethod(IsZeroRectangularBand, IsZeroGroup);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -747,13 +747,34 @@ gap> S := RegularBooleanMatMonoid(3);;
 gap> StructureDescriptionMaximalSubgroups(S);
 [ "1", "C2", "S3" ]
 
-#T# attr: IdempotentGeneratedSubsemigroup
+#T# attr: IdempotentGeneratedSubsemigroup, 1
 gap> S := RegularBooleanMatMonoid(3);;
 gap> T := IdempotentGeneratedSubsemigroup(S);;
 gap> HasIsIdempotentGenerated(T) and IsIdempotentGenerated(T);
 true
 gap> Size(T);
 381
+
+#T# attr: IdempotentGeneratedSubsemigroup, 2
+gap> S := SymmetricInverseMonoid(3);;
+gap> T := IdempotentGeneratedSubsemigroup(S);;
+gap> HasIsSemilattice(T) and IsSemilattice(T);
+true
+gap> S := AsSemigroup(IsTransformationSemigroup, S);;
+gap> IsInverseSemigroup(S);
+true
+gap> T := IdempotentGeneratedSubsemigroup(S);;
+gap> HasIsSemilattice(T) and IsSemilattice(T);
+true
+gap> S := Semigroup([
+>  PartialPerm([1, 3], [5, 4]),
+>  PartialPerm([1, 2, 5], [1, 4, 5]),
+>  PartialPerm([1, 3, 4], [3, 4, 5])]);;
+gap> T := IdempotentGeneratedSubsemigroup(S);;
+gap> IsInverseSemigroup(S);
+false
+gap> HasIsSemilattice(T) and IsSemilattice(T);
+true
 
 #T# attr: InjectionPrincipalFactor
 gap> S := Monoid([BooleanMat([[1, 0, 1], [0, 1, 0], [0, 0, 1]]),

--- a/tst/standard/attract.tst
+++ b/tst/standard/attract.tst
@@ -71,7 +71,7 @@ gap> StructureDescriptionSchutzenbergerGroups(S);
 gap> S := Semigroup([PartialPerm([1, 2, 3], [2, 5, 3]),
 > PartialPerm([1, 2, 3, 4], [2, 4, 1, 5])]);;
 gap> IdempotentGeneratedSubsemigroup(S);
-<partial perm monoid of rank 1 with 2 generators>
+<inverse partial perm monoid of rank 1 with 2 generators>
 
 #T# attract: IdempotentGeneratedSubsemigroup, for an inverse semigroup
 gap> S := InverseSemigroup([PartialPerm([1, 2], [4, 3]),

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -693,7 +693,7 @@ TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLPADDING=\"10\" CELLSPACING=\"0\" PORT=\
  BGCOLOR=\"gray\" PORT=\"e1\">*</TD></TR>\n</TABLE>>];\n1 -> 2\n2 -> 3\n3 -> 4\
 \nedge [color=blue,arrowhead=none,style=dashed]\n3:e2 -> 4:e1\n3:e3 -> 4:e1\n2\
 :e4 -> 3:e2\n2:e4 -> 3:e3\n3:e5 -> 4:e1\n2:e6 -> 3:e3\n2:e6 -> 3:e5\n2:e7 -> 3\
-:e5\n1:e8 -> 2:e4\n1:e8 -> 2:e6\n1:e8 -> 2:e7\n }"
+:e2\n2:e7 -> 3:e5\n1:e8 -> 2:e4\n1:e8 -> 2:e6\n1:e8 -> 2:e7\n }"
 
 # DotSemilatticeOfIdempotents
 gap> S := Semigroup(SymmetricInverseMonoid(3), rec(acting := true));;


### PR DESCRIPTION
If a semigroup has commuting idempotents, then its idempotent generated subsemigroup is commutative, and is therefore a band. In other words, it's a semilattice.

We should set this information if we already know that the semigroup has commuting idempotents (for instance, if it's any partial perm semigroup).