### PR TITLE
Adjust Makefile.am to copy recursively

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ endif
 
 all-local: semigroups.la
 	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR) $(top_srcdir)/bin/lib
-	cp src/libsemigroups/.libs/* $(top_srcdir)/bin/lib/
+	cp -R src/libsemigroups/.libs/* $(top_srcdir)/bin/lib/
 if SYS_IS_CYGWIN
 	cp .libs/semigroups.dll $(GAPINSTALLLIB)
 else


### PR DESCRIPTION
When compiling Semigroups at the moment in either `stable-3.0` or `master`, I get the following problem:
```
Making all in src/libsemigroups
  CXX      src/libsemigroups_la-blocks.lo
  CXX      src/libsemigroups_la-cong.lo
  CXX      src/libsemigroups_la-elements.lo
  CXX      src/libsemigroups_la-semigroups.lo
  CXX      src/libsemigroups_la-rws.lo
  CXX      src/libsemigroups_la-rwse.lo
  CXX      src/libsemigroups_la-uf.lo
  CXXLD    libsemigroups.la
  CXX      src/semigroups_la-pkg.lo
  CXX      src/semigroups_la-converter.lo
  CXX      src/semigroups_la-bipart.lo
  CXX      src/semigroups_la-uf.lo
  CXX      src/semigroups_la-fropin.lo
  CXX      src/semigroups_la-congpairs.lo
  CXX      src/semigroups_la-semigrp.lo
  CXXLD    semigroups.la
cnf/install-sh -c -d ./bin/x86_64-apple-darwin13.4.0-default64 ./bin/lib
cp src/libsemigroups/.libs/* ./bin/lib/
cp: src/libsemigroups/.libs/libsemigroups.0.dylib.dSYM is a directory (not copied).
make[1]: *** [all-local] Error 1
make: *** [all-recursive] Error 1
```
For some reason I have this `.dSYM` directory that isn't present on other peoples' systems (maybe because I'm running an old OS?). In any case, I can make this go away by changing the `cp` command in `Makefile.am` to use `-R`, which copies directories and their contents, too. This PR makes that change.