### PR TITLE
Remove IndecomposableElements immediate method

### DIFF
--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -943,15 +943,14 @@ function(S)
   TryNextMethod();
 end);
 
-InstallImmediateMethod(IndecomposableElements,
-IsDecomposableSemigroup, 0,
-S -> []);
-
 InstallMethod(IndecomposableElements, "for a semigroup",
 [IsSemigroup],
 function(S)
   local out, D;
 
+  if HasIsDecomposableSemigroup(S) and IsDecomposableSemigroup(S) then
+    return [];
+  fi;
   out := [];
   for D in MaximalDClasses(S) do
     if not IsRegularDClass(D) then

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1730,7 +1730,7 @@ true
 gap> HasIsDecomposableSemigroup(S) and IsDecomposableSemigroup(S);
 true
 gap> HasIndecomposableElements(S);
-true
+false
 gap> IndecomposableElements(S);
 [  ]
 gap> S := MonogenicSemigroup(3, 2);;


### PR DESCRIPTION
I'm not sure why I created an immediate method for `IndecomposableElements`. This PR removes the immediate method, because of https://github.com/gap-system/gap/issues/2377. It doesn't seem to serve an important purpose. I think I just assumed that setting an empty list as an attribute was cheap.