### PR TITLE
Use MarkBag instead of MARK_BAG

### DIFF
--- a/src/pkg.cc
+++ b/src/pkg.cc
@@ -327,11 +327,11 @@ void TBlocksObjLoadFunc(Obj o) {
 void TBipartObjMarkSubBags(Obj o) {
   if (ADDR_OBJ(o)[1] != NULL) {
     // SEMIGROUPS_ASSERT(TNUM_OBJ(ADDR_OBJ(o)[1]) == T_BLOCKS);
-    MARK_BAG(ADDR_OBJ(o)[1]);
+    MarkBag(ADDR_OBJ(o)[1]);
   }
   if (ADDR_OBJ(o)[2] != NULL) {
     // SEMIGROUPS_ASSERT(TNUM_OBJ(ADDR_OBJ(o)[2]) == T_BLOCKS);
-    MARK_BAG(ADDR_OBJ(o)[2]);
+    MarkBag(ADDR_OBJ(o)[2]);
   }
 }
 


### PR DESCRIPTION
In GAP 4.9, the latter is an alias for backwards compatibility for the former.

Alternatively, one could replace `TBipartObjMarkSubBags` by `MarkTwoSubBags` if one was willing to reorder the content of `T_BIPART` blocks so that the two subobject pointers come first, and the C++ pointer last (instead of first).