### PR TITLE
Smaller generating pair sets for RMS congruences

### DIFF
--- a/doc/cong.xml
+++ b/doc/cong.xml
@@ -573,7 +573,7 @@ gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3),
 gap> cong := CongruencesOfSemigroup(S)[3];;
 gap> AsSemigroupCongruenceByGeneratingPairs(cong);
 <semigroup congruence over <Rees 0-matrix semigroup 2x2 over 
-  Sym( [ 1 .. 3 ] )> with 3 generating pairs>]]></Example>
+  Sym( [ 1 .. 3 ] )> with 1 generating pairs>]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/gap/congruences/congrms.gi
+++ b/gap/congruences/congrms.gi
@@ -1260,48 +1260,59 @@ InstallMethod(GeneratingPairsOfMagmaCongruence,
 "for Rees matrix semigroup congruence by linked triple",
 [IsRMSCongruenceByLinkedTriple],
 function(cong)
-  local S, g, m, pairs, x, bl, j, rowNo, i, colNo;
+  local S, G, m, pairs, n_gens, col_pairs, bl, j, row_pairs, max, n, cp, rp,
+        pair_no, r, c;
   S := Range(cong);
-  g := UnderlyingSemigroup(S);
+  G := UnderlyingSemigroup(S);
   m := Matrix(S);
-
-  # Create a list of generating pairs
   pairs := [];
 
-  # PAIRS FROM THE NORMAL SUBGROUP
-  # for each x in the subgroup,
-  # (1,x,1) is related to (1,id,1)
-  for x in cong!.n do
-    Add(pairs, [RMSElement(S, 1, x, 1),
-                RMSElement(S, 1, One(g), 1)]);
-  od;
+  # Normal subgroup elements to identify with id
+  n_gens := GeneratorsOfSemigroup(cong!.n);
 
-  # PAIRS FROM THE COLUMNS RELATION
-  # For each class in the relation...
+  # Pairs that generate the columns relation
+  col_pairs := [];
   for bl in cong!.colBlocks do
-    # For each column in the class...
     for j in [2 .. Size(bl)] do
-      # For each row in the matrix...
-      for rowNo in [1 .. Size(m)] do
-        Add(pairs,
-            [RMSElement(S, bl[1], m[rowNo][bl[1]] ^ -1, rowNo),
-             RMSElement(S, bl[j], m[rowNo][bl[j]] ^ -1, rowNo)]);
-      od;
+      Add(col_pairs, [bl[1], bl[j]]);
     od;
   od;
 
-  # PAIRS FROM THE ROWS RELATION
-  # For each class in the relation...
+  # Pairs that generate the rows relation
+  row_pairs := [];
   for bl in cong!.rowBlocks do
-    # For each row in the class...
-    for i in [2 .. Size(bl)] do
-      # For each column in the matrix...
-      for colNo in [1 .. Size(m[1])] do
-        Add(pairs,
-            [RMSElement(S, colNo, m[bl[1]][colNo] ^ -1, bl[1]),
-             RMSElement(S, colNo, m[bl[i]][colNo] ^ -1, bl[i])]);
-      od;
+    for j in [2 .. Size(bl)] do
+      Add(row_pairs, [bl[1], bl[j]]);
     od;
+  od;
+
+  # Collate into RMS element pairs
+  max := Maximum(Length(n_gens), Length(col_pairs), Length(row_pairs));
+  pairs := EmptyPlist(max);
+  # Set default values in case a list has length 0
+  n := One(G);
+  cp := [1, 1];
+  rp := [1, 1];
+  # Iterate through all 3 lists together
+  for pair_no in [1 .. max] do
+    # If any list has run out, just keep using the last entry or default value
+    if pair_no <= Length(n_gens) then
+      n := n_gens[pair_no];
+    fi;
+    if pair_no <= Length(col_pairs) then
+      cp := col_pairs[pair_no];
+    fi;
+    if pair_no <= Length(row_pairs) then
+      rp := row_pairs[pair_no];
+    fi;
+    # Choose r and c s.t. m[r][cp[1]] and m[rp[1]][c] are both non-zero
+    # (since there are no zeroes, we can just use 1 for both)
+    r := 1;
+    c := 1;
+    # Make the pair and add it
+    pairs[pair_no] :=
+      [RMSElement(S, cp[1], m[r][cp[1]] ^ -1 * n * m[rp[1]][c] ^ -1, rp[1]),
+       RMSElement(S, cp[2], m[r][cp[2]] ^ -1 * m[rp[2]][c] ^ -1, rp[2])];
   od;
   return pairs;
 end);
