### PR TITLE
Add SEMIGROUPS.StopTest() to standard/semieunit.tst

### DIFF
--- a/tst/standard/semieunit.tst
+++ b/tst/standard/semieunit.tst
@@ -9,7 +9,6 @@
 ##
 gap> START_TEST("Semigroups package: standard/semieunit.tst");
 gap> LoadPackage("semigroups", false);;
-gap> LoadPackage("Digraphs", false);;
 
 # Set info levels and user preferences
 gap> SEMIGROUPS.StartTest();
@@ -333,4 +332,5 @@ gap> Unbind(y2);
 gap> Unbind(y3);
 
 #E#
-gap> STOP_TEST("Semigroups package: standard/eunittest.tst");
+gap> SEMIGROUPS.StopTest();
+gap> STOP_TEST("Semigroups package: standard/semieunit.tst");


### PR DESCRIPTION
The usual `gap> SEMIGROUPS.StopTest();` line was missing from `standard/semieunit.tst`. This was causing problems since, by default, `InfoWarning` has level `1` in GAP, but after running this test file, it has level `0`. There are test files in GAP (eg `tst/testinstall/function.tst`) that assume that `InfoWarning` is at least `1` (which is not a good idea, but never mind). This was causing problems when I tried to add `testinstall.g` to Travis.

Additionally, I fixed a string, and removed a redundant line.