### PR TITLE
Require Orb v4.8.0

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -12,7 +12,7 @@
 ##  <!ENTITY VERSION "3.0.7">
 ##  <!ENTITY GAPVERS "4.9.0">
 ##  <!ENTITY DIGRAPHSVERS "0.7.1">
-##  <!ENTITY ORBVERS "4.7.5">
+##  <!ENTITY ORBVERS "4.8.0">
 ##  <!ENTITY IOVERS "4.4.4">
 ##  <!ENTITY GENSSVERS "1.5">
 ##  <!ENTITY ARCHIVENAME "semigroups-3.0.7">
@@ -234,7 +234,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">=4.9.0",
-  NeededOtherPackages := [["orb", ">=4.7.5"],
+  NeededOtherPackages := [["orb", ">=4.8.0"],
                           ["io", ">=4.4.4"],
                           ["digraphs", ">=0.7.1"],
                           ["genss", ">=1.5"]],

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The  following  is  a  summary of the steps that should lead to a successful ins
 
 * get the [IO](http://gap-system.github.io/io/) package version 4.4.4 or higher
 
-* get the [Orb](http://gap-system.github.io/orb/) package version 4.7.5 or higher. 
+* get the [Orb](http://gap-system.github.io/orb/) package version 4.8.0 or higher. 
   Both [Orb](http://gap-system.github.io/orb/) and [Semigroups](https://gap-packages.github.io/Semigroups) perform better if [Orb](http://gap-system.github.io/orb/) is compiled, so compile [Orb](http://gap-system.github.io/orb/)!
 
 * ensure that the [Digraphs](http://gap-system.github.io/digraphs/) package version 0.7.1 or higher is available.  [Digraphs](http://gap-system.github.io/digraphs/) must be compiled before [Semigroups](https://gap-packages.github.io/Semigroups) can be

--- a/gap/attributes/attract.gi
+++ b/gap/attributes/attract.gi
@@ -143,7 +143,7 @@ function(S, x)
   j := 0;
 
   # can't use GradedRhoOrb here since there may be inverses not D-related to f
-  if HasRhoOrb(S) and IsClosed(RhoOrb(S)) then
+  if HasRhoOrb(S) and IsClosedOrbit(RhoOrb(S)) then
     o := RhoOrb(S);
     rhos := EmptyPlist(Length(o));
     for i in [2 .. Length(o)] do
@@ -184,7 +184,7 @@ function(S, x)
   out := [];
   k := 0;
 
-  #if HasLambdaOrb(S) and IsClosed(LambdaOrb(S)) then
+  #if HasLambdaOrb(S) and IsClosedOrbit(LambdaOrb(S)) then
   # Notes: it seems that LambdaOrb(S) is always closed at this point
   o := LambdaOrb(S);
   Enumerate(o); # just in case

--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -509,7 +509,7 @@ function(S)
     return true;
   fi;
 
-  if IsClosedData(SemigroupData(S)) and IsClosed(RhoOrb(S)) then
+  if IsClosedData(SemigroupData(S)) and IsClosedOrbit(RhoOrb(S)) then
     for x in GreensDClasses(S) do
       if (not IsTrivial(SchutzenbergerGroup(x)))
           or Length(LambdaOrbSCC(x)) > 1 then
@@ -671,7 +671,7 @@ function(S)
     Enumerate(lambda);
     rho := RhoOrb(S);
     Enumerate(rho, Length(lambda) + 1);
-    if not (IsClosed(rho) and Length(rho) = Length(lambda)) then
+    if not (IsClosedOrbit(rho) and Length(rho) = Length(lambda)) then
       Info(InfoSemigroups, 2,
            "the numbers of lambda and rho values are not equal");
       return false;
@@ -1300,7 +1300,7 @@ InstallMethod(IsRegularSemigroupElementNC,
 function(S, x)
   local o, l, scc, rho, tester, i;
 
-   if IsClosed(LambdaOrb(S)) then
+   if IsClosedOrbit(LambdaOrb(S)) then
     o := LambdaOrb(S);
     l := Position(o, LambdaFunc(S)(x));
     if l = fail then
@@ -1330,7 +1330,7 @@ end);
 #function(S, x)
 #  local o, k, l;
 #
-#   if IsClosed(LambdaOrb(S)) then
+#   if IsClosedOrbit(LambdaOrb(S)) then
 #    o := LambdaOrb(S);
 #    k := Position(o, LambdaFunc(S)(x));
 #    if k = fail then

--- a/gap/greens/grac.gi
+++ b/gap/greens/grac.gi
@@ -145,7 +145,8 @@ SEMIGROUPS.SetLambda := function(C)
   local S, o;
 
   S := Parent(C);
-  if HasLambdaOrb(S) and IsClosed(LambdaOrb(S)) and not IsGreensClassNC(C) then
+  if HasLambdaOrb(S) and IsClosedOrbit(LambdaOrb(S))
+      and not IsGreensClassNC(C) then
     SetLambdaOrb(C, LambdaOrb(S));
     SetLambdaOrbSCCIndex(C, OrbSCCIndex(LambdaOrb(S), LambdaFunc(S)(C!.rep)));
   else
@@ -159,7 +160,7 @@ SEMIGROUPS.SetRho := function(C)
   local S, o;
 
   S := Parent(C);
-  if HasRhoOrb(S) and IsClosed(RhoOrb(S)) and not IsGreensClassNC(C) then
+  if HasRhoOrb(S) and IsClosedOrbit(RhoOrb(S)) and not IsGreensClassNC(C) then
     SetRhoOrb(C, RhoOrb(S));
     SetRhoOrbSCCIndex(C, OrbSCCIndex(RhoOrb(S), RhoFunc(S)(C!.rep)));
   else

--- a/gap/greens/gracinv.gi
+++ b/gap/greens/gracinv.gi
@@ -531,7 +531,7 @@ function(S, n)
 
   o := LambdaOrb(S);
 
-  if not IsClosed(o) then
+  if not IsClosedOrbit(o) then
     Enumerate(o, infinity);
   fi;
 

--- a/gap/ideals/idealact.gi
+++ b/gap/ideals/idealact.gi
@@ -727,8 +727,8 @@ function(data, limit, record)
   data!.pos := i;
 
   if nr_d = i then
-    SetFilterObj(lambdao, IsClosed);
-    SetFilterObj(rhoo, IsClosed);
+    SetFilterObj(lambdao, IsClosedOrbit);
+    SetFilterObj(rhoo, IsClosedOrbit);
     SetFilterObj(data, IsClosedData);
     if not HasIsRegularSemigroup(I) then
       SetIsRegularSemigroup(I, ForAll(regular, x -> x));
@@ -783,7 +783,7 @@ function(x, I)
   l := Position(o, xx);
 
   if l = fail then
-    if IsClosed(o) then
+    if IsClosedOrbit(o) then
       return false;
     fi;
 
@@ -828,7 +828,7 @@ function(x, I)
   l := Position(o, RhoFunc(I)(x));
 
   if l = fail then
-    Assert(1, IsClosed(o));
+    Assert(1, IsClosedOrbit(o));
     # Because I is regular once we have found the lambda-val we have found the
     # (unique) D-class of I containing something with the same lambda-val. If x
     # in I, then the D-class we've found must contain x and so we already know
@@ -1187,8 +1187,8 @@ function(data, limit, record)
   data!.pos := i;
 
   if nr_d = i then
-    SetFilterObj(lambdao, IsClosed);
-    SetFilterObj(rhoo, IsClosed);
+    SetFilterObj(lambdao, IsClosedOrbit);
+    SetFilterObj(rhoo, IsClosedOrbit);
     SetFilterObj(data, IsClosedData);
   fi;
 

--- a/gap/ideals/ideallam.gi
+++ b/gap/ideals/ideallam.gi
@@ -18,12 +18,12 @@ InstallMethod(Enumerate, "for an ideal orb, and a number",
 function(o, limit)
   local newlookfunc;
 
-  if IsClosed(o) then
+  if IsClosedOrbit(o) then
     return o;
   fi;
 
   newlookfunc := function(data, x)
-    return IsClosed(o) or Length(o) >= limit;
+    return IsClosedOrbit(o) or Length(o) >= limit;
   end;
   Enumerate(SemigroupData(o!.parent), infinity, newlookfunc);
 
@@ -36,7 +36,7 @@ function(o, limit, lookfunc)
   local newlookfunc;
 
   newlookfunc := function(data, x)
-    return IsClosed(o) or Length(o) >= limit;
+    return IsClosedOrbit(o) or Length(o) >= limit;
   end;
   if IsLambdaOrb(o) then
     Enumerate(SemigroupData(o!.parent), infinity,
@@ -149,7 +149,7 @@ InstallMethod(ViewObj, "for a ideal orb",
 [IsIdealOrb],
 function(o)
   Print("<");
-  if IsClosed(o) then
+  if IsClosedOrbit(o) then
     Print("closed ");
   else
     Print("open ");

--- a/gap/main/acting.gi
+++ b/gap/main/acting.gi
@@ -104,7 +104,7 @@ function(x, S)
   lambda := LambdaFunc(S)(x);
   lambdao := LambdaOrb(S);
   # TODO(later) lookahead here too
-  if not IsClosed(lambdao) then
+  if not IsClosedOrbit(lambdao) then
     Enumerate(lambdao, infinity);
   fi;
 
@@ -166,7 +166,7 @@ function(x, S)
 
   if l = fail then
     # rho is not already known, so we look for it
-    if IsClosed(rhoo) or not LookAhead() then
+    if IsClosedOrbit(rhoo) or not LookAhead() then
       return false;
     fi;
 
@@ -675,7 +675,7 @@ function(data, limit, lookfunc)
   fi;
   if nr = i then
     SetFilterObj(data, IsClosedData);
-    SetFilterObj(rho_o, IsClosed);
+    SetFilterObj(rho_o, IsClosedOrbit);
     rho_o!.orbind := [1 .. rho_nr];
   fi;
 

--- a/gap/main/orbits.gi
+++ b/gap/main/orbits.gi
@@ -152,7 +152,7 @@ function(o, limit)
   o!.pos := i;
   o!.depth := depth;
   if i > nr then
-    SetFilterObj(o, IsClosed);
+    SetFilterObj(o, IsClosedOrbit);
     o!.orbind := [1 .. nr];
   fi;
   return o;
@@ -216,12 +216,12 @@ function(arg)
 
   if not onlynew then
     pos := Position(o, val);
-    if pos <> fail or IsClosed(o) then
+    if pos <> fail or IsClosedOrbit(o) then
       return pos;
     fi;
   fi;
 
-  if IsClosed(o) then
+  if IsClosedOrbit(o) then
     return fail;
   fi;
   o!.looking := true;
@@ -260,7 +260,7 @@ function(o, func, start)
     od;
   fi;
 
-  if IsClosed(o) then
+  if IsClosedOrbit(o) then
     return false;
   fi;
 
@@ -284,7 +284,7 @@ function(o)
     return o!.scc;
   fi;
 
-  if not IsClosed(o) or not IsClosedData(o) then
+  if not IsClosedOrbit(o) or not IsClosedData(o) then
     Enumerate(o, infinity);
   fi;
 

--- a/gap/main/semiact.gi
+++ b/gap/main/semiact.gi
@@ -169,7 +169,7 @@ function(Constructor, S, coll, opts)
   rho_o!.parent := t;
   rho_o!.scc_reps := [FakeOne(GeneratorsOfSemigroup(t))];
   Append(rho_o!.gens, coll);
-  ResetFilterObj(rho_o, IsClosed);
+  ResetFilterObj(rho_o, IsClosedOrbit);
   SetRhoOrb(t, rho_o);
 
   # get new and old R-rep orbit data
@@ -515,7 +515,7 @@ InstallMethod(Random, "for a regular acting semigroup rep",
 function(S)
   local gens, i, w, x, o, m;
 
-  if not IsClosed(LambdaOrb(S)) or not IsClosed(RhoOrb(S)) then
+  if not IsClosedOrbit(LambdaOrb(S)) or not IsClosedOrbit(RhoOrb(S)) then
     if HasGeneratorsOfSemigroup(S) then
       gens := GeneratorsOfSemigroup(S);
       i := Random([1 .. 2 * Int(Length(gens))]);
@@ -557,7 +557,7 @@ InstallMethod(Random,
 function(S)
   local gens, i, w, x, o, m;
 
-  if not IsClosed(LambdaOrb(S)) then
+  if not IsClosedOrbit(LambdaOrb(S)) then
     if HasGeneratorsOfSemigroup(S) then
       gens := GeneratorsOfSemigroup(S);
       i := Random([1 .. 2 * Int(Length(gens))]);

--- a/gap/tools/iterators.gi
+++ b/gap/tools/iterators.gi
@@ -138,7 +138,7 @@ function(o, func, start)
 
     pos := iter!.pos;
 
-    if IsClosed(o) and pos >= Length(o) then
+    if IsClosedOrbit(o) and pos >= Length(o) then
       return fail;
     fi;
 
@@ -820,7 +820,7 @@ InstallMethod(IteratorOfDClassData, "for regular acting semigroup",
 function(s)
   local record, o, scc, func;
 
-  if not IsClosed(LambdaOrb(s)) then
+  if not IsClosedOrbit(LambdaOrb(s)) then
     record := rec(m := fail, graded := IteratorOfGradedLambdaOrbs(s));
     record.NextIterator := function(iter)
       local l, rep, m;
@@ -890,7 +890,7 @@ function(s)
     return [s, 1, GradedRhoOrb(s, rep, false)[1], rep, true];
   end;
 
-  if not IsClosed(o) then
+  if not IsClosedOrbit(o) then
     iter := IteratorByOrbFunc(o, func, 2);
   else
     return IteratorByIterator(IteratorList([2 .. Length(o)]), func);
@@ -922,7 +922,7 @@ function(s)
     return [s, 1, GradedLambdaOrb(s, rep, false), rep, true];
   end;
 
-  if not IsClosed(o) then
+  if not IsClosedOrbit(o) then
     # JDM should we use IteratorOfGradedRhoOrbs here instead??
     iter := IteratorByOrbFunc(o, func, 2);
   else
@@ -973,7 +973,7 @@ InstallMethod(IteratorOfDClassData, "for inverse acting semigroup",
 function(s)
   local graded, record, o, scc, func;
 
-  if not IsClosed(LambdaOrb(s)) then
+  if not IsClosedOrbit(LambdaOrb(s)) then
     graded := IteratorOfGradedLambdaOrbs(s);
     record := rec(m := 0, graded := graded, o := NextIterator(graded));
     record.NextIterator := function(iter)
@@ -1028,7 +1028,7 @@ function(s)
   local o, func, iter, lookup;
 
   o := LambdaOrb(s);
-  if not IsClosed(o) then
+  if not IsClosedOrbit(o) then
     func := function(iter, i)
       local rep;
       rep := Inverse(EvaluateWord(o, TraceSchreierTreeForward(o, i)));

--- a/scripts/travis-build-dependencies.sh
+++ b/scripts/travis-build-dependencies.sh
@@ -78,8 +78,7 @@ PKGS=( "digraphs" "genss" "io" "orb" "profiling" )
 for PKG in "${PKGS[@]}"; do
   cd $GAPROOT/pkg
   # TODO remove the condition about IO when IO 4.4.7 or newer is released
-  # TODO remove the condition about Orb when Orb 4.7.7 or newer is released
-  if ([ "$PACKAGES" == "master" ] && [ ! "$PKG" == "io" ]) || [ "$PKG" == "orb" ]; then
+  if [ "$PACKAGES" == "master" ] && [ ! "$PKG" == "io" ]; then
     echo -e "\nGetting master branch of $PKG repository..."
     git clone -b master --depth=1 https://github.com/gap-packages/$PKG.git $PKG
     PKGDIR=$PKG

--- a/tst/extreme/misc.tst
+++ b/tst/extreme/misc.tst
@@ -2015,7 +2015,7 @@ gap> f := Transformation([1, 2, 4, 4]);
 Transformation( [ 1, 2, 4, 4 ] )
 gap> o := LambdaOrb(s);
 <closed orbit, 15 points with Schreier tree with log>
-gap> HasRhoOrb(s) and IsClosed(RhoOrb(s));
+gap> HasRhoOrb(s) and IsClosedOrbit(RhoOrb(s));
 true
 gap> o := RhoOrb(s);
 <closed orbit, 12 points with Schreier tree with log>


### PR DESCRIPTION
This is required due to changes in GAP that affected the hashing of permutations, and because Orb v4.8.0 renames `IsClosed` to `IsClosedOrbit`.