### PR TITLE
Add SemigroupsTestAll

### DIFF
--- a/doc/utils.xml
+++ b/doc/utils.xml
@@ -91,6 +91,24 @@
   </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="SemigroupsTestAll">
+  <ManSection>
+    <Func Name = "SemigroupsTestAll" Arg = ""/>
+    <Returns><K>true</K> or <K>false</K>.</Returns>
+    <Description>
+      This function should be called with no argument to compile the
+      &Semigroups; package's documentation, run the standard suite of tests, and
+      run all the examples from the documentation to ensure that their output is
+      correct.  The value returned is <K>true</K> if all the tests succeed, and
+      <K>false</K> otherwise.  The whole process should take no more than a few
+      minutes. <P/>
+
+      See <Ref Func = "SemigroupsMakeDoc"/>
+      and <Ref Func = "SemigroupsTestStandard"/>.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="InfoSemigroups">
   <ManSection>
     <InfoClass Name = "InfoSemigroups"/>

--- a/doc/z-chap02.xml
+++ b/doc/z-chap02.xml
@@ -185,6 +185,7 @@ make]]></Listing>
     <#Include Label = "SemigroupsTestInstall">
     <#Include Label = "SemigroupsTestStandard">
     <#Include Label = "SemigroupsTestExtreme">
+    <#Include Label = "SemigroupsTestAll">
 
   </Section>
 

--- a/gap/tools/utils.gd
+++ b/gap/tools/utils.gd
@@ -12,5 +12,6 @@ DeclareGlobalFunction("SemigroupsMakeDoc");
 DeclareGlobalFunction("SemigroupsTestInstall");
 DeclareGlobalFunction("SemigroupsTestStandard");
 DeclareGlobalFunction("SemigroupsTestExtreme");
+DeclareGlobalFunction("SemigroupsTestAll");
 
 SEMIGROUPS.OmitFromTests := [];

--- a/gap/tools/utils.gi
+++ b/gap/tools/utils.gi
@@ -463,6 +463,16 @@ function()
                                   "testinstall.tst"));
 end);
 
+InstallGlobalFunction(SemigroupsTestAll,
+function()
+  local success;
+  SemigroupsMakeDoc();
+  # Return true if both test suites succeed, but run both anyway
+  success := IsEmpty(SemigroupsTestStandard()[1]);
+  success := SEMIGROUPS.TestManualExamples() and success;
+  return success;
+end);
+
 # The following is based on doc/ref/testconsistency.g
 
 # Detect which ManSection should be used to document obj. Returns one of

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -46,7 +46,7 @@ elif [ ! -z "$GAP" ]; then
     cd ../..
     # Run all tests and manual examples
     echo -e "\nRunning tests and manual examples..."
-    echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples();" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee $TESTLOG
+    echo "LoadPackage(\"semigroups\"); SemigroupsTestAll();" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee $TESTLOG
     if [ ! "$ABI" == "32" ]; then
       echo "LoadPackage(\"semigroups\"); Read(\"$GAP_DIR/tst/testinstall.g\");" | $GAP_DIR/bin/gap.sh -A -x 80 -r -m 100m -o 1g -K 2g -T 2>&1 | tee $TESTLOG
     fi


### PR DESCRIPTION
This is in reference to Issue #372, adding `SemigroupsTestAll`, a function which runs
- `SemigroupsMakeDoc`
- `SemigroupsTestStandard`
- `SEMIGROUPS.TestManualExamples`
all in one command.

If one fails, it still runs the other two.  Then it returns `true` if and only if all tests were successful.