### PR TITLE
Fix issue #461 (NrCongruenceClasses)

### DIFF
--- a/gap/congruences/cong.gi
+++ b/gap/congruences/cong.gi
@@ -26,7 +26,11 @@
 InstallMethod(NrEquivalenceClasses, "for a semigroup congruence",
 [IsSemigroupCongruence],
 function(cong)
-  return Length(EquivalenceClasses(cong));
+  local classes;
+  classes := EquivalenceClasses(cong);
+  # Note: EquivalenceClasses may exclude all singletons due to a bug in GAP.
+  # This is a workaround which adds any missing singletons.
+  return Length(classes) + Size(Range(cong)) - Sum(classes, Size);
 end);
 
 InstallMethod(\in,

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1743,6 +1743,19 @@ false
 gap> Size(M0);
 0
 
+# Issue 461: NrCongruenceClasses gives incorrect answer
+gap> tab := [[1, 2, 3, 3], [2, 3, 1, 1], [3, 1, 2, 2], [3, 1, 2, 2]];;
+gap> S := SemigroupByMultiplicationTable(tab);;
+gap> cong := SemigroupCongruence(S, [[S.3, S.4]]);;
+gap> S.1 in EquivalenceClassOfElement(cong, S.3);
+false
+gap> NrCongruenceClasses(cong);
+3
+gap> S.1 in EquivalenceClassOfElement(cong, S.3);
+false
+gap> IsUniversalSemigroupCongruence(cong);
+false
+
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(D);
@@ -1787,6 +1800,7 @@ gap> Unbind(rel);
 gap> Unbind(s);
 gap> Unbind(sgns);
 gap> Unbind(t);
+gap> Unbind(tab);
 gap> Unbind(tuples);
 gap> Unbind(u);
 gap> Unbind(x);


### PR DESCRIPTION
This PR fixes issue #461 by altering `NrEquivalenceClasses`.  The new version doesn't assume that singletons are included in the output of `EquivalenceClasses`, and adds to the output appropriately.  The number of equivalence classes is equal to:

```(Number of EquivalenceClasses) + (Size of semigroup) - (Sum of the sizes of EquivalenceClasses)```

I added a test to `SemigroupsTestInstall` to check it's working.