### PR TITLE
Brandt semigroups

### DIFF
--- a/doc/semicons.xml
+++ b/doc/semicons.xml
@@ -196,6 +196,69 @@ true]]></Example>
   </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="BrandtSemigroup">
+  <ManSection>
+    <Func Name="BrandtSemigroup" Arg="[[filt, ]G, ]n"/>
+    <Returns>
+      An <A>n</A> by <A>n</A> Brandt semigroup over the group <A>G</A>.
+    </Returns>
+      <Description>
+        If <A>n</A> is a positive integer, then this function returns an
+        <A>n</A> by <A>n</A> Brandt semigroup over the group <A>G</A>
+        in the representation given by the filter <A>filt</A>. <P/>
+
+        The optional argument <A>filt</A> can be any of the following:
+        <List>
+          <Item><C>IsPartialPermSemigroup</C>
+            (the default, if <A>filt</A> is not specified),</Item>
+          <Item><C>IsReesZeroMatrixSemigroup</C>,</Item>
+          <Item><C>IsTransformationSemigroup</C>,</Item>
+          <Item><C>IsBipartitionSemigroup</C>,</Item>
+          <Item><C>IsPBRSemigroup</C>,</Item>
+          <Item><C>IsBooleanMatSemigroup</C>,</Item>
+          <Item><C>IsNTPMatrixSemigroup</C>,</Item>
+          <Item><C>IsMaxPlusMatrixSemigroup</C>,</Item>
+          <Item><C>IsMinPlusMatrixSemigroup</C>,</Item>
+          <Item><C>IsTropicalMaxPlusMatrixSemigroup</C>,</Item>
+          <Item><C>IsTropicalMinPlusMatrixSemigroup</C>,</Item>
+          <Item><C>IsProjectiveMaxPlusMatrixSemigroup</C>,</Item>
+          <Item><C>IsIntegerMatrixSemigroup.</C></Item>
+        </List>
+        
+        The optional argument <A>G</A> defaults to a trivial permutation group.
+        If present <A>G</A> must be a permutation group, unless <A>filt</A> is
+        <C>IsReesZeroMatrixSemigroup</C> when <A>G</A> may be any type of
+        finite group. 
+        <P/>
+        
+        See <Ref Prop="IsBrandtSemigroup"/> for more information about Brandt
+        semigroups.
+
+        <Example><![CDATA[
+gap> S := BrandtSemigroup(5);
+<0-simple inverse partial perm semigroup of rank 5 with 4 generators>
+gap> IsBrandtSemigroup(S);
+true
+gap> S := BrandtSemigroup(IsTransformationSemigroup, 15);
+<0-simple transformation semigroup of degree 16 with 28 generators>
+gap> Size(S);
+226
+gap> MultiplicativeZero(S);
+Transformation( [ 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+  16, 16, 16 ] )
+gap> S := BrandtSemigroup(Group((1, 2)), 3);
+<0-simple inverse partial perm semigroup of rank 6 with 3 generators>
+gap> S := BrandtSemigroup(IsTransformationSemigroup, Group((1, 2)), 3);
+<0-simple transformation semigroup of degree 7 with 5 generators>
+gap> S := BrandtSemigroup(IsReesZeroMatrixSemigroup, 
+>                         DihedralGroup(4), 
+>                         2);
+<Rees 0-matrix semigroup 2x2 over <pc group of size 4 with 
+ 2 generators>>]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="LeftZeroSemigroup">
   <ManSection>
     <Func Name="LeftZeroSemigroup" Arg="[filt, ]n"/>

--- a/doc/z-chap09.xml
+++ b/doc/z-chap09.xml
@@ -26,6 +26,7 @@
     <#Include Label = "RectangularBand">
     <#Include Label = "ZeroSemigroup">
     <#Include Label = "LeftZeroSemigroup">
+    <#Include Label = "BrandtSemigroup">
   </Section>
 
   <!--**********************************************************************-->

--- a/gap/semigroups/semicons.gd
+++ b/gap/semigroups/semicons.gd
@@ -18,3 +18,5 @@ DeclareGlobalFunction("ZeroSemigroup");
 DeclareConstructor("ZeroSemigroupCons", [IsSemigroup, IsPosInt]);
 DeclareGlobalFunction("LeftZeroSemigroup");
 DeclareGlobalFunction("RightZeroSemigroup");
+DeclareConstructor("BrandtSemigroupCons", [IsSemigroup, IsGroup, IsPosInt]);
+DeclareGlobalFunction("BrandtSemigroup");

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -236,7 +236,7 @@ end);
 
 # Monogenic semigroup: other constructors
 
