### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ before_script:
     fi;
   - if [ "$ABI" == "64" ]; then sudo apt-get install libgmp-dev; fi;
   - if [ "$ABI" == "32" ]; then
+      sudo apt-get install libtool 
       sudo apt-get install libgmp-dev:i386;
       sudo ln -s /usr/include/asm-generic /usr/include/asm;
     fi;

--- a/src/bipart.h
+++ b/src/bipart.h
@@ -19,9 +19,9 @@
 #ifndef SEMIGROUPS_SRC_BIPART_H_
 #define SEMIGROUPS_SRC_BIPART_H_
 
-#include "semigroups-debug.h"
 #include "libsemigroups/src/elements.h"
 #include "pkg.h"
+#include "semigroups-debug.h"
 #include "src/compiled.h"
 
 using libsemigroups::Bipartition;

--- a/src/congpairs.cc
+++ b/src/congpairs.cc
@@ -19,9 +19,9 @@
 #include "src/congpairs.h"
 
 #include <string>
-#include <vector>
-#include <utility>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "fropin.h"
 #include "rnams.h"

--- a/src/congpairs.h
+++ b/src/congpairs.h
@@ -19,6 +19,18 @@
 #ifndef SEMIGROUPS_SRC_CONGPAIRS_H_
 #define SEMIGROUPS_SRC_CONGPAIRS_H_
 
+// Inclusion of <cstdef> appears to be required to prevent travis from issuing
+// the warning:
+//
+//     /usr/include/c++/5/cstddef:51:11: error: ‘::max_align_t’ has not been
+//     declared
+//
+// according to:
+//
+// https://stackoverflow.com/questions/35110786/how-to-fix-the-error-max-align-t
+
+#include <cstddef>
+
 #include "src/compiled.h"
 
 // GAP level functions

--- a/src/converter.cc
+++ b/src/converter.cc
@@ -67,7 +67,7 @@ Obj BoolMatConverter::unconvert(Element const* x) const {
 #ifdef SET_ELM_BLIST
         SET_ELM_BLIST(blist, j + 1, True);  // for GAP < 4.9
 #else
-        SET_BIT_BLIST(blist, j + 1);    // for GAP >= 4.9
+        SET_BIT_BLIST(blist, j + 1);  // for GAP >= 4.9
 #endif
       }
     }

--- a/src/converter.h
+++ b/src/converter.h
@@ -19,6 +19,18 @@
 #ifndef SEMIGROUPS_SRC_CONVERTER_H_
 #define SEMIGROUPS_SRC_CONVERTER_H_
 
+// Inclusion of <cstdef> appears to be required to prevent travis from issuing
+// the warning:
+//
+//     /usr/include/c++/5/cstddef:51:11: error: ‘::max_align_t’ has not been
+//     declared
+//
+// according to:
+//
+// https://stackoverflow.com/questions/35110786/how-to-fix-the-error-max-align-t
+
+#include <cstddef>
+
 #include <algorithm>
 #include <vector>
 

--- a/src/pkg.cc
+++ b/src/pkg.cc
@@ -27,8 +27,8 @@
 #include "bipart.h"
 #include "congpairs.h"
 #include "converter.h"
-#include "semigroups-debug.h"
 #include "fropin.h"
+#include "semigroups-debug.h"
 #include "semigrp.h"
 #include "uf.h"
 

--- a/src/pkg.h
+++ b/src/pkg.h
@@ -23,11 +23,23 @@
 #ifndef SEMIGROUPS_SRC_PKG_H_
 #define SEMIGROUPS_SRC_PKG_H_
 
+// Inclusion of <cstdef> appears to be required to prevent travis from issuing
+// the warning:
+//
+//     /usr/include/c++/5/cstddef:51:11: error: ‘::max_align_t’ has not been
+//     declared
+//
+// according to:
+//
+// https://stackoverflow.com/questions/35110786/how-to-fix-the-error-max-align-t
+
+#include <cstddef>
+
 #include <iostream>
 #include <vector>
 
-#include "semigroups-debug.h"
 #include "rnams.h"
+#include "semigroups-debug.h"
 
 #include "src/compiled.h"
 

--- a/src/semigroups-debug.h
+++ b/src/semigroups-debug.h
@@ -22,7 +22,6 @@
 #define SEMIGROUPS_SRC_SEMIGROUPS_DEBUG_H_
 
 #include <assert.h>
-#include <src/compiled.h>
 
 #include "semigroups-config.h"
 

--- a/src/uf.cc
+++ b/src/uf.cc
@@ -22,8 +22,8 @@
 
 #include "uf.h"
 
-#include "semigroups-debug.h"
 #include "pkg.h"
+#include "semigroups-debug.h"
 #include "src/compiled.h"
 
 #include "libsemigroups/src/uf.h"


### PR DESCRIPTION
It looks like all of the travis builds are failing with:

~~~~
In file included from /usr/include/x86_64-linux-gnu/gmp.h:51:0,
                 from /home/travis/gap/src/integer.h:24,
                 from /home/travis/gap/src/compiled.h:35,
                 from src/semigroups-debug.h:25,
                 from src/pkg.h:29,
                 from src/pkg.cc:23:
/usr/include/c++/5/cstddef:51:11: error: ‘::max_align_t’ has not been declared
   using ::max_align_t;
~~~~
this PR attempts to resolve this. 