### PR TITLE
Add EvaluateExtRepObjWord change EvaluateWord

### DIFF
--- a/gap/main/orbits.gd
+++ b/gap/main/orbits.gd
@@ -8,10 +8,9 @@
 #############################################################################
 ##
 
-DeclareOperation("EvaluateWord", [IsBipartitionCollection, IsList]);
-DeclareOperation("EvaluateWord", [IsPartialPermCollection, IsList]);
-DeclareOperation("EvaluateWord",
-                 [IsReesZeroMatrixSemigroupElementCollection, IsList]);
+DeclareOperation("EvaluateWord", [IsMultiplicativeElementCollection, IsList]);
+DeclareOperation("EvaluateExtRepObjWord",
+                 [IsMultiplicativeElementCollection, IsList]);
 DeclareOperation("TraceSchreierTreeOfSCCForward",
                  [IsOrbit, IsPosInt, IsPosInt]);
 DeclareOperation("TraceSchreierTreeOfSCCBack",

--- a/gap/main/orbits.gi
+++ b/gap/main/orbits.gi
@@ -158,8 +158,9 @@ function(o, limit)
   return o;
 end);
 
-InstallMethod(EvaluateWord, "for bipartition coll and list of integers",
-[IsBipartitionCollection, IsList],
+InstallMethod(EvaluateWord,
+"for multiplicative element with one coll and list of integers",
+[IsMultiplicativeElementWithOneCollection, IsList],
 function(gens, w)
     local i, res;
     if Length(w) = 0  then
@@ -167,36 +168,59 @@ function(gens, w)
     fi;
     res := gens[AbsInt(w[1])] ^ SignInt(w[1]);
     for i in [2 .. Length(w)]  do
-      res := res * gens[AbsInt(w[i])] ^ SignInt(w[i]);
-    od;
-    return res;
-end);
-
-InstallMethod(EvaluateWord, "for partial perm coll and list of integers",
-[IsPartialPermCollection, IsList],
-function(gens, w)
-    local i, res;
-    if Length(w) = 0  then
-      return One(gens);
-    fi;
-    res := gens[AbsInt(w[1])] ^ SignInt(w[1]);
-    for i  in [2 .. Length(w)]  do
       res := res * gens[AbsInt(w[i])] ^ SignInt(w[i]);
     od;
     return res;
 end);
 
 InstallMethod(EvaluateWord,
-"for Rees 0-matrix semigroup element collection and a list of positive ints",
-[IsReesZeroMatrixSemigroupElementCollection, IsList],
+"for multiplicative element coll and list of integers",
+[IsMultiplicativeElementCollection, IsList],
 function(gens, w)
     local i, res;
     if Length(w) = 0  then
       return SEMIGROUPS.UniversalFakeOne;
     fi;
-    res := gens[w[1]];
+    res := gens[AbsInt(w[1])] ^ SignInt(w[1]);
     for i in [2 .. Length(w)]  do
-      res := res * gens[w[i]];
+      res := res * gens[AbsInt(w[i])] ^ SignInt(w[i]);
+    od;
+    return res;
+end);
+
+InstallMethod(EvaluateExtRepObjWord,
+"for a multiplicative element coll and list of integers",
+[IsMultiplicativeElementCollection, IsList],
+function(gens, w)
+  local res, i;
+    if Length(w) = 0 then
+      ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
+                    "must be a non-empty list");
+    elif Length(w) mod 2 = 1 then
+      ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
+                    "must be a list of even length");
+    fi;
+    res := gens[AbsInt(w[1])] ^ w[2];
+    for i in [3, 5 .. Length(w) - 1] do
+      res := res * gens[AbsInt(w[i])] ^ w[i + 1];
+    od;
+    return res;
+end);
+
+InstallMethod(EvaluateExtRepObjWord,
+"for a multiplicative element with one coll and list of integers",
+[IsMultiplicativeElementWithOneCollection, IsList],
+function(gens, w)
+  local res, i;
+    if Length(w) = 0 then
+      return One(gens);
+    elif Length(w) mod 2 = 1 then
+      ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
+                    "must be a list of even length");
+    fi;
+    res := gens[AbsInt(w[1])] ^ w[2];
+    for i in [3, 5 .. Length(w) - 1] do
+      res := res * gens[AbsInt(w[i])] ^ w[i + 1];
     od;
     return res;
 end);

--- a/tst/standard/semifp.tst
+++ b/tst/standard/semifp.tst
@@ -2121,6 +2121,23 @@ true
 gap> ForAll(tst{[1 .. 10]}, S -> BruteForceInverseCheck(IsomorphismFpSemigroup(S)));
 true
 
+# Test EvaluateExtRepObjWord
+gap> F := FreeSemigroup(4);;
+gap> x := EvaluateExtRepObjWord(Generators(F), [1, 4, 2, 5, 3, 1, 2, 1]);
+s1^4*s2^5*s3*s2
+gap> ExtRepOfObj(x) = [1, 4, 2, 5, 3, 1, 2, 1];
+true
+gap> EvaluateExtRepObjWord(Generators(F), []);
+Error, Semigroups: EvaluateExtRepObjWord, the second argument must be a non-em\
+pty list
+gap> F := FreeMonoid(4);;
+gap> x := EvaluateExtRepObjWord(Generators(F), [1, 4, 2, 5, 3, 1, 2, 1]);
+m1^4*m2^5*m3*m2
+gap> ExtRepOfObj(x) = [1, 4, 2, 5, 3, 1, 2, 1];
+true
+gap> EvaluateExtRepObjWord(Generators(F), []);
+<identity ...>
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);


### PR DESCRIPTION
Added new method `EvaluateExtRepObjWord` to help when dealing with ExtRep objects. Reduced the three methods for `EvaluateWord` to two methods that have less restrictive filters.

EDIT: I still need to add documentation and tests