### PR TITLE
semifp: Add a method for IsomorphismFpSemigroup

### DIFF
--- a/gap/semigroups/semifp.gi
+++ b/gap/semigroups/semifp.gi
@@ -298,7 +298,7 @@ function(S)
     spos := Position(sgens, sgens[i]);
     mpos := Position(mgens, sgens[i], start[spos]);
     lookup[i] := mpos;
-    if spos <> fail then
+    if mpos <> fail then
       start[spos] := mpos;
     fi;
   od;
@@ -542,6 +542,10 @@ function(S, x)
   return SEMIGROUPS.ExtRepObjToWord(ExtRepOfObj(x));
 end);
 
+# This method is based on the following paper
+# Presentations of Factorizable Inverse Monoids
+# David Easdown, James East, and D. G. FitzGerald
+# July 19, 2004
 InstallMethod(IsomorphismFpSemigroup,
 "for an inverse partial perm semigroup",
 [IsPartialPermSemigroup and IsInverseActingSemigroupRep],
@@ -555,16 +559,11 @@ function(M)
   fi;
 
   add_to_odd_positions := function(list, s)
-    local i;
-    for i in [1, 3 .. Length(list) - 1] do
-      list[i] := list[i] + s;
-    od;
+    list{[1, 3 .. Length(list) - 1]} := list{[1, 3 .. Length(list) - 1]} + s;
     return list;
   end;
 
-  # FIXME: this shouldn't be necessary but for an error with
-  # MinimalFactorization
-  S := Semigroup(IdempotentGeneratedSubsemigroup(M), rec(acting := false));
+  S := Semigroup(IdempotentGeneratedSubsemigroup(M));
   SS := GeneratorsOfSemigroup(S);
   G := GroupOfUnits(M);
   GG := GeneratorsOfSemigroup(G);
@@ -590,7 +589,7 @@ function(M)
     Add(rels, [ObjByExtRep(fam, lhs), ObjByExtRep(fam, rhs)]);
   od;
 
-  # R_product
+  # R_product - see page 4 of the paper
   for x in [1 .. s] do
     for y in [1 .. g] do
       rhs := Factorization(S, SS[x] ^ (GG[y] ^ -1));
@@ -602,7 +601,7 @@ function(M)
   map := InverseGeneralMapping(IsomorphismPermGroup(G));
   H   := Source(map);
   o   := Enumerate(LambdaOrb(M));
-  #R_tilde
+  #R_tilde - see page 4 of the paper
   for m in [2 .. Length(OrbSCC(o))] do
     comp := OrbSCC(o)[m];
     U := SmallGeneratingSet(Stabilizer(H,
@@ -634,7 +633,7 @@ function(M)
   map := x -> ElementOfFpSemigroup(fam, EvaluateWord(GeneratorsOfSemigroup(F),
                                                      Factorization(T, x)));
   inv := x -> EvaluateWord(GeneratorsOfSemigroup(T),
-         SEMIGROUPS.ExtRepObjToWord(ExtRepOfObj(x)));
+                           SEMIGROUPS.ExtRepObjToWord(ExtRepOfObj(x)));
 
   return MagmaIsomorphismByFunctionsNC(M, MF, map, inv);
 end);

--- a/tst/standard/semifp.tst
+++ b/tst/standard/semifp.tst
@@ -2060,6 +2060,67 @@ gap> SEMIGROUPS.ExtRepObjToString([100, 1]);
 Error, SEMIGROUPS.ExtRepObjToString: the maximum value in an odd position of t\
 he argument must be at most 52,
 
+# Test IsomorphismFpSemigroup (for factorizable inverse monoids)
+gap> S := SymmetricInverseMonoid(4);;
+gap> iso := IsomorphismFpSemigroup(S);;
+gap> BruteForceIsoCheck(iso);
+true
+gap> BruteForceInverseCheck(iso);
+true
+gap> S := InverseSemigroup(
+> [PartialPerm([1, 2, 3, 4, 5, 6, 7, 8], [2, 4, 8, 6, 3, 1, 5, 7]),
+> PartialPerm([1, 2, 3, 4, 5, 6, 7, 8], [3, 5, 4, 7, 6, 8, 1, 2]),
+> PartialPerm([1, 2, 3, 4, 5, 6, 7, 8], [4, 6, 7, 1, 8, 2, 3, 5]),
+> PartialPerm([], [])]);;
+gap> iso := IsomorphismFpSemigroup(S);;
+gap> BruteForceIsoCheck(iso);
+true
+gap> BruteForceInverseCheck(iso);
+true
+gap> S := InverseSemigroup(
+> [PartialPerm([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [9, 10, 8, 2, 1, 7, 5, 4, 6, 3]),
+> PartialPerm([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 3, 6, 5, 2, 8, 1, 4, 7]),
+> PartialPerm([], [])]);;
+gap> iso := IsomorphismFpSemigroup(S);;
+gap> BruteForceIsoCheck(iso);
+true
+gap> BruteForceInverseCheck(iso);
+true
+gap> tst := [InverseMonoid([PartialPerm([1, 2, 3, 4, 5], [4, 5, 2, 3, 1]),
+> PartialPerm([1, 3], [1, 3])]), 
+> InverseMonoid([PartialPerm([1, 2, 3, 4], [1, 2, 3, 4]), 
+> PartialPerm([1, 2, 3, 4, 5], [3, 1, 5, 4, 2])]),
+> InverseMonoid([PartialPerm([1, 2, 3, 4, 5], [5, 4, 2, 3, 1]),
+> PartialPerm([1, 2, 4], [1, 2, 4])]),
+> InverseMonoid([PartialPerm([1, 2, 5], [2, 1, 5]),
+> PartialPerm([1, 2], [1, 2])]),
+> InverseMonoid([PartialPerm([1, 2, 3], [1, 4, 5]),
+> PartialPerm([1, 2, 3, 4, 5], [1, 5, 4, 2, 3])]),
+> InverseMonoid([PartialPerm([1, 2, 3, 4, 5], [3, 1, 5, 4, 2]),
+> PartialPerm([1, 2, 3, 4, 5], [5, 1, 3, 4, 2])]),
+> InverseMonoid([PartialPerm([1, 2, 5], [2, 3, 5]),
+> PartialPerm([1, 2, 3, 5], [2, 3, 1, 5])]),
+> InverseMonoid([PartialPerm([1, 2, 3, 4, 5], [4, 2, 3, 1, 5]),
+> PartialPerm([1, 2, 3, 4, 5], [5, 3, 2, 1, 4])]),
+> InverseMonoid([PartialPerm([1, 2, 3, 5], [2, 1, 3, 5]),
+> PartialPerm([1, 2, 3, 5], [5, 2, 1, 3])]),
+> InverseMonoid([PartialPerm([1, 2, 3], [5, 4, 1]),
+> PartialPerm([1, 2, 3, 4, 5], [2, 3, 5, 1, 4])]),
+> InverseMonoid([PartialPerm([1, 2, 3, 4, 5], [4, 3, 5, 2, 1]),
+> PartialPerm([1, 2, 4, 5], [5, 4, 2, 1]),
+> PartialPerm([1, 4], [3, 2]), PartialPerm([1, 2, 3, 4, 5], [2, 3, 5, 1, 4]),
+> PartialPerm([1, 2, 5], [2, 3, 4])]),
+> InverseMonoid([PartialPerm([1, 2, 3, 4, 5], [2, 4, 1, 5, 3]),
+> PartialPerm([1, 3, 4], [2, 1, 3]),
+> PartialPerm([1, 2, 3, 4, 5], [4, 1, 2, 5, 3]), PartialPerm([1, 3], [5, 4]),
+> PartialPerm([1, 3, 5], [2, 4, 1])])];;
+gap> ForAll(tst, IsFactorisableInverseMonoid);
+true
+gap> ForAll(tst, S -> BruteForceIsoCheck(IsomorphismFpSemigroup(S)));
+true
+gap> ForAll(tst{[1 .. 10]}, S -> BruteForceInverseCheck(IsomorphismFpSemigroup(S)));
+true
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);


### PR DESCRIPTION
This method applies to factorizable inverse monoids of partial perms. Method is
based on the paper Presentations of Factorizable Inverse Monoids by D. Easdown,
J. East, and D. G. FitzGerald (2004).