### PR TITLE
Better info warnings for congruence lattices

### DIFF
--- a/gap/congruences/conginv.gi
+++ b/gap/congruences/conginv.gi
@@ -635,9 +635,9 @@ SEMIGROUPS.KernelTraceClosure := function(S, kernel, traceBlocks, pairstoapply)
     enumerate_trace();
     trace_unchanged := (oldLookup = UF_TABLE(traceUF));
     kernel_unchanged := (oldKernel = kernel);
-    Info(InfoSemigroups, 2, "lookup: ", trace_unchanged);
-    Info(InfoSemigroups, 2, "kernel: ", kernel_unchanged);
-    Info(InfoSemigroups, 2, "nrk = 0: ", nrk = 0);
+    Info(InfoSemigroups, 3, "lookup: ", trace_unchanged);
+    Info(InfoSemigroups, 3, "kernel: ", kernel_unchanged);
+    Info(InfoSemigroups, 3, "nrk = 0: ", nrk = 0);
   until trace_unchanged and kernel_unchanged and (nrk = 0);
 
   # Convert traceLookup to traceBlocks

--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -208,6 +208,8 @@ function(poset, join_func)
           found := true;
         fi;
       od;
+      Info(InfoSemigroups, 2, "Processed cong ", i, " of ", Length(congs),
+           " (", Length(congs) - i, " remaining)");
     od;
   od;
 


### PR DESCRIPTION
@ChristopherRussell was having trouble knowing how his calculation was coming along when calculating the join semilattice of a bunch of congruences he was playing with.  So I thought I'd add an info warning showing how the process is coming along:

```
gap> S := RandomSemigroup(IsTransformationSemigroup, 2, 5); Size(S);
<transformation semigroup of degree 5 with 2 generators>
59
gap> latt := LatticeOfCongruences(S);
#I  Finding principal congruences . . .
#I  at least one H-class is not a subgroup
#I  the numbers of lambda and rho values are not equal
#I  Finding joins of congruences . . .
#I  Processed cong 1 of 20 (19 remaining)
#I  Processed cong 2 of 23 (21 remaining)
#I  Processed cong 3 of 26 (23 remaining)
#I  Processed cong 4 of 28 (24 remaining)
#I  Processed cong 5 of 28 (23 remaining)
#I  Processed cong 6 of 28 (22 remaining)
#I  Processed cong 7 of 29 (22 remaining)
#I  Processed cong 8 of 29 (21 remaining)
#I  Processed cong 9 of 29 (20 remaining)
#I  Processed cong 10 of 29 (19 remaining)
#I  Processed cong 11 of 29 (18 remaining)
#I  Processed cong 12 of 29 (17 remaining)
#I  Processed cong 13 of 31 (18 remaining)
#I  Processed cong 14 of 31 (17 remaining)
#I  Processed cong 15 of 31 (16 remaining)
#I  Processed cong 16 of 31 (15 remaining)
#I  Processed cong 17 of 31 (14 remaining)
#I  Processed cong 18 of 31 (13 remaining)
#I  Processed cong 19 of 31 (12 remaining)
#I  Processed cong 20 of 31 (11 remaining)
#I  Processed cong 21 of 31 (10 remaining)
#I  Processed cong 22 of 31 (9 remaining)
#I  Processed cong 23 of 31 (8 remaining)
#I  Processed cong 24 of 31 (7 remaining)
#I  Processed cong 25 of 31 (6 remaining)
#I  Processed cong 26 of 31 (5 remaining)
#I  Processed cong 27 of 31 (4 remaining)
#I  Processed cong 28 of 31 (3 remaining)
#I  Processed cong 29 of 31 (2 remaining)
#I  Processed cong 30 of 31 (1 remaining)
#I  Processed cong 31 of 31 (0 remaining)
<poset of 32 congruences over <transformation semigroup of size 59, degree 5 with 2 generators>>
```
That's showing how many congruences have been checked for joins, how many congruences have been found in total, and how many still need to be checked.  The process ends when the number remaining gets to zero.

This is fairly verbose, so I've set it to level 2.  I also downgraded some `conginv` stuff to level 3, since it's mostly not too useful, and it clashes badly with this.