### PR TITLE
Improve the code for transformation semigroup RectangularBandCons

### DIFF
--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -302,7 +302,7 @@ InstallMethod(RectangularBandCons,
 "for a filter and a positive integer and positive integer",
 [IsTransformationSemigroup, IsPosInt, IsPosInt],
 function(filter, m, n)
-  local L, R, div, deg, gens, act, i;
+  local L, R, div, deg, gen, gens, min, out, i;
 
   if m = 1 then
     return RightZeroSemigroup(filter, n);
@@ -319,39 +319,29 @@ function(filter, m, n)
   div := DegreeOfTransformationSemigroup(L);
   deg := div + DegreeOfTransformationSemigroup(R);
 
-  gens := [];
-
-  act := function(l, r, i)
-    if i <= div then
-      return i ^ l;
-    else
-      return (i - div) ^ r + div;
-    fi;
+  gen := function(l, r)
+    return Transformation(Concatenation(ListTransformation(L.(l), div),
+                                        ListTransformation(R.(r)) + div));
   end;
 
-  if m < n then
+  gens := [];
+  min := Minimum(m, n);
 
-    for i in [1 .. m] do
-      Add(gens, Transformation([1 .. deg], j -> act(L.(i), R.(i), j)));
-    od;
+  for i in [1 .. min] do # 'diagonal' generators
+    Add(gens, gen(i, i));
+  od;
 
-    for i in [m + 1 .. n] do
-      Add(gens, Transformation([1 .. deg], j -> act(L.1, R.(i), j)));
-    od;
+  for i in [min + 1 .. n] do # additional generators when n > m
+    Add(gens, gen(1, i));
+  od;
 
-  else
+  for i in [min + 1 .. m] do # additional generators when n < m
+    Add(gens, gen(i, 1));
+  od;
 
-    for i in [1 .. n] do
-      Add(gens, Transformation([1 .. deg], j -> act(L.(i), R.(i), j)));
-    od;
-
-    for i in [n + 1 .. m] do
-      Add(gens, Transformation([1 .. deg], j -> act(L.(i), R.1, j)));
-    od;
-
-  fi;
-
-  return Semigroup(gens);
+  out := Semigroup(gens);
+  SetMinimalSemigroupGeneratingSet(out, GeneratorsOfSemigroup(out));
+  return out;
 end);
 
 InstallMethod(RectangularBandCons,


### PR DESCRIPTION
(I wrote this ages ago, and never made a pull request, but I think it's a decent change to make).

I have changed the code of RectangularBandCons for a transformation semigroup, for clarity. The method still returns the same semigroup, however the code is now shorter and I believe it is much clearer what is going on (i.e. the generators are elements of the direct product of a left zero semigroup and a right zero semigroup).

The diff makes it hard to see the difference exactly, so I'll copy-paste them below.

Old:
```
  L := LeftZeroSemigroup(filter, m);
  R := RightZeroSemigroup(filter, n);
  div := DegreeOfTransformationSemigroup(L);
  deg := div + DegreeOfTransformationSemigroup(R);

  gens := [];

  act := function(l, r, i)
    if i <= div then
      return i ^ l;
    else
      return (i - div) ^ r + div;
    fi;
  end;

  if m < n then

    for i in [1 .. m] do
      Add(gens, Transformation([1 .. deg], j -> act(L.(i), R.(i), j)));
    od;

    for i in [m + 1 .. n] do
      Add(gens, Transformation([1 .. deg], j -> act(L.1, R.(i), j)));
    od;

  else

    for i in [1 .. n] do
      Add(gens, Transformation([1 .. deg], j -> act(L.(i), R.(i), j)));
    od;

    for i in [n + 1 .. m] do
      Add(gens, Transformation([1 .. deg], j -> act(L.(i), R.1, j)));
    od;

  fi;

  return Semigroup(gens);
```

New:
```
  L := LeftZeroSemigroup(filter, m);
  R := RightZeroSemigroup(filter, n);
  div := DegreeOfTransformationSemigroup(L);
  deg := div + DegreeOfTransformationSemigroup(R);

  gen := function(l, r)
    return Transformation(Concatenation(ListTransformation(L.(l), div),
                                        ListTransformation(R.(r)) + div));
  end;

  gens := [];
  min := Minimum(m, n);

  for i in [1 .. min] do # 'diagonal' generators
    Add(gens, gen(i, i));
  od;

  for i in [min + 1 .. n] do # additional generators when n > m
    Add(gens, gen(1, i));
  od;

  for i in [min + 1 .. m] do # additional generators when n < m
    Add(gens, gen(i, 1));
  od;

  out := Semigroup(gens);
  SetMinimalSemigroupGeneratingSet(out, GeneratorsOfSemigroup(out));
  return out;
```