### PR TITLE
Add method to find all the ideals of a semigroup

### DIFF
--- a/doc/ideals.xml
+++ b/doc/ideals.xml
@@ -152,3 +152,38 @@ false]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="Ideals">
+  <ManSection>
+    <Attr Name = "Ideals" Arg = "S" Label = "for a semigroup"/>
+    <Returns>
+      An list of ideals.
+    </Returns>
+    <Description>
+      If <A>S</A> is a finite non-empty semigroup, then this attribute returns a
+      list of all the ideals of <A>S</A>. <P/>
+
+      The ideals are returned in no particular order, and each ideal uses the
+      minimum possible number of generators
+      (see <Ref Attr = "GeneratorsOfSemigroupIdeal"/>).
+
+      <Example><![CDATA[
+gap> S := Semigroup([Transformation([4, 3, 4, 1]),
+>                    Transformation([4, 3, 2, 2])]);
+<transformation semigroup of degree 4 with 2 generators>
+gap> Ideals(S);
+[ <non-regular transformation semigroup ideal of degree 4 with
+      1 generator>, 
+ <non-regular transformation semigroup ideal of degree 4 with
+     1 generator>, 
+<non-regular transformation semigroup ideal of degree 4 with
+    2 generators>, 
+<regular transformation semigroup ideal of degree 4 with 1 generator>,
+<non-regular transformation semigroup ideal of degree 4 with
+  1 generator>, 
+<regular transformation semigroup ideal of degree 4 with 1 generator> 
+]
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/z-chap07.xml
+++ b/doc/z-chap07.xml
@@ -29,6 +29,7 @@
     </Heading>
 
     <#Include Label = "SemigroupIdeal">
+    <#Include Label = "Ideals">
  
   </Section>
  

--- a/gap/ideals/ideals.gd
+++ b/gap/ideals/ideals.gd
@@ -42,3 +42,5 @@ DeclareAttribute("MinimalIdealGeneratingSet", IsSemigroupIdeal);
 DeclareAttribute("SupersemigroupOfIdeal", IsSemigroupIdeal);
 
 InstallTrueMethod(IsSemigroup, IsSemigroupIdeal);
+
+DeclareAttribute("Ideals", IsSemigroup);

--- a/gap/ideals/ideals.gi
+++ b/gap/ideals/ideals.gi
@@ -424,3 +424,23 @@ function(I)
   fi;
   return false;
 end);
+
+InstallMethod(Ideals, "for a finite semigroup",
+[IsSemigroup and IsFinite],
+function(S)
+  local reps, gr, cliques;
+  # Groups have only one ideal
+  if IsGroup(S) or (HasIsGroupAsSemigroup(S) and IsGroupAsSemigroup(S)) then
+    return [SemigroupIdeal(S, S.1)];
+  fi;
+  reps := DClassReps(S);
+  # Digraph of D-class partial order
+  gr := Digraph(PartialOrderOfDClasses(S));
+  # Graph with an edge between any two comparable D-classes
+  gr := DigraphSymmetricClosure(DigraphReflexiveTransitiveClosure(gr));
+  # Graph with an edge between any two non-comparable D-classes
+  gr := DigraphDual(gr);
+  # All non-empty sets of pairwise incomparable D-classes
+  cliques := DigraphCliques(gr);
+  return List(cliques, clique -> SemigroupIdeal(S, reps{clique}));
+end);

--- a/tst/standard/ideals.tst
+++ b/tst/standard/ideals.tst
@@ -329,6 +329,17 @@ gap> ideals := Ideals(S);;
 gap> Size(ideals);
 179
 
+# SEMIGROUPS_UnbindVariables
+gap> Unbind(A);
+gap> Unbind(I);
+gap> Unbind(J);
+gap> Unbind(S);
+gap> Unbind(T);
+gap> Unbind(ideals);
+gap> Unbind(x);
+gap> Unbind(y);
+gap> Unbind(z);
+
 #
 gap> SEMIGROUPS.StopTest();
 gap> STOP_TEST("Semigroups package: standard/ideals.tst");

--- a/tst/standard/ideals.tst
+++ b/tst/standard/ideals.tst
@@ -302,6 +302,33 @@ gap> I := MinimalIdeal(I);
 gap> IsFactorisableInverseMonoid(I);
 false
 
+# Test Ideals method
+gap> S := Semigroup([Transformation([5, 3, 1, 5, 3]),
+>                    Transformation([4, 3, 1, 5, 5]),
+>                    Transformation([1, 5, 5, 4, 2])]);;
+gap> ideals := Ideals(S);;
+gap> Size(ideals);
+17
+gap> IsDuplicateFreeList(ideals);
+true
+gap> S := TrivialSemigroup(IsBlockBijectionSemigroup);;
+gap> ideals := Ideals(S);;
+gap> Size(ideals);
+1
+gap> Size(ideals[1]);
+1
+gap> A := AlternatingGroup(100);;
+gap> ideals := Ideals(S);;
+gap> Size(ideals);
+1
+gap> S := Semigroup([
+>           Bipartition([[1, 2, -1, -4], [3, -5], [4], [5, -2], [-3]]), 
+>           Bipartition([[1, 2, 4, -3, -5], [3, -4], [5, -1, -2]]),
+>           Bipartition([[1, 2, 5, -3, -4], [3, 4, -1, -2], [-5]])]);;
+gap> ideals := Ideals(S);;
+gap> Size(ideals);
+179
+
 #
 gap> SEMIGROUPS.StopTest();
 gap> STOP_TEST("Semigroups package: standard/ideals.tst");


### PR DESCRIPTION
This pull request adds a new attribute for a semigroup, called `Ideals`.  An attribute with the same name already exists for rings, so I chose this name for consistency.  I've only added a method for _finite_ semigroups – I'm not sure how we would approach infinite semigroups.

An ideal is a downward closed union of D-classes.  So to find all the ideals, we first find all the D-classes, then find every possible set of pairwise incomparable D-classes.  For each set, we take an element from each class, and use these as generators for an ideal (they generate all the D-classes that lie below them).  In this way, we use the minimum possible number of generators for each ideal, since we only use one generator from each of the ideal's maximal D-classes.

It turns out the Digraphs package is quite useful for implementing this, so we use several Digraphs methods, including `DigraphCliques`.

Doc and tests are included.  Since this is a new feature, I've put it on `master`.