### PR TITLE
Use C99 init for StructInitInfo

### DIFF
--- a/src/pkg.cc
+++ b/src/pkg.cc
@@ -639,18 +639,11 @@ static Int InitLibrary(StructInitInfo* module) {
 *F  InitInfopl()  . . . . . . . . . . . . . . . . . table of init functions
 */
 static StructInitInfo module = {
-    /* type        = */ MODULE_DYNAMIC,
-    /* name        = */ "semigroups",
-    /* revision_c  = */ 0,
-    /* revision_h  = */ 0,
-    /* version     = */ 0,
-    /* crc         = */ 0,
-    /* initKernel  = */ InitKernel,
-    /* initLibrary = */ InitLibrary,
-    /* checkInit   = */ 0,
-    /* preSave     = */ 0,
-    /* postSave    = */ 0,
-    /* postRestore = */ 0};
+    .type = MODULE_DYNAMIC,
+    .name = "semigroups",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+};
 
 extern "C" StructInitInfo* Init__Dynamic(void) {
   return &module;


### PR DESCRIPTION
This is not against stable-2.8 because the file was renamed compared to there. But if you prefer, I can also make this PR against stable-2.8.