### PR TITLE
Update for Digraphs

### DIFF
--- a/gap/elements/blocks.gi
+++ b/gap/elements/blocks.gi
@@ -81,7 +81,7 @@ function(blocks)
   local gr, canon, scc, rep, i;
 
   gr := AsDigraph(blocks);
-  gr := OnDigraphs(gr, DigraphCanonicalLabelling(gr));
+  gr := OnDigraphs(gr, BlissCanonicalLabelling(gr));
   canon := [];
 
   scc := DigraphStronglyConnectedComponents(gr).comps;

--- a/gap/elements/boolmat.gi
+++ b/gap/elements/boolmat.gi
@@ -592,7 +592,7 @@ function(mat)
   colors := Concatenation([1 .. Length(mat![1])] * 0 + 1,
                           [1 .. Length(mat![1])] * 0 + 2);
 
-  p  := DigraphCanonicalLabelling(gr, colors);
+  p  := BlissCanonicalLabelling(gr, colors);
   return _AsBooleanMat(OnDigraphs(gr, p));
 end);
 

--- a/gap/elements/trans.gi
+++ b/gap/elements/trans.gi
@@ -25,7 +25,7 @@ function(f, n)
 
   digraph := AsDigraph(f, n);
   return AsTransformation(OnDigraphs(digraph,
-                                     DigraphCanonicalLabelling(digraph)));
+                                     BlissCanonicalLabelling(digraph)));
 end);
 
 InstallMethod(TransformationByImageAndKernel, "for an image and partition",


### PR DESCRIPTION
This PR changes `DigraphCanonicalLabelling` to `BlissCanonicalLabelling` because of [Digraphs PR number 99](https://github.com/gap-packages/Digraphs/pull/99).