### PR TITLE
Use IS_CONSTRUCTOR instead of CONSTRUCTORS

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -236,7 +236,7 @@ Dependencies := rec(
   GAP := ">=4.9.0",
   NeededOtherPackages := [["orb", ">=4.8.0"],
                           ["io", ">=4.5.1"],
-                          ["digraphs", ">=0.11.0"],
+                          ["digraphs", ">=0.12.0"],
                           ["genss", ">=1.5"]],
   SuggestedOtherPackages := [["gapdoc", ">=1.5.1"]],
 

--- a/gap/tools/utils.gi
+++ b/gap/tools/utils.gi
@@ -427,7 +427,7 @@ SEMIGROUPS.ManSectionType := function(op)
     class := "Oper";
     if IS_IDENTICAL_OBJ(op, IS_OBJECT) then
       class := "Filt";
-    elif op in CONSTRUCTORS then
+    elif IS_CONSTRUCTOR(op) then
       class := "Constructor";
       # seem to never get one
     elif IsFilter(op) then


### PR DESCRIPTION
CONSTRUCTORS has been removed from the GAP master branch: see https://github.com/gap-system/gap/pull/2114/commits/b597f5cbf18b89e9264d2fff4362c0c652d22270