### PR TITLE
Adjust iterators for T_n and I_n

### DIFF
--- a/gap/tools/iterators.gi
+++ b/gap/tools/iterators.gi
@@ -663,6 +663,12 @@ InstallMethod(Iterator, "for a full transformation semigroup",
 7, #to beat the method for acting semigroups TODO check this is necessary!!
 function(S)
   local iter;
+
+  if HasAsSSortedList(S) or HasAsListCanonical(S) then
+    # This is much faster
+    TryNextMethod();
+  fi;
+
   iter := IteratorByFunctions(rec(
     tups := IteratorOfTuples([1 .. DegreeOfTransformationSemigroup(S)],
                              DegreeOfTransformationSemigroup(S)),
@@ -690,6 +696,11 @@ InstallMethod(Iterator, "for a symmetric inverse semigroup",
  and HasGeneratorsOfSemigroup],
 function(s)
   local deg, record, iter;
+
+  if HasAsSSortedList(s) or HasAsListCanonical(s) then
+    # This is much faster
+    TryNextMethod();
+  fi;
 
   deg := DegreeOfPartialPermSemigroup(s);
 

--- a/tst/standard/semipperm.tst
+++ b/tst/standard/semipperm.tst
@@ -2077,6 +2077,16 @@ MappingByFunction( <inverse partial perm monoid of rank 25 with 3 generators>
  , <inverse partial perm semigroup of rank 6 with 3 generators>
  , function( x ) ... end, function( x ) ... end )
 
+#T# Iterator, for a symmetric inverse monoid
+gap> S := SymmetricInverseMonoid(4);;
+gap> y := Iterator(S);
+<iterator of semigroup>
+gap> for x in y do od;
+gap> S := SymmetricInverseMonoid(4);; Elements(S);;
+gap> y := Iterator(S);
+<iterator>
+gap> for x in y do od;
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(F);
 gap> Unbind(H1);

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -2791,6 +2791,16 @@ gap> DigraphOfActionOnPairs(S);
 gap> DigraphOfActionOnPairs(S, 3);
 <digraph with 6 vertices, 9 edges>
 
+#T# Iterator, for a full transformation monoid
+gap> S := FullTransformationMonoid(4);;
+gap> y := Iterator(S);
+<iterator of semigroup>
+gap> for x in y do od;
+gap> S := FullTransformationMonoid(4);; Elements(S);;
+gap> y := Iterator(S);
+<iterator>
+gap> for x in y do od;
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(BruteForceInverseCheck);


### PR DESCRIPTION
We've long had a card on Trello about why this distinction exists:
```
gap> S := FullTransformationMonoid(7);; Elements(S);;
gap> for x in S do od; time;
1158
gap> for x in Elements(S) do od; time;
21
```
You might hope that these would take the same time.

This difference is simply related to the speed of looping over an iterator as opposed to an enumerator:
```
gap> S := FullTransformationMonoid(7);; Elements(S);;
gap> for x in S do od; time;
1158
gap> for x in Iterator(S) do od; time;
1297
gap> for x in Elements(S) do od; time;
21
gap> for x in Enumerator(S) do od; time;
20
```
For full transformation semigroups, there is (sensibly) a special method for `Iterator` for full transformation semigroups, which allows us to iterator over any full transformation semigroup, basically, no matter how big. However, when we have the elements, this method is a lot slower than simply making an iterator out of the list of elements (which is what the normal `Iterator` methods do in this case). I've made this change. This is the performance now:
```
gap> S := FullTransformationMonoid(7);; Elements(S);;
gap> for x in S do od; time;
334
gap> for x in Iterator(S) do od; time;
352
gap> for x in Elements(S) do od; time;
20
gap> for x in Enumerator(S) do od; time;
20
```
Which is a decent speed-up. I've done the same for symmetric inverse monoids. Before:
```
gap> S := SymmetricInverseMonoid(8);; Elements(S);;
gap> for x in S do od; time;
22141
gap> for x in Elements(S) do od; time;
33
```
After:
```
gap> S := SymmetricInverseMonoid(8);; Elements(S);;
gap> for x in S do od; time;
587
gap> for x in Elements(S) do od; time;
32
```
This is basically as fast as we can make the iterator, however, so we'll have to live with the difference.