-for IsXSemigroup in ["IsPBRSemigroup",
+for _IsXSemigroup in ["IsPBRSemigroup",
                      "IsBooleanMatSemigroup",
                      "IsNTPMatrixSemigroup",
                      "IsMaxPlusMatrixSemigroup",
@@ -248,13 +248,14 @@ for IsXSemigroup in ["IsPBRSemigroup",
                      "IsReesMatrixSemigroup",
                      "IsReesZeroMatrixSemigroup"] do
   InstallMethod(MonogenicSemigroupCons,
-  Concatenation("for ", IsXSemigroup, " and two positive integers"),
-  [EvalString(IsXSemigroup), IsPosInt, IsPosInt],
+  Concatenation("for ", _IsXSemigroup, " and two positive integers"),
+  [EvalString(_IsXSemigroup), IsPosInt, IsPosInt],
   function(filter, m, r)
     return AsSemigroup(filter,
                        MonogenicSemigroupCons(IsTransformationSemigroup, m, r));
   end);
 od;
+Unbind(_IsXSemigroup);
 
 # Rectangular band: main method
 
@@ -399,7 +400,7 @@ end);
 
 # Rectangular band: other constructors
 
-for IsXSemigroup in ["IsBooleanMatSemigroup",
+for _IsXSemigroup in ["IsBooleanMatSemigroup",
                      "IsNTPMatrixSemigroup",
                      "IsMaxPlusMatrixSemigroup",
                      "IsMinPlusMatrixSemigroup",
@@ -408,13 +409,14 @@ for IsXSemigroup in ["IsBooleanMatSemigroup",
                      "IsProjectiveMaxPlusMatrixSemigroup",
                      "IsIntegerMatrixSemigroup"] do
   InstallMethod(RectangularBandCons,
-  Concatenation("for ", IsXSemigroup, ", pos int, and pos int"),
-  [EvalString(IsXSemigroup), IsPosInt, IsPosInt],
+  Concatenation("for ", _IsXSemigroup, ", pos int, and pos int"),
+  [EvalString(_IsXSemigroup), IsPosInt, IsPosInt],
   function(filter, m, n)
     return AsSemigroup(filter,
                        RectangularBandCons(IsTransformationSemigroup, m, n));
   end);
 od;
+Unbind(_IsXSemigroup);
 
 # Zero semigroup: main method
 
@@ -703,3 +705,97 @@ function(arg)
   od;
   return Semigroup(gens, rec(acting := false));
 end);
+
+InstallGlobalFunction(BrandtSemigroup,
+function(arg)
+  local S;
+
+  if Length(arg) = 1 and IsPosInt(arg[1]) then
+    S := BrandtSemigroupCons(IsPartialPermSemigroup, Group(()), arg[1]);
+  elif Length(arg) = 2 and IsOperation(arg[1]) and IsPosInt(arg[2]) then
+    S := BrandtSemigroupCons(arg[1], Group(()), arg[2]);
+  elif Length(arg) = 2 and IsGroup(arg[1]) and IsPosInt(arg[2]) then
+    S := BrandtSemigroupCons(IsPartialPermSemigroup, arg[1], arg[2]);
+  elif Length(arg) = 3 and IsOperation(arg[1]) and IsGroup(arg[2])
+      and IsPosInt(arg[3]) then
+    S := BrandtSemigroupCons(arg[1], arg[2], arg[3]);
+  else
+    ErrorNoReturn("Semigroups: BrandtSemigroup: usage,\n",
+                   "the arguments must be a positive integer or a filter and",
+                   " a positive integer, or\n a perm group and positive ",
+                   "integer, or a filter, perm group, and positive\n ",
+                   "integer,");
+  fi;
+  SetIsZeroSimpleSemigroup(S, true);
+  SetIsBrandtSemigroup(S, true);
+  return S;
+end);
+
+InstallMethod(BrandtSemigroupCons,
+"for IsPartialPermSemigroup, a perm group, and a positive integer",
+[IsPartialPermSemigroup, IsPermGroup, IsPosInt],
+function(filter, G, n)
+  local gens, one, m, i, x;
+
+  gens := [];
+
+  if IsTrivial(G) then
+    if n = 1 then
+      Add(gens, PartialPerm([1], [1]));
+      Add(gens, EmptyPartialPerm());
+    else
+      for i in [2 .. n] do
+        Add(gens, PartialPerm([1], [i]));
+      od;
+    fi;
+  else
+    one := PartialPerm(MovedPoints(G), MovedPoints(G));
+    for x in GeneratorsOfGroup(G) do
+      Add(gens, one * x);
+    od;
+    m := LargestMovedPoint(G) - SmallestMovedPoint(G) + 1;
+    for i in [1 .. n - 1] do
+      Add(gens, PartialPerm(MovedPoints(G), MovedPoints(G) + m * i));
+    od;
+    if n = 1 then
+      Add(gens, EmptyPartialPerm());
+    fi;
+  fi;
+
+  return InverseSemigroup(gens);
+end);
+
+InstallMethod(BrandtSemigroupCons,
+"for IsReesZeroMatrixSemigroup, a finite group, and a positive integer",
+[IsReesZeroMatrixSemigroup, IsGroup and IsFinite, IsPosInt],
+function(filter, G, n)
+  local mat, i;
+  mat := [];
+  for i in [1 .. n] do
+    Add(mat, ListWithIdenticalEntries(n, 0));
+    mat[i][i] := One(G);
+  od;
+
+  return ReesZeroMatrixSemigroup(G, mat);
+end);
+
+for _IsXSemigroup in ["IsTransformationSemigroup",
+                      "IsBipartitionSemigroup",
+                      "IsPBRSemigroup",
+                      "IsBooleanMatSemigroup",
+                      "IsNTPMatrixSemigroup",
+                      "IsMaxPlusMatrixSemigroup",
+                      "IsMinPlusMatrixSemigroup",
+                      "IsTropicalMaxPlusMatrixSemigroup",
+                      "IsTropicalMinPlusMatrixSemigroup",
+                      "IsProjectiveMaxPlusMatrixSemigroup",
+                      "IsIntegerMatrixSemigroup"] do
+  InstallMethod(BrandtSemigroupCons,
+  Concatenation("for ", _IsXSemigroup, " and a positive integer"),
+  [EvalString(_IsXSemigroup), IsPermGroup, IsPosInt],
+  function(filter, G, n)
+    return AsSemigroup(filter,
+                       BrandtSemigroupCons(IsPartialPermSemigroup, G, n));
+  end);
+od;
+Unbind(_IsXSemigroup);

--- a/gap/semigroups/semimaxplus.gi
+++ b/gap/semigroups/semimaxplus.gi
@@ -282,6 +282,13 @@ for _IsXMatrix in ["IsTropicalMaxPlusMatrix",
   end);
 
   InstallMethod(IsomorphismSemigroup,
+  Concatenation("for ", _IsXSemigroup, ", and a semigroup"),
+  [EvalString(_IsXSemigroup), IsSemigroup],
+  function(filter, S)
+    return IsomorphismSemigroup(filter, 1, S);
+  end);
+
+  InstallMethod(IsomorphismSemigroup,
   Concatenation("for ", _IsXSemigroup, " and a ", _IsXSemigroup),
   [EvalString(_IsXSemigroup), IsPosInt, EvalString(_IsXSemigroup)],
   function(filter, threshold, S)
@@ -312,6 +319,13 @@ function(filter, threshold, period, S)
                                        Range(iso2),
                                        x -> (x ^ iso1) ^ iso2,
                                        x -> (x ^ inv2) ^ inv1);
+end);
+
+InstallMethod(IsomorphismSemigroup,
+"for IsNTPMatrixSemigroup and a semigroup",
+[IsNTPMatrixSemigroup, IsSemigroup],
+function(filter, S)
+  return IsomorphismSemigroup(IsNTPMatrixSemigroup, 1, 1, S);
 end);
 
 InstallMethod(IsomorphismSemigroup,
@@ -444,6 +458,13 @@ _InstallIsomorphism1 := function(filter)
   end);
 
   InstallMethod(IsomorphismMonoid,
+  Concatenation("for ", IsXMonoid, " and a semigroup"),
+  [EvalString(IsXMonoid), IsSemigroup],
+  function(filter, S)
+    return IsomorphismMonoid(filter, 1, S);
+  end);
+
+  InstallMethod(IsomorphismMonoid,
   Concatenation("for ", IsXMonoid, ", pos int, and a monoid"),
   [EvalString(IsXMonoid), IsPosInt, IsMonoid],
   function(filter, threshold, S)
@@ -467,6 +488,15 @@ _InstallIsomorphism1 := function(filter)
                                          T,
                                          map,
                                          AsTransformation);
+  end);
+
+  InstallMethod(IsomorphismSemigroup,
+  Concatenation("for ", IsXSemigroup,
+                " and a transformation semigroup with generators"),
+  [EvalString(IsXSemigroup),
+   IsTransformationSemigroup and HasGeneratorsOfSemigroup],
+  function(filt, S)
+    return IsomorphismSemigroup(filt, 1, S);
   end);
 end;
 
