### PR TITLE
Make changes to remove diffs in GAP tests and manual examples

### DIFF
--- a/gap/semigroups/semigrp.gi
+++ b/gap/semigroups/semigrp.gi
@@ -394,13 +394,12 @@ function(gens, opts)
   S := Objectify(NewType(FamilyObj(gens), filts), rec(opts := opts));
   SetOne(S, One(gens));
 
-  if CanEasilyCompareElements(gens) and not One(gens) in gens then
-    SetGeneratorsOfInverseSemigroup(S, Concatenation([One(gens)], gens));
+  SetGeneratorsOfInverseMonoid(S, AsList(gens));
+  if not CanEasilyCompareElements(gens) or not One(gens) in gens then
+    SetGeneratorsOfInverseSemigroup(S, Concatenation(gens, [One(gens)]));
   else
     SetGeneratorsOfInverseSemigroup(S, AsList(gens));
   fi;
-  SetGeneratorsOfInverseMonoid(S, AsList(gens));
-
   return S;
 end);
 

--- a/tst/extreme/semigroups.tst
+++ b/tst/extreme/semigroups.tst
@@ -166,8 +166,8 @@ gap> s := InverseMonoid(PartialPermNC([1, 2, 3, 5], [5, 6, 8, 2]),
 gap> Generators(s);
 [ [1,5,2,6][3,8], [3,1,7][10,4](2)(5)(9) ]
 gap> GeneratorsOfInverseSemigroup(s);
-[ <identity partial perm on [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]>, 
-  [1,5,2,6][3,8], [3,1,7][10,4](2)(5)(9) ]
+[ [1,5,2,6][3,8], [3,1,7][10,4](2)(5)(9), 
+  <identity partial perm on [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]> ]
 gap> GeneratorsOfInverseMonoid(s);
 [ [1,5,2,6][3,8], [3,1,7][10,4](2)(5)(9) ]
 gap> GeneratorsOfSemigroup(s);

--- a/tst/standard/factor.tst
+++ b/tst/standard/factor.tst
@@ -205,10 +205,15 @@ gap> Factorization(S, x);
 #T# factor: test for use of minimal factorization it is known, regular.
 gap> S := SymmetricInverseMonoid(6);;
 gap> x := PartialPerm([1, 2, 5], [6, 2, 4]);;
+gap> GeneratorsOfSemigroup(S);
+[ <identity partial perm on [ 1, 2, 3, 4, 5, 6 ]>, (1,2,3,4,5,6), 
+  (1,2)(3)(4)(5)(6), [6,5,4,3,2,1], [1,2,3,4,5,6] ]
 gap> MinimalFactorization(S, x);
 [ 5, 2, 5, 5, 2, 3 ]
 gap> Factorization(S, x);
 [ 5, 2, 5, 5, 2, 3 ]
+gap> EvaluateWord(GeneratorsOfSemigroup(S), last) = x;
+true
 
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(S);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -613,9 +613,9 @@ gap> GeneratorsOfInverseMonoid(T) =
 >   PartialPerm([1, 2, 3, 4, 6], [2, 5, 4, 1, 3])];
 true
 gap> GeneratorsOfInverseSemigroup(T) =
-> [PartialPerm([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]),
->  PartialPerm([1, 2, 4, 5, 6], [1, 2, 4, 5, 6]),
->  PartialPerm([1, 2, 3, 4, 6], [2, 5, 4, 1, 3])];
+> [PartialPerm([1, 2, 4, 5, 6], [1, 2, 4, 5, 6]),
+>  PartialPerm([1, 2, 3, 4, 6], [2, 5, 4, 1, 3]),
+>  PartialPerm([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6])];
 true
 gap> One(S) in T;
 true


### PR DESCRIPTION
This removes some diffs in the GAP manual examples that occur when the Semigroups package is loaded. As a result of this change, I had to change some of the Semigroups package tests, but not many.

Additionally, for GeneratorsOfInverseSemigroup, we always add the One if the semigroup does not have easily comparable elements (we never added it before - which was a bug). When we're adding the One, we add it to the end of the list of GeneratorsOfInverseMonoid, rather than to the beginning, to resolve some diffs.