### PR TITLE
kernel: update to check for GAP kernel version for GVarFilt definition

### DIFF
--- a/src/pkg.cc
+++ b/src/pkg.cc
@@ -401,7 +401,11 @@ Obj IsActingSemigroup;
  *V  GVarFilts . . . . . . . . . . . . . . . . . . . list of filters to export
  */
 
+#if defined(GAP_KERNEL_MAJOR_VERSION) && (GAP_KERNEL_MAJOR_VERSION >= 2)
+typedef Obj (*GVarFilt)(Obj, Obj);
+#else
 typedef Obj (*GVarFilt)(/*arguments*/);
+#endif
 
 static StructGVarFilt GVarFilts[] = {
     {"IS_BIPART",


### PR DESCRIPTION
Check the kernel version of GAP to see which signature `GVarFilt` should have.