@@ -517,6 +547,13 @@ function(filter, threshold, period, S)
                                        Range(iso2),
                                        x -> (x ^ iso1) ^ iso2,
                                        x -> (x ^ inv2) ^ inv1);
+end);
+
+InstallMethod(IsomorphismMonoid,
+"for IsNTPMatrixMonoid and a semigroup",
+[IsNTPMatrixMonoid, IsSemigroup],
+function(filter, S)
+  return IsomorphismMonoid(filter, 1, 1, S);
 end);
 
 InstallMethod(IsomorphismMonoid,

--- a/tst/standard/semicons.tst
+++ b/tst/standard/semicons.tst
@@ -822,6 +822,133 @@ gap> Size(S);
 gap> S := RightZeroSemigroup(9);
 <transformation semigroup of degree 6 with 9 generators>
 
+#T# constructions: Brandt semigroups, partial perm semigroups, default
+gap> S := BrandtSemigroup(Group((1, 2)), 1);
+<0-simple inverse partial perm semigroup of rank 2 with 2 generators>
+gap> MultiplicativeZero(S);
+<empty partial perm>
+gap> Size(S);
+3
+gap> IsBrandtSemigroup(S);
+true
+gap> S := BrandtSemigroup(Group((1, 2)), 2);
+<0-simple inverse partial perm semigroup of rank 4 with 2 generators>
+gap> MultiplicativeZero(S);
+<empty partial perm>
+gap> Size(S);
+9
+gap> IsBrandtSemigroup(S);
+true
+gap> S := BrandtSemigroup(IsPartialPermSemigroup, Group((1, 2)), 5);
+<0-simple inverse partial perm semigroup of rank 10 with 5 generators>
+gap> Size(S);
+51
+gap> S := BrandtSemigroup(10);
+<0-simple inverse partial perm semigroup of rank 10 with 9 generators>
+gap> Size(S);
+101
+gap> S := BrandtSemigroup(1);
+<0-simple inverse partial perm monoid of rank 1 with 2 generators>
+gap> Size(S);
+2
+gap> S := BrandtSemigroup(TrivialGroup(IsPermGroup), 1);
+<0-simple inverse partial perm monoid of rank 1 with 2 generators>
+gap> Size(S);
+2
+
+#T# constructions: Brandt semigroups, Rees 0-matrix semigroup
+gap> S := BrandtSemigroup(IsReesZeroMatrixSemigroup, 4);
+<Rees 0-matrix semigroup 4x4 over Group(())>
+gap> S := BrandtSemigroup(IsReesZeroMatrixSemigroup, DihedralGroup(4), 4);
+<Rees 0-matrix semigroup 4x4 over <pc group of size 4 with 2 generators>>
+gap> IsInverseSemigroup(last);
+true
+gap> S := BrandtSemigroup(IsReesZeroMatrixSemigroup, DihedralGroup(4));
+Error, Semigroups: BrandtSemigroup: usage,
+the arguments must be a positive integer or a filter and a positive integer, o\
+r
+ a perm group and positive integer, or a filter, perm group, and positive
+ integer,
+
+#T# constructions: Brandt semigroups, other semigroups
+gap> S := BrandtSemigroup(IsTransformationSemigroup, 3);
+<0-simple transformation semigroup of degree 4 with 4 generators>
+gap> S := BrandtSemigroup(IsTransformationSemigroup, Group((1, 2)), 3);
+<0-simple transformation semigroup of degree 7 with 5 generators>
+gap> S := BrandtSemigroup(IsTransformationSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsBipartitionSemigroup, 3);
+<0-simple inverse bipartition semigroup of degree 3 with 2 generators>
+gap> S := BrandtSemigroup(IsBipartitionSemigroup, Group((1, 2)), 3);
+<0-simple inverse bipartition semigroup of degree 6 with 3 generators>
+gap> S := BrandtSemigroup(IsBipartitionSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsPBRSemigroup, 3);
+<0-simple pbr semigroup of degree 4 with 4 generators>
+gap> S := BrandtSemigroup(IsPBRSemigroup, Group((1, 2)), 3);
+<0-simple pbr semigroup of degree 7 with 5 generators>
+gap> S := BrandtSemigroup(IsPBRSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsBooleanMatSemigroup, 3);
+<0-simple semigroup of 4x4 boolean matrices with 4 generators>
+gap> S := BrandtSemigroup(IsBooleanMatSemigroup, Group((1, 2)), 3);
+<0-simple semigroup of 7x7 boolean matrices with 5 generators>
+gap> S := BrandtSemigroup(IsBooleanMatSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsNTPMatrixSemigroup, 3);
+<0-simple semigroup of 4x4 ntp matrices with 4 generators>
+gap> S := BrandtSemigroup(IsNTPMatrixSemigroup, Group((1, 2)), 3);
+<0-simple semigroup of 7x7 ntp matrices with 5 generators>
+gap> S := BrandtSemigroup(IsNTPMatrixSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsMaxPlusMatrixSemigroup, 3);
+<0-simple semigroup of 4x4 max-plus matrices with 4 generators>
+gap> S := BrandtSemigroup(IsMaxPlusMatrixSemigroup, Group((1, 2)), 3);
+<0-simple semigroup of 7x7 max-plus matrices with 5 generators>
+gap> S := BrandtSemigroup(IsMaxPlusMatrixSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsMinPlusMatrixSemigroup, 3);
+<0-simple semigroup of 4x4 min-plus matrices with 4 generators>
+gap> S := BrandtSemigroup(IsMinPlusMatrixSemigroup, Group((1, 2)), 3);
+<0-simple semigroup of 7x7 min-plus matrices with 5 generators>
+gap> S := BrandtSemigroup(IsMinPlusMatrixSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsTropicalMaxPlusMatrixSemigroup, 3);
+<0-simple semigroup of 4x4 tropical max-plus matrices with 4 generators>
+gap> S := BrandtSemigroup(IsTropicalMaxPlusMatrixSemigroup, Group((1, 2)), 3);
+<0-simple semigroup of 7x7 tropical max-plus matrices with 5 generators>
+gap> S := BrandtSemigroup(IsTropicalMaxPlusMatrixSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsTropicalMinPlusMatrixSemigroup, 3);
+<0-simple semigroup of 4x4 tropical min-plus matrices with 4 generators>
+gap> S := BrandtSemigroup(IsTropicalMinPlusMatrixSemigroup, Group((1, 2)), 3);
+<0-simple semigroup of 7x7 tropical min-plus matrices with 5 generators>
+gap> S := BrandtSemigroup(IsTropicalMinPlusMatrixSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsProjectiveMaxPlusMatrixSemigroup, 3);
+<0-simple semigroup of 4x4 projective max-plus matrices with 4 generators>
+gap> S := BrandtSemigroup(IsProjectiveMaxPlusMatrixSemigroup, Group((1, 2)), 3);
+<0-simple semigroup of 7x7 projective max-plus matrices with 5 generators>
+gap> S := BrandtSemigroup(IsProjectiveMaxPlusMatrixSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+gap> S := BrandtSemigroup(IsIntegerMatrixSemigroup, 3);
+<0-simple semigroup of 4x4 integer matrices with 4 generators>
+gap> S := BrandtSemigroup(IsIntegerMatrixSemigroup, Group((1, 2)), 3);
+<0-simple semigroup of 7x7 integer matrices with 5 generators>
+gap> S := BrandtSemigroup(IsIntegerMatrixSemigroup, DihedralGroup(4), 3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(S);
 


### PR DESCRIPTION
This PR adds a `BrandtSemigroup` constructor in the same vein as `TrivialSemigroup` and chums. 