### PR TITLE
Fix immediate monogenic methods in prop.gi

### DIFF
--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -775,11 +775,12 @@ function(S)
   local gens;
 
   gens := GeneratorsOfSemigroup(S);
-  if CanEasilyCompareElements(S) then
-    gens := DuplicateFreeList(gens);
-  fi;
-  if Length(gens) = 1 then
+  if Length(gens) <= 1 then
     SetMinimalSemigroupGeneratingSet(S, gens);
+    return true;
+  elif CanEasilyCompareElements(gens)
+      and ForAll([2 .. Length(gens)], i -> gens[1] = gens[i]) then
+    SetMinimalSemigroupGeneratingSet(S, [gens[1]]);
     return true;
   fi;
   TryNextMethod();
@@ -792,11 +793,12 @@ function(S)
   local gens;
 
   gens := GeneratorsOfMonoid(S);
-  if CanEasilyCompareElements(S) then
-    gens := DuplicateFreeList(gens);
-  fi;
-  if Length(gens) = 1 then
+  if Length(gens) <= 1 then
     SetMinimalMonoidGeneratingSet(S, gens);
+    return true;
+  elif CanEasilyCompareElements(gens)
+      and ForAll([2 .. Length(gens)], i -> gens[1] = gens[i]) then
+    SetMinimalMonoidGeneratingSet(S, [gens[1]]);
     return true;
   fi;
   TryNextMethod();

--- a/tst/standard/properties.tst
+++ b/tst/standard/properties.tst
@@ -939,6 +939,10 @@ gap> HasIsMonogenicSemigroup(S);
 true
 gap> IsMonogenicSemigroup(S);
 true
+gap> x := MinimalSemigroupGeneratingSet(S)[1];;
+gap> S := Semigroup(x, x, x);;
+gap> HasIsMonogenicSemigroup(S) and IsMonogenicSemigroup(S);
+true
 
 #T# properties: IsMonogenicInverseSemigroup, 1
 gap> IsMonogenicInverseSemigroup(AsSemigroup(IsBooleanMatSemigroup,
@@ -1032,6 +1036,12 @@ gap> S := MonogenicSemigroup(IsTransformationSemigroup, 3, 2);;
 gap> S := Monoid(S.1, S.1 ^ 2);;
 gap> GreensDClasses(S);;
 gap> IsMonogenicMonoid(S);
+true
+
+#T# properties: IsMonogenicMonoid, 9
+gap> S := Monoid(Transformation([2, 1, 2, 3, 4]),
+>                Transformation([2, 1, 2, 3, 4]));;
+gap> HasIsMonogenicMonoid(S) and IsMonogenicMonoid(S);
 true
 
 #T# properties: IsMonogenicInverseMonoid, 1


### PR DESCRIPTION
Previously the immediate methods for `IsMonogenicSemigroup` and `IsMonogenicMonoid` called the line `CanEasilyCompareElements(S)`, for the semigroup `S`, when I actually wanted to know whether I could compare the elements of the semigroup `S`. So there was a block of code that never got executed. I fixed this (accidentally in the `master` branch), but now that the block of code is executed, it is too slow, and is causing a performance regression in `tst/standard/semitrans.tst`.

I've now made all of the appropriate changes.

Once this is merged, `stable-3.0` should be merged into `master`, and then the performance regression (that currently is only present in `master`) will be resolved.