### PR TITLE
Run testinstall.g from GAP in the Travis setup

### DIFF
--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -22,48 +22,45 @@ elif [ ! -z "$GAP_BRANCH" ]; then
 
   # Work out the Digraphs versions/branches in which to run the tests
   if [ ! -z "$DIGRAPHS_BR" ]; then
-    DIGRAPHS_BRANCHES=($DIGRAPHS_BR)
+    DIGRAPHS_BRANCH=$DIGRAPHS_BR
   else
     cd $GAP_DIR/pkg/semigroups
-    DIGRAPHS_VERS=v`grep "\"digraphs\"" PackageInfo.g| awk -F'"' '{print $4}' | cut -c3-`
-    DIGRAPHS_BRANCHES=("master" "$DIGRAPHS_VERS")
+    DIGRAPHS_BRANCH=v`grep "\"digraphs\"" PackageInfo.g| awk -F'"' '{print $4}' | cut -c3-`
   fi
 
-  for DIGRAPHS_BRANCH in "${DIGRAPHS_BRANCHES[@]}"; do
-    echo -e "\nRunning tests with Digraphs package in $DIGRAPHS_BRANCH..."
-    cd $GAP_DIR/pkg/digraphs
-    git checkout $DIGRAPHS_BRANCH
-    echo "Compiling Digraphs..."
-    ./autogen.sh
-    ./configure $PKG_FLAGS
-    make
-    cd $GAP_DIR/pkg/semigroups
+  echo -e "\nRunning tests with Digraphs package in $DIGRAPHS_BRANCH..."
+  cd $GAP_DIR/pkg/digraphs
+  git checkout $DIGRAPHS_BRANCH
+  echo "Compiling Digraphs..."
+  ./autogen.sh
+  ./configure $PKG_FLAGS
+  make
+  cd $GAP_DIR/pkg/semigroups
 
-    if [ ! -z "$COVERAGE" ]; then
+  if [ ! -z "$COVERAGE" ]; then
 
-      echo -e "\nPerforming code coverage tests..."
-      for TESTFILE in tst/standard/*.tst; do
-        FILENAME=${TESTFILE##*/}
-        if [ ! `grep -E "$FILENAME" .covignore` ]; then
-          ../digraphs/scripts/travis-coverage.py $TESTFILE $THRESHOLD | tee -a $TESTLOG
-        else
-          echo -e "\033[35mignoring $FILENAME, since it is listed in .covignore\033[0m"
-        fi
-      done
+    echo -e "\nPerforming code coverage tests..."
+    for TESTFILE in tst/standard/*.tst; do
+      FILENAME=${TESTFILE##*/}
+      if [ ! `grep -E "$FILENAME" .covignore` ]; then
+        ../digraphs/scripts/travis-coverage.py $TESTFILE $THRESHOLD | tee -a $TESTLOG
+      else
+        echo -e "\033[35mignoring $FILENAME, since it is listed in .covignore\033[0m"
+      fi
+    done
 
-    else
-      # Run the SaveWorkspace tests
-      cd tst/workspaces
-      echo -e "\nRunning SaveWorkspace tests..."
-      echo "LoadPackage(\"semigroups\", false); SemigroupsTestInstall(); Test(\"save-workspace.tst\"); quit; quit; quit;" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee -a $TESTLOG
-      echo "Test(\"load-workspace.tst\"); SemigroupsTestInstall(); quit; quit; quit;" | $GAP_DIR/bin/gap.sh -L test-output.w -A -r -m 1g -T 2>&1 | tee -a $TESTLOG
-      rm test-output.w
-      cd ../..
-      # Run all tests and manual examples
-      echo -e "\nRunning tests and manual examples..."
-      echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples(); Read(\"$GAP_DIR/tst/testinstall.g\");" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee $TESTLOG
-    fi
-  done
+  else
+    # Run the SaveWorkspace tests
+    cd tst/workspaces
+    echo -e "\nRunning SaveWorkspace tests..."
+    echo "LoadPackage(\"semigroups\", false); SemigroupsTestInstall(); Test(\"save-workspace.tst\"); quit; quit; quit;" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee -a $TESTLOG
+    echo "Test(\"load-workspace.tst\"); SemigroupsTestInstall(); quit; quit; quit;" | $GAP_DIR/bin/gap.sh -L test-output.w -A -r -m 1g -T 2>&1 | tee -a $TESTLOG
+    rm test-output.w
+    cd ../..
+    # Run all tests and manual examples
+    echo -e "\nRunning tests and manual examples..."
+    echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples(); Read(\"$GAP_DIR/tst/testinstall.g\");" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee $TESTLOG
+  fi
 fi
 
 ( ! grep -E "Diff|brk>|#E|Error|Errors detected|# WARNING|fail|Syntax warning|Couldn't open saved workspace|insufficient|WARNING in|FAILED|Total errors found:" $TESTLOG )

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -61,9 +61,9 @@ elif [ ! -z "$GAP_BRANCH" ]; then
       cd ../..
       # Run all tests and manual examples
       echo -e "\nRunning tests and manual examples..."
-      echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples(); quit; quit; quit;" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee $TESTLOG
+      echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples(); Read(\"$GAP_DIR/tst/testinstall.g\");" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee $TESTLOG
     fi
   done
 fi
 
-( ! grep -E "Diff|brk>|#E|Error|error|# WARNING|fail|Syntax warning|Couldn't open saved workspace|insufficient|WARNING in|FAILED|Total errors found:" $TESTLOG )
+( ! grep -E "Diff|brk>|#E|Error|Errors detected|# WARNING|fail|Syntax warning|Couldn't open saved workspace|insufficient|WARNING in|FAILED|Total errors found:" $TESTLOG )


### PR DESCRIPTION
We should run some of the GAP tests so that we make sure we're not breaking things in GAP when the Semigroups package is loaded. As a start, we can try running testinstall.g. In the future, maybe we'd want to consider running more of the GAP tests or manual examples.

This will fail until my related PR to GAP is merged, and my related PR to Semigroups is merged, and this is either merged in, or rebased on top of that.