### PR TITLE
Make Travis work for Semigroups and libsemigroups

### DIFF
--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -19,7 +19,7 @@ if [ "$SUITE" == "lint" ]; then
   $GAPLINT `grep "^\s\+gaplint" Makefile.am | cut -d " " -f2-`
   $CPPLINT --extensions=c,cc,h `grep "^\s\+cpplint" Makefile.am | cut -d " " -f2-`
 
-elif [ ! -z "$GAP" ]; then
+else
 
   GAP_DIR=`pwd`
   cd $GAP_DIR/pkg/semigroups

--- a/tst/standard/isorms.tst
+++ b/tst/standard/isorms.tst
@@ -249,7 +249,7 @@ true
 gap> BruteForceInverseCheck(map);
 true
 gap> map := InverseGeneralMapping(map);
-((3,4), GroupHomomorphismByImages( Group( () ), Group( [ () ] ), [  ], 
+((3,4), GroupHomomorphismByImages( Group( [ () ] ), Group( [ () ] ), [  ], 
 [  ] ), [ (), (), (), () ])
 gap> BruteForceIsoCheck(map);
 true
@@ -687,7 +687,7 @@ true
 gap> BruteForceInverseCheck(map);
 true
 gap> map := InverseGeneralMapping(map);
-((), GroupHomomorphismByImages( Group( [ (1,2)(3,6)(4,5), (1,4)(2,3)(5,6) 
+((), GroupHomomorphismByImages( Group( [ (1,2)(3,6)(4,5), (1,3,5)(2,4,6) 
  ] ), Group( [ (2,4), (1,2) ] ), [ (1,2)(3,6)(4,5), (1,4)(2,3)(5,6) ], 
 [ (2,4), (1,2) ] ), [ (), (1,2), (1,4,2) ])
 gap> BruteForceIsoCheck(map);


### PR DESCRIPTION
This removes some harmless diffs from `isorms.tst` that were causing Travis to fail, as noted first by @ChristopherRussell.

This also tweaks `scripts/travis-test.sh` so that it should mean that the libsemigroups tests work properly. Currently the tests are only run if the `GAP` environment variable is set, but libsemigroups doesn't set this variable.

After merging into `stable-3.0`, this needs to be merged into `master` before the libsemigroups Travis setup will work properly.