@@ -1310,55 +1321,58 @@ InstallMethod(GeneratingPairsOfMagmaCongruence,
 "for Rees 0-matrix semigroup congruence by linked triple",
 [IsRZMSCongruenceByLinkedTriple],
 function(cong)
-  local S, g, m, pairs, i1, x, bl, j, rowNo, i, colNo;
+  local S, G, m, pairs, n_gens, col_pairs, bl, j, row_pairs, max, n, cp, rp,
+        pair_no, r, c;
   S := Range(cong);
-  g := UnderlyingSemigroup(S);
+  G := UnderlyingSemigroup(S);
   m := Matrix(S);
-
-  # Create a list of generating pairs
   pairs := [];
 
-  # PAIRS FROM THE NORMAL SUBGROUP
-  # First, find a matrix entry not equal to zero
-  i1 := PositionProperty(m[1], x -> x <> 0);
+  # Normal subgroup elements to identify with id
+  n_gens := GeneratorsOfSemigroup(cong!.n);
 
-  # for each x in the subgroup,
-  # (i1,x,1) is related to (i1,id,1)
-  for x in cong!.n do
-    Add(pairs, [RMSElement(S, i1, x, 1),
-                RMSElement(S, i1, One(g), 1)]);
-  od;
-
-  # PAIRS FROM THE COLUMNS RELATION
-  # For each class in the relation...
+  # Pairs that generate the columns relation
+  col_pairs := [];
   for bl in cong!.colBlocks do
-    # For each column in the class...
     for j in [2 .. Size(bl)] do
-      # For each row in the matrix...
-      for rowNo in [1 .. Size(m)] do
-        if m[rowNo][bl[1]] <> 0 then
-          Add(pairs,
-              [RMSElement(S, bl[1], m[rowNo][bl[1]] ^ -1, rowNo),
-               RMSElement(S, bl[j], m[rowNo][bl[j]] ^ -1, rowNo)]);
-        fi;
-      od;
+      Add(col_pairs, [bl[1], bl[j]]);
     od;
   od;
 
-  # PAIRS FROM THE ROWS RELATION
-  # For each class in the relation...
+  # Pairs that generate the rows relation
+  row_pairs := [];
   for bl in cong!.rowBlocks do
-    # For each row in the class...
-    for i in [2 .. Size(bl)] do
-      # For each column in the matrix...
-      for colNo in [1 .. Size(m[1])] do
-        if m[bl[1]][colNo] <> 0 then
-          Add(pairs,
-              [RMSElement(S, colNo, m[bl[1]][colNo] ^ -1, bl[1]),
-               RMSElement(S, colNo, m[bl[i]][colNo] ^ -1, bl[i])]);
-        fi;
-      od;
+    for j in [2 .. Size(bl)] do
+      Add(row_pairs, [bl[1], bl[j]]);
     od;
+  od;
+
+  # Collate into RMS element pairs
+  max := Maximum(Length(n_gens), Length(col_pairs), Length(row_pairs));
+  pairs := EmptyPlist(max);
+  # Set default values in case a list has length 0
+  n := One(G);
+  cp := [1, 1];
+  rp := [1, 1];
+  # Iterate through all 3 lists together
+  for pair_no in [1 .. max] do
+    # If any list has run out, just keep using the last entry or default value
+    if pair_no <= Length(n_gens) then
+      n := n_gens[pair_no];
+    fi;
+    if pair_no <= Length(col_pairs) then
+      cp := col_pairs[pair_no];
+    fi;
+    if pair_no <= Length(row_pairs) then
+      rp := row_pairs[pair_no];
+    fi;
+    # Choose r and c s.t. m[r][cp[1]] and m[rp[1]][c] are both non-zero
+    r := First([1 .. Length(m)], r -> m[r][cp[1]] <> 0);
+    c := First([1 .. Length(m[1])], c -> m[rp[1]][c] <> 0);
+    # Make the pair and add it
+    pairs[pair_no] :=
+      [RMSElement(S, cp[1], m[r][cp[1]] ^ -1 * n * m[rp[1]][c] ^ -1, rp[1]),
+       RMSElement(S, cp[2], m[r][cp[2]] ^ -1 * m[rp[2]][c] ^ -1, rp[2])];
   od;
   return pairs;
 end);

