### PR TITLE
Avoid GAP headers other than src/compiled.h

### DIFF
--- a/src/bipart.cc
+++ b/src/bipart.cc
@@ -29,8 +29,7 @@
 #include <vector>
 
 #include "libsemigroups/src/semigroups.h"
-#include "src/permutat.h"
-#include "src/precord.h"
+#include "src/compiled.h"
 
 using libsemigroups::Timer;
 using libsemigroups::glob_reporter;

--- a/src/semigroups-debug.h
+++ b/src/semigroups-debug.h
@@ -22,7 +22,7 @@
 #define SEMIGROUPS_SRC_SEMIGROUPS_DEBUG_H_
 
 #include <assert.h>
-#include <src/system.h>
+#include <src/compiled.h>
 
 #include "semigroups-config.h"
 


### PR DESCRIPTION
I'd like to clean up the GAP src directory for GAP 4.10 (see <https://github.com/gap-system/gap/pull/1915>). However, this will break packages which directly include GAP headers other than src/compiled.h -- but luckily there are just two packages doing that, IO and semigroups. Hence this PR.

The name `src/compiled.h` is of course not very "intuitive", so I'd like to change that eventually, too (naming suggestions are welcome :-), but it'll stick around as long as packages use it.