### PR TITLE
Add generic method for NrEquivalenceClasses for a semigroup congruence

### DIFF
--- a/gap/congruences/cong.gi
+++ b/gap/congruences/cong.gi
@@ -21,6 +21,14 @@
 ## cong.gd contains declarations for many of these.
 ##
 
+# Fallback method
+
+InstallMethod(NrEquivalenceClasses, "for a semigroup congruence",
+[IsSemigroupCongruence],
+function(cong)
+  return Length(EquivalenceClasses(cong));
+end);
+
 InstallMethod(\in,
 "for dense list and left semigroup congruence",
 [IsDenseList, IsLeftSemigroupCongruence],

--- a/tst/standard/cong.tst
+++ b/tst/standard/cong.tst
@@ -570,6 +570,18 @@ gap> Length(lookup1);
 gap> lookup1 = lookup2;
 true
 
+# Issue 393, missing method for NrEquivalenceClasses for a generic semigroup
+# congruence
+gap> f := FreeGroup("a");;
+gap> g := f / [f.1 ^ 4];;
+gap> phi := InjectionZeroMagma(g);;
+gap> m := Range(phi);;
+gap> el := Elements(m);;
+gap> c := MagmaCongruenceByGeneratingPairs(m, [[el[2], el[3]]]);;
+gap> EquivalenceRelationPartition(c);;
+gap> IsReesCongruence(c);
+false
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(F);
 gap> Unbind(I);


### PR DESCRIPTION
This commit fixes a diff in GAP's `tst/testinstall/semigrp.tst`, caused by
there being not method for `NrEquivalenceClasses` for some types of
congruences. This commit provides a fallback method for
`NrEquivalenceClasses`.

This addresses part of Issue #395.