--- a/tst/standard/conguniv.tst
+++ b/tst/standard/conguniv.tst
@@ -238,10 +238,10 @@ gap> S := Semigroup([Transformation([2, 1, 2]),
 gap> uni := UniversalSemigroupCongruence(S);
 <universal semigroup congruence over <transformation semigroup of degree 3 
  with 2 generators>>
-gap> GeneratingPairsOfSemigroupCongruence(uni);
-[ [ Transformation( [ 1, 2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ], 
-  [ Transformation( [ 2, 1, 2 ] ), Transformation( [ 1, 2, 1 ] ) ], 
-  [ Transformation( [ 1, 2, 1 ] ), Transformation( [ 1, 2, 2 ] ) ] ]
+gap> pairs := GeneratingPairsOfSemigroupCongruence(uni);;
+gap> cong := SemigroupCongruenceByGeneratingPairs(S, pairs);;
+gap> NrCongruenceClasses(cong);
+1
 
 #T# IsUniversalSemigroupCongruence for a cong by generating pairs
 gap> S := Semigroup([PartialPerm([1], [2]),


### PR DESCRIPTION
If `cong` is a congruence on a finite (0-)simple semigroup described by a linked triple (i.e. if it satisfies `IsR(Z)MSCongruenceByLinkedTriple`) then we might wish to convert it to a congruence defined by generating pairs (e.g. by using `AsSemigroupCongruenceByGeneratingPairs`).  This uses a special method for `GeneratingPairsOfMagmaCongruence`, which is installed in `congrms.gi`.

It turns out that the current method is really bad in terms of the number of pairs it spits out.  It iterates over every element of the normal subgroup `n`, and doesn't combine this in any way with the column and row operations.  This PR replaces it with an all-new, improved algorithm which avoids unnecessary work and condenses the information into as few pairs as possible.  The number of generating pairs produced is drastically reduced, as displayed in the following example:

```
gap> g := SymmetricGroup(4);;
gap> mat := [[(1, 3), (1, 2)(3, 4)],
>            [(1, 4, 3, 2), ()],
>            [(1, 3)(2, 4), (1, 3, 4, 2)]];;
gap> S := ReesMatrixSemigroup(g, mat);;
gap> congs := CongruencesOfSemigroup(S);;
gap> List(congs, c -> Size(GeneratingPairsOfSemigroupCongruence(c)));
```
The output of this example is currently
```[ 1, 4, 6, 12, 14, 14, 16, 14, 15, 17, 17, 19, 17, 24, 26, 26, 28, 26, 27, 29, 29, 31, 29 ]```
but after this PR it is improved to
```[ 1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ]```

The idea behind the algorithm is to create three lists:
* pairs of columns to be identified
* pairs of rows to be identified
* group elements to be put into the normal subgroup `n`

and then to make pairs of RMS elements for the generating set, where each pair of RMS elements encompasses three pieces of information, one from each list of these three lists.  I'm currently TeXing a proper description of the algorithm and a proof of its validity for my thesis (I can show this to anyone who's interested when it's done).  Anyway, I'm confident it is correct, and it certainly passes the suite of tests we have, along with any more I've thrown at it.

Note that currently `congrms` has different for RMS and RZMS congruences.  These methods are different but similar, causing a certain amount of code duplication.  This duplication should be removed eventually, but this PR doesn't make it any worse.