### PR TITLE
Make McAlister triple semigroups acting

### DIFF
--- a/doc/semieunit.xml
+++ b/doc/semieunit.xml
@@ -118,11 +118,7 @@ gap> T := McAlisterTripleSemigroup(A, x, y);
 gap> S = T;
 false
 gap> IsIsomorphicSemigroup(S, T);
-true
-gap> GeneratorsOfSemigroup(T);
-[ (1, ()), (4, ()), (5, ()), (1, (2,4)(3,5)) ]
-gap> AsSemigroup(IsPartialPermSemigroup, T);
-<inverse partial perm monoid of size 4, rank 4 with 4 generators>]]></Example>
+true]]></Example>
   </Description>
   </ManSection>
 <#/GAPDoc>

--- a/gap/main/setup.gi
+++ b/gap/main/setup.gi
@@ -51,7 +51,8 @@ InstallMethod(IsGeneratorsOfActingSemigroup,
 "for a McAlister triple element collection",
 [IsMcAlisterTripleSemigroupElementCollection],
 function(coll)
-  return IsPermGroup(McAlisterTripleSemigroupGroup(MTSEParent(coll[1])));
+  return
+  IsPermGroup(McAlisterTripleSemigroupGroup(MTSEParent(Representative(coll))));
     # and McAlisterTripleSemigroupAction(MTSEParent(coll[1])) = OnPoints;
 end);
 
@@ -102,11 +103,10 @@ function(x)
   return NrMovedPoints(x![2]) + 1;
 end);
 
-# TODO correct?
 InstallMethod(ActionDegree, "for a McAlister semigroup element",
 [IsMcAlisterTripleSemigroupElement],
 function(x)
-  return NrMovedPoints(x[2]);
+  return 0;
 end);
 
 InstallMethod(ActionDegree, "for a matrix over finite field object",
@@ -169,14 +169,10 @@ function(R)
   return 0;
 end);
 
-# TODO check this is ok?
-
 InstallMethod(ActionDegree, "for a McAlister triple subsemigroup",
 [IsMcAlisterTripleSubsemigroup],
 function(S)
-  local rep;
-  rep := Representative(S);
-  return NrMovedPoints(McAlisterTripleSemigroupGroup(MTSEParent(rep)));
+  return 0;
 end);
 
 InstallMethod(ActionDegree, "for a matrix over finite field semigroup",
@@ -248,8 +244,6 @@ function(R)
   end;
 end);
 
-# TODO: ok?
-
 InstallMethod(ActionRank, "for a McAlister triple semigroup element and int",
 [IsMcAlisterTripleSemigroupElement, IsInt],
 function(f, n)
@@ -259,8 +253,6 @@ function(f, n)
   id      := McAlisterTripleSemigroupComponents(MTSEParent(f)).id;
   return Position(DigraphTopologicalSort(digraph), id[f[1]]);
 end);
-
-# TODO: ok?
 
 InstallMethod(ActionRank, "for a McAlister triple subsemigroup",
 [IsMcAlisterTripleSubsemigroup],
@@ -784,11 +776,12 @@ end);
 InstallMethod(RhoBound, "for a Rees 0-matrix semigroup",
 [IsReesZeroMatrixSubsemigroup], LambdaBound);
 
-# TODO improve the upper bound here
 InstallMethod(LambdaBound, "for a McAlister subsemigroup",
 [IsMcAlisterTripleSubsemigroup], S ->
 function(r)
-  return Size(McAlisterTripleSemigroupGroup(MTSEParent(Representative(S))));
+  local G;
+  G := McAlisterTripleSemigroupGroup(MTSEParent(Representative(S)));
+  return Size(Stabilizer(G, r));
 end);
 
 InstallMethod(RhoBound, "for a McAlister subsemigroup",

--- a/gap/main/setup.gi
+++ b/gap/main/setup.gi
@@ -47,6 +47,14 @@ function(coll)
   return IsPermGroup(UnderlyingSemigroup(R)) and IsRegularSemigroup(R);
 end);
 
+InstallMethod(IsGeneratorsOfActingSemigroup,
+"for a McAlister triple element collection",
+[IsMcAlisterTripleSemigroupElementCollection],
+function(coll)
+  return IsPermGroup(McAlisterTripleSemigroupGroup(MTSEParent(coll[1])));
+    # and McAlisterTripleSemigroupAction(MTSEParent(coll[1])) = OnPoints;
+end);
+
 # FIXME with the below uncommented many tests fail
 ## The HasRows and HasColumns could be removed if it was possible to apply
 ## immediate methods to Rees 0-matrix semigroups
@@ -94,6 +102,13 @@ function(x)
   return NrMovedPoints(x![2]) + 1;
 end);
 
+# TODO correct?
+InstallMethod(ActionDegree, "for a McAlister semigroup element",
+[IsMcAlisterTripleSemigroupElement],
+function(x)
+  return NrMovedPoints(x[2]);
+end);
+
 InstallMethod(ActionDegree, "for a matrix over finite field object",
 [IsMatrixOverFiniteField], DimensionOfMatrixOverSemiring);
 
@@ -124,6 +139,12 @@ function(coll)
   return DimensionOfMatrixOverSemiring(coll[1]);
 end);
 
+InstallMethod(ActionDegree, "for a McAlister semigroup element collection",
+[IsMcAlisterTripleSemigroupElementCollection],
+function(coll)
+  return MaximumList(List(coll, x -> ActionDegree(x)));
+end);
+
 InstallMethod(ActionDegree, "for a transformation semigroup",
 [IsTransformationSemigroup], DegreeOfTransformationSemigroup);
 
@@ -146,6 +167,16 @@ function(R)
     return NrMovedPoints(UnderlyingSemigroup(parent)) + 1;
   fi;
   return 0;
+end);
+
+# TODO check this is ok?
+
+InstallMethod(ActionDegree, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  local rep;
+  rep := Representative(S);
+  return NrMovedPoints(McAlisterTripleSemigroupGroup(MTSEParent(rep)));
 end);
 
 InstallMethod(ActionDegree, "for a matrix over finite field semigroup",
@@ -217,6 +248,26 @@ function(R)
   end;
 end);
 
+# TODO: ok?
+
+InstallMethod(ActionRank, "for a McAlister triple semigroup element and int",
+[IsMcAlisterTripleSemigroupElement, IsInt],
+function(f, n)
+  local digraph, id;
+  digraph := McAlisterTripleSemigroupQuotientDigraph(MTSEParent(f));
+  digraph := DigraphReverse(digraph);
+  id      := McAlisterTripleSemigroupComponents(MTSEParent(f)).id;
+  return Position(DigraphTopologicalSort(digraph), id[f[1]]);
+end);
+
+# TODO: ok?
+
+InstallMethod(ActionRank, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return x -> ActionDegree(S);
+end);
+
 InstallMethod(ActionRank, "for a matrix object and integer",
 [IsMatrixOverFiniteField, IsInt],
 function(x, i)
@@ -243,6 +294,9 @@ InstallMethod(MinActionRank, "for a bipartition semigroup",
 InstallMethod(MinActionRank, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], x -> 0);
 
+InstallMethod(MinActionRank, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], x -> 1);
+
 InstallMethod(MinActionRank, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], x -> 0);
 
@@ -260,6 +314,9 @@ InstallMethod(LambdaOrbOpts, "for a bipartition semigroup",
 InstallMethod(LambdaOrbOpts, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], S -> rec());
 
+InstallMethod(LambdaOrbOpts, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S -> rec());
+
 InstallMethod(LambdaOrbOpts, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], s -> rec());
 
@@ -274,6 +331,9 @@ InstallMethod(RhoOrbOpts, "for a bipartition semigroup",
 
 InstallMethod(RhoOrbOpts, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], S -> rec());
+
+InstallMethod(RhoOrbOpts, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S -> rec());
 
 InstallMethod(RhoOrbOpts, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], s -> rec());
@@ -305,6 +365,24 @@ InstallMethod(LambdaAct, "for a Rees 0-matrix subsemigroup",
   else
     return 0;
   fi;
+end);
+
+InstallMethod(LambdaAct, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  local act, digraph;
+  S := MTSEParent(Representative(S));
+  act     := McAlisterTripleSemigroupAction(S);
+  digraph := McAlisterTripleSemigroupPartialOrder(S);
+  return
+  function(pt, x)
+    if pt = 0 then
+      return act(x[1], x[2] ^ -1);
+    fi;
+    return PartialOrderDigraphJoinOfVertices(digraph,
+                                             act(pt, x[2] ^ -1),
+                                             act(x[1], x[2] ^ -1));
+  end;
 end);
 
 InstallMethod(LambdaAct, "for a matrix semigroup",
@@ -345,6 +423,24 @@ InstallMethod(RhoAct, "for a Rees 0-matrix subsemigroup",
   fi;
 end);
 
+InstallMethod(RhoAct, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  local act, digraph;
+  S := MTSEParent(Representative(S));
+  act     := McAlisterTripleSemigroupAction(S);
+  digraph := McAlisterTripleSemigroupPartialOrder(S);
+  return
+    function(pt, x)
+      if pt = 0 then
+        return x[1];
+      fi;
+      return PartialOrderDigraphJoinOfVertices(digraph,
+                                               act(pt, x[2]),
+                                               x[1]);
+    end;
+end);
+
 InstallMethod(RhoAct, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup],
 function(S)
@@ -369,6 +465,9 @@ end);
 
 InstallMethod(LambdaOrbSeed, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], S -> -1);
+
+InstallMethod(LambdaOrbSeed, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S -> 0);
 
 InstallMethod(LambdaOrbSeed, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup],
@@ -396,6 +495,9 @@ end);
 
 InstallMethod(RhoOrbSeed, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], S -> -1);
+
+InstallMethod(RhoOrbSeed, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S -> 0);
 
 InstallMethod(RhoOrbSeed, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], LambdaOrbSeed);
@@ -427,6 +529,14 @@ InstallMethod(LambdaFunc, "for a Rees 0-matrix subsemigroup",
   return 0;
 end);
 
+InstallMethod(LambdaFunc, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  local act;
+  act := McAlisterTripleSemigroupAction(MTSEParent(Representative(S)));
+  return x -> act(x[1], x[2] ^ -1);
+end);
+
 InstallMethod(LambdaFunc, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup],
 s -> function(mat)
@@ -454,6 +564,12 @@ InstallMethod(RhoFunc, "for a bipartition semigroup",
 InstallMethod(RhoFunc, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], R -> (x -> x![1]));
 
+InstallMethod(RhoFunc, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return x -> x[1];
+end);
+
 InstallMethod(RhoFunc, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup],
 function(S)
@@ -464,7 +580,7 @@ function(S)
     end;
 end);
 
-# the function used to calculate the rank of lambda or rho value
+# The function used to calculate the rank of lambda or rho value
 
 InstallMethod(LambdaRank, "for a transformation semigroup",
 [IsTransformationSemigroup], x -> Length);
@@ -485,6 +601,17 @@ function(x)
     parent := ReesMatrixSemigroupOfFamily(ElementsFamily(FamilyObj(R)));
     return NrMovedPoints(UnderlyingSemigroup(parent)) + 1;
   fi;
+end);
+
+InstallMethod(LambdaRank, "for a McAlister subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S ->
+function(x)
+  local T;
+  if x = 0 then
+    return 0;
+  fi;
+  T := MTSEParent(Representative(S));
+  return ActionRank(MTSE(T, x, One(McAlisterTripleSemigroupGroup(T))), 0);
 end);
 
 # Why are there row spaces and matrices passed in here?
@@ -512,6 +639,17 @@ InstallMethod(RhoRank, "for a Rees 0-matrix subsemigroup",
 InstallMethod(RhoRank, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], S -> LambdaRank(S));
 
+InstallMethod(RhoRank, "for a McAlister subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S ->
+function(x)
+  local T;
+  if x = 0 then
+    return 0;
+  fi;
+  T := MTSEParent(Representative(S));
+  return ActionRank(MTSE(T, x, One(McAlisterTripleSemigroupGroup(T))), 0);
+end);
+
 # if g=LambdaInverse(X, f) and X^f=Y, then Y^g=X and g acts on the right
 # like the inverse of f on Y.
 
@@ -522,6 +660,11 @@ InstallMethod(LambdaInverse, "for a partial perm semigroup",
 [IsPartialPermSemigroup], S -> function(x, f)
                                  return f ^ -1;
                                end);
+
+InstallMethod(LambdaInverse, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S -> function(x, f)
+                                   return f ^ -1;
+                                 end);
 
 InstallMethod(LambdaInverse, "for a bipartition semigroup",
 [IsBipartitionSemigroup], S -> BLOCKS_INV_RIGHT);
@@ -558,6 +701,11 @@ InstallMethod(RhoInverse, "for a partial perm semigroup",
   function(dom, f)
     return f ^ -1;
   end);
+
+InstallMethod(RhoInverse, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S -> function(x, f)
+                                        return f ^ -1;
+                                      end);
 
 # JDM better method for this!!
 
@@ -636,6 +784,16 @@ end);
 InstallMethod(RhoBound, "for a Rees 0-matrix semigroup",
 [IsReesZeroMatrixSubsemigroup], LambdaBound);
 
+# TODO improve the upper bound here
+InstallMethod(LambdaBound, "for a McAlister subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S ->
+function(r)
+  return Size(McAlisterTripleSemigroupGroup(MTSEParent(Representative(S))));
+end);
+
+InstallMethod(RhoBound, "for a McAlister subsemigroup",
+[IsMcAlisterTripleSubsemigroup], LambdaBound);
+
 InstallMethod(LambdaBound, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], S ->
 function(r)
@@ -705,6 +863,15 @@ InstallMethod(RhoIdentity, "for a Rees 0-matrix semigroup",
     return ();
   end);
 
+InstallMethod(LambdaIdentity, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+  S -> function(r)
+    return ();
+  end);
+
+InstallMethod(RhoIdentity, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], LambdaIdentity);
+
 InstallMethod(LambdaIdentity, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], S ->
 function(r)
@@ -739,6 +906,12 @@ function(x, y)
   return x![2] ^ -1 * y![2];
 end);
 
+InstallMethod(LambdaPerm, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return {x, y} -> x[2] ^ -1 * y[2];
+end);
+
 # Returns a permutation mapping LambdaFunc(S)(x) to LambdaFunc(S)(y) so that
 # yx ^ -1(i) = p(i) when RhoFunc(S)(x) = RhoFunc(S)(y)!!
 
@@ -763,7 +936,20 @@ InstallMethod(LambdaConjugator, "for a bipartition semigroup",
 InstallMethod(LambdaConjugator, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], S ->
 function(x, y)
-  return ();
+  return ();  # FIXME is this right???? This is not right!!
+end);
+
+InstallMethod(LambdaConjugator, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  local T, G, act;
+  T := MTSEParent(Representative(S));
+  G := McAlisterTripleSemigroupGroup(T);
+  act := MTSUnderlyingAction(T);  # MTSAction is not an action, causes problems
+  return {x, y} -> RepresentativeAction(G,
+                                        LambdaFunc(S)(x),
+                                        LambdaFunc(S)(y),
+                                        act);
 end);
 
 InstallMethod(LambdaConjugator, "for a matrix semigroup",
@@ -801,6 +987,12 @@ function(j, i)
   return Matrix(parent)[j][i] <> 0;
 end);
 
+InstallMethod(IdempotentTester, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S ->
+function(x, y)
+  return x = y;
+end);
+
 InstallMethod(IdempotentTester, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], S -> function(x, y)
     return MatrixOverFiniteFieldIdempotentTester(S, x, y);
@@ -830,6 +1022,14 @@ function(j, i)
                    [i, mat[j][i] ^ -1, j, mat]);
 end);
 
+InstallMethod(IdempotentCreator, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S ->
+function(x, y)
+  local T;
+  T := MTSEParent(Representative(S));
+  return MTSE(T, x, One(McAlisterTripleSemigroupGroup(T)));
+end);
+
 InstallMethod(IdempotentCreator, "for a matrix semigroup",
 [IsMatrixOverFiniteFieldSemigroup], S -> function(x, y)
     return MatrixOverFiniteFieldIdempotentCreator(S, x, y);
@@ -853,11 +1053,18 @@ InstallMethod(StabilizerAction, "for a bipartition semigroup",
 InstallMethod(StabilizerAction, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup], S ->
 function(x, p)
-
   if x![1] = 0 then
     return x;
   fi;
   return Objectify(TypeObj(x), [x![1], x![2] * p, x![3], x![4]]);
+end);
+
+InstallMethod(StabilizerAction, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup], S ->
+function(x, p)
+  local T;
+  T := MTSEParent(x);
+  return MTSE(T, x[1], x[2] * p);
 end);
 
 InstallMethod(StabilizerAction, "for a matrix semigroup",
@@ -886,6 +1093,10 @@ InstallMethod(IsActingSemigroupWithFixedDegreeMultiplication,
 "for an acting Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup and IsActingSemigroup], ReturnFalse);
 
+InstallMethod(IsActingSemigroupWithFixedDegreeMultiplication,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup and IsActingSemigroup], ReturnFalse);
+
 InstallTrueMethod(IsActingSemigroupWithFixedDegreeMultiplication,
                   IsMatrixOverFiniteFieldSemigroup);
 
@@ -907,6 +1118,14 @@ end);
 
 InstallMethod(SchutzGpMembership, "for a Rees 0-matrix subsemigroup",
 [IsReesZeroMatrixSubsemigroup],
+function(S)
+  return function(stab, x)
+    return SiftedPermutation(stab, x) = ();
+  end;
+end);
+
+InstallMethod(SchutzGpMembership, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
 function(S)
   return function(stab, x)
     return SiftedPermutation(stab, x) = ();
@@ -940,6 +1159,10 @@ InstallMethod(FakeOne, "for a bipartition collection",
 
 InstallMethod(FakeOne, "for a Rees 0-matrix semigroup element collection",
 [IsReesZeroMatrixSemigroupElementCollection], R -> SEMIGROUPS.UniversalFakeOne);
+
+InstallMethod(FakeOne, "for a McAlister triple semigroup element collection",
+[IsMcAlisterTripleSemigroupElementCollection],
+S -> SEMIGROUPS.UniversalFakeOne);
 
 # Matrix semigroup elements
 InstallMethod(FakeOne, "for an FFE coll coll coll",

--- a/gap/semigroups/semieunit.gd
+++ b/gap/semigroups/semieunit.gd
@@ -28,11 +28,12 @@ DeclareRepresentation("IsMcAlisterTripleSemigroupElementRep",
                       and IsPositionalObjectRep, 3);
 
 DeclareCategoryCollections("IsMcAlisterTripleSemigroupElement");
-DeclareSynonym("IsMTSE", IsMcAlisterTripleSemigroupElement);
+DeclareSynonymAttr("IsMTSE", IsMcAlisterTripleSemigroupElement);
 DeclareSynonymAttr("IsMcAlisterTripleSemigroup",
                    IsInverseSemigroup and IsGeneratorsOfInverseSemigroup
                    and IsMcAlisterTripleSemigroupElementCollection
                    and IsWholeFamily and IsEnumerableSemigroupRep);
+DeclareSynonymAttr("IsMTS", IsMcAlisterTripleSemigroup);
 
 # This is a representation for McAlister triple semigroup, which are
 # created via the function McAlisterTripleSemigroup.
@@ -67,12 +68,16 @@ DeclareOperation("McAlisterTripleSemigroup",
 # Attributes for McAlister triple semigroups
 DeclareAttribute("McAlisterTripleSemigroupGroup",
                  IsMcAlisterTripleSemigroup and IsWholeFamily);
+DeclareSynonymAttr("MTSGroup", McAlisterTripleSemigroupGroup);
 DeclareAttribute("McAlisterTripleSemigroupAction",
                  IsMcAlisterTripleSemigroup and IsWholeFamily);
+DeclareSynonymAttr("MTSAction", McAlisterTripleSemigroupAction);
 DeclareAttribute("McAlisterTripleSemigroupPartialOrder",
                  IsMcAlisterTripleSemigroup and IsWholeFamily);
+DeclareSynonymAttr("MTSPartialOrder", McAlisterTripleSemigroupPartialOrder);
 DeclareAttribute("McAlisterTripleSemigroupSemilattice",
                  IsMcAlisterTripleSemigroup and IsWholeFamily);
+DeclareSynonymAttr("MTSSemilattice", McAlisterTripleSemigroupSemilattice);
 DeclareAttribute("McAlisterTripleSemigroupElmList",
                  IsMcAlisterTripleSemigroup and IsWholeFamily);
 DeclareAttribute("OneImmutable",
@@ -91,7 +96,7 @@ DeclareSynonym("MTSE", McAlisterTripleSemigroupElement);
 # Operations for McAlister triple semigroup elements
 DeclareAttribute("McAlisterTripleSemigroupElementParent",
                  IsMcAlisterTripleSemigroupElementRep);
-DeclareSynonym("MTSEParent", McAlisterTripleSemigroupElementParent);
+DeclareSynonymAttr("MTSEParent", McAlisterTripleSemigroupElementParent);
 DeclareOperation("ELM_LIST", [IsMcAlisterTripleSemigroupElementRep, IsPosInt]);
 
 # Inverse semigroup methods

--- a/gap/semigroups/semieunit.gd
+++ b/gap/semigroups/semieunit.gd
@@ -32,8 +32,10 @@ DeclareSynonymAttr("IsMTSE", IsMcAlisterTripleSemigroupElement);
 DeclareSynonymAttr("IsMcAlisterTripleSemigroup",
                    IsInverseSemigroup and IsGeneratorsOfInverseSemigroup
                    and IsMcAlisterTripleSemigroupElementCollection
-                   and IsWholeFamily and IsEnumerableSemigroupRep);
+                   and IsWholeFamily and IsActingSemigroup);
 DeclareSynonymAttr("IsMTS", IsMcAlisterTripleSemigroup);
+DeclareSynonym("IsMcAlisterTripleSubsemigroup",
+IsMcAlisterTripleSemigroupElementCollection and IsSemigroup);
 
 # This is a representation for McAlister triple semigroup, which are
 # created via the function McAlisterTripleSemigroup.
@@ -44,6 +46,9 @@ DeclareSynonymAttr("IsMTS", IsMcAlisterTripleSemigroup);
 #   McAlisterTripleSemigroupPartialOrder
 #   McAlisterTripleSemigroupSemilattice
 #   McAlisterTripleSemigroupAction
+#   McAlisterTripleSemigroupUnderlyingAction
+#   McAlisterTripleSemigroupActionHomomorphism
+#   GeneratorsOfSemigroup
 #
 # their purpose is described in the section of the user manual on McAlister
 # triple semigroups.
@@ -65,23 +70,41 @@ DeclareOperation("McAlisterTripleSemigroup",
 DeclareOperation("McAlisterTripleSemigroup",
                  [IsPermGroup, IsDigraph, IsHomogeneousList]);
 
-# Attributes for McAlister triple semigroups
+# Attributes for McAlister triple subsemigroups
 DeclareAttribute("McAlisterTripleSemigroupGroup",
-                 IsMcAlisterTripleSemigroup and IsWholeFamily);
+                 IsMcAlisterTripleSubsemigroup);
 DeclareSynonymAttr("MTSGroup", McAlisterTripleSemigroupGroup);
 DeclareAttribute("McAlisterTripleSemigroupAction",
-                 IsMcAlisterTripleSemigroup and IsWholeFamily);
+                 IsMcAlisterTripleSubsemigroup);
 DeclareSynonymAttr("MTSAction", McAlisterTripleSemigroupAction);
 DeclareAttribute("McAlisterTripleSemigroupPartialOrder",
-                 IsMcAlisterTripleSemigroup and IsWholeFamily);
+                 IsMcAlisterTripleSubsemigroup);
 DeclareSynonymAttr("MTSPartialOrder", McAlisterTripleSemigroupPartialOrder);
 DeclareAttribute("McAlisterTripleSemigroupSemilattice",
-                 IsMcAlisterTripleSemigroup and IsWholeFamily);
+                 IsMcAlisterTripleSubsemigroup);
 DeclareSynonymAttr("MTSSemilattice", McAlisterTripleSemigroupSemilattice);
-DeclareAttribute("McAlisterTripleSemigroupElmList",
-                 IsMcAlisterTripleSemigroup and IsWholeFamily);
+DeclareAttribute("McAlisterTripleSemigroupActionHomomorphism",
+                 IsMcAlisterTripleSubsemigroup);
+DeclareSynonymAttr("MTSActionHomomorphism",
+                 McAlisterTripleSemigroupActionHomomorphism);
+DeclareAttribute("McAlisterTripleSemigroupUnderlyingAction",
+                 IsMcAlisterTripleSubsemigroup);
+DeclareSynonymAttr("MTSUnderlyingAction",
+                 McAlisterTripleSemigroupUnderlyingAction);
+DeclareAttribute("McAlisterTripleSemigroupSemilatticeVertexLabelInverseMap",
+                 IsMcAlisterTripleSubsemigroup);
+DeclareSynonymAttr("MTSSemilatticeVertexLabelInverseMap",
+                 McAlisterTripleSemigroupSemilatticeVertexLabelInverseMap);
 DeclareAttribute("OneImmutable",
                  IsMcAlisterTripleSemigroup and IsWholeFamily and IsMonoid);
+DeclareAttribute("McAlisterTripleSemigroupComponents",
+                 IsMcAlisterTripleSubsemigroup);
+DeclareSynonymAttr("MTSComponents",
+                 McAlisterTripleSemigroupComponents);
+DeclareAttribute("McAlisterTripleSemigroupQuotientDigraph",
+                 IsMcAlisterTripleSubsemigroup);
+DeclareSynonymAttr("MTSQuotientDigraph",
+                 McAlisterTripleSemigroupQuotientDigraph);
 
 # Operations for relating to McAlister triple semigroups
 DeclareAttribute("IsomorphismMcAlisterTripleSemigroup",

--- a/gap/semigroups/semieunit.gi
+++ b/gap/semigroups/semieunit.gi
@@ -28,7 +28,8 @@ function(G, X, Y, act)
 
   hom := ActionHomomorphism(G, DigraphVertices(X), anti_act);
 
-  if not IsSubgroup(AutomorphismGroup(X), Image(hom)) then
+  if ForAny(GeneratorsOfGroup(Image(hom)),
+            g -> not IsDigraphAutomorphism(X, g)) then
     ErrorNoReturn("Semigroups: McAlisterTripleSemigroup: usage,\n",
                   "the first argument (a group) must act by order ",
                   "automorphisms on the second argument (a partial order ",

--- a/gap/semigroups/semieunit.gi
+++ b/gap/semigroups/semieunit.gi
@@ -149,8 +149,7 @@ InstallMethod(OneImmutable, "for a McAlister triple semigroup",
 function(S)
   local Y;
   if not IsMonoid(S) then
-    ErrorNoReturn("Semigroups: OneImutable (for McAlister triple semigroup):",
-                  " usage,\n", "the argument must be a monoid,");
+    return fail;
   fi;
   Y := McAlisterTripleSemigroupSemilattice(S);
   return MTSE(S, DigraphSources(DigraphRemoveLoops(Y))[1], ());

--- a/gap/semigroups/semieunit.gi
+++ b/gap/semigroups/semieunit.gi
@@ -117,7 +117,7 @@ function(G, X, Y, act)
   SetMcAlisterTripleSemigroupSemilattice(M, Y);
   SetMcAlisterTripleSemigroupActionHomomorphism(M, hom);
 
-  GeneratorsOfSemigroup(M);
+  SetGeneratorsOfSemigroup(M, SEMIGROUPS.MTSSmallGen(M));
   return M;
 end);
 
@@ -302,7 +302,6 @@ function(S, T)
       McAlisterTripleSemigroupAction(T)((x ^ iso_x), (g ^ iso_g)) ^ rep)) then
     return MappingByFunction(S, T, s -> MTSE(T, s[1] ^ iso_x, s[2] ^ iso_g));
   fi;
-
   return fail;
 end);
 
@@ -807,7 +806,7 @@ function(S)
 end);
 
 ###############################################################################
-# Find E-unitary inverse covers
+# E-unitary inverse covers
 ###############################################################################
 InstallMethod(EUnitaryInverseCover,
 "for an inverse partial perm semigroup",
@@ -841,21 +840,6 @@ function(S)
   return MappingByFunction(InverseSemigroup(cover_gens), S, x -> cover(x, 1));
 end);
 
-InstallMethod(EUnitaryInverseCover,
-"for an inverse semigroup",
-[IsSemigroup],
-function(S)
-  local cov, iso, T;
-  if not IsInverseSemigroup(S) then
-    ErrorNoReturn("Semigroups: EUnitaryInverseCover: usage,\n",
-                  "the argument must be an inverse semigroup,");
-  fi;
-  iso := IsomorphismPartialPermSemigroup(S);
-  T := Range(iso);
-  cov := EUnitaryInverseCover(T);
-  return CompositionMapping(InverseGeneralMapping(iso), cov);
-end);
-
 # This method extends a partial perm 'x' to a permutation of degree 'deg'.
 SEMIGROUPS.PartialPermExtendToPerm := function(x, deg)
   local c, i, dom, image;
@@ -880,23 +864,35 @@ SEMIGROUPS.PartialPermExtendToPerm := function(x, deg)
   return(PartialPerm(dom, image));
 end;
 
+InstallMethod(EUnitaryInverseCover,
+"for a semigroup",
+[IsSemigroup],
+function(S)
+  local cov, iso, T;
+  if not IsInverseSemigroup(S) then
+    ErrorNoReturn("Semigroups: EUnitaryInverseCover: usage,\n",
+                  "the argument must be an inverse semigroup,");
+  fi;
+  iso := IsomorphismPartialPermSemigroup(S);
+  T := Range(iso);
+  cov := EUnitaryInverseCover(T);
+  return CompositionMapping(InverseGeneralMapping(iso), cov);
+end);
+
 ###############################################################################
 # TODO:
-# 1) Write hash function that works when group is not a perm group.
+# 1) Write hash function that works when the MTSGroup is not a perm group.
 # 2) Consider hash function for improvements.
 # 3) Write OrderIdeal and FindOrderIrreducibleElements for digraphs package
 #    (order irreducible elements are the ones which generate the semilattice
 #    and order ideals relate to checking condition M2 from Howie).
-# 4) Improve GeneratorsOfSemigroup method.
-# 5) Line break hints for printing MTSEs and McAlisterTripleSemigroups.
-# 6) Implement EUnitaryInverseCover which covers with a McAlisterTriple
-# 7) Improve EUnitaryInverseCover by finding smaller covers
-# 8) Improve IsomorphismSemigroup method.
-# 9) Improve 'if not IsSubgroup(AutomorphismGroup(X), Image(hom)) then' line of
-# McAlisterTripleSemigroup
-# 10) Implement function that turns MTS over a non-perm group into one that is
-# over a perm group.
-# 11) Add to documentation of DigraphReverse returns a digraph where vertex i in
-# the reverse is adjacent to j in the reverse when j is adjacent to i in the
-# original
+# 4) Line break hints for printing MTSEs and McAlisterTripleSemigroups.
+# 5) Implement EUnitaryInverseCover which covers with a McAlisterTriple
+# 6) Improve EUnitaryInverseCover by finding smaller covers
+# 7) Implement function that turns MTS over a non-perm group into one that is
+#    over a perm group.
+# 8) Add to documentation of DigraphReverse returns a digraph where vertex i in
+#    the reverse is adjacent to j in the reverse when j is adjacent to i in the
+#    original
+# 9) Consider shortening McAlisterTripleSemigroupX to McAlisterTripleX
 ###############################################################################

--- a/gap/semigroups/semieunit.gi
+++ b/gap/semigroups/semieunit.gi
@@ -112,8 +112,10 @@ function(G, X, Y, act)
 
   SetMcAlisterTripleSemigroupGroup(M, G);
   SetMcAlisterTripleSemigroupAction(M, anti_act);
+  SetMcAlisterTripleSemigroupUnderlyingAction(M, act);
   SetMcAlisterTripleSemigroupPartialOrder(M, X);
   SetMcAlisterTripleSemigroupSemilattice(M, Y);
+  SetMcAlisterTripleSemigroupActionHomomorphism(M, hom);
 
   GeneratorsOfSemigroup(M);
   return M;
@@ -156,28 +158,70 @@ function(S)
   return MTSE(S, DigraphSources(DigraphRemoveLoops(Y))[1], ());
 end);
 
-# (A, g) in S if and only if Ag^-1 is a vertex of the semilattice of S
-InstallMethod(AsList, "for a McAlister triple semigroup",
-[IsMcAlisterTripleSemigroup],
+InstallMethod(McAlisterTripleSemigroupComponents,
+"for a McAlister triple semigroup",
+[IsMcAlisterTripleSemigroup and IsWholeFamily],
 function(S)
-  local out, g, A, V;
-  out := [];
-  V := DigraphVertexLabels(McAlisterTripleSemigroupSemilattice(S));
-  for g in McAlisterTripleSemigroupGroup(S) do
-    for A in V do
-      if (McAlisterTripleSemigroupAction(S)(A, Inverse(g)) in V) then
-        Add(out, MTSE(S, A, g));
-      fi;
-    od;
+  local G, XX, YY, act, comps, id, next, o, v;
+
+  G := McAlisterTripleSemigroupGroup(S);
+  XX := McAlisterTripleSemigroupPartialOrder(S);
+  YY := McAlisterTripleSemigroupSemilattice(S);
+  act := McAlisterTripleSemigroupAction(S);
+
+  comps := [];
+  id    := ListWithIdenticalEntries(DigraphNrVertices(XX), 0);
+  next  := 1;
+
+  for v in DigraphVertexLabels(YY) do
+    if id[v] = 0 then
+      o := Intersection(Orbit(G, v, act), DigraphVertexLabels(YY));
+      Add(comps, o);
+      id{o} := ListWithIdenticalEntries(Length(o), next);
+      next := next + 1;
+    fi;
   od;
-  SetMcAlisterTripleSemigroupElmList(S, out);
-  return out;
+  return rec(comps := comps, id := id);
 end);
 
-InstallMethod(String, "for a McAlister triple semigroup",
-[IsMcAlisterTripleSemigroup],
+InstallMethod(McAlisterTripleSemigroupQuotientDigraph,
+"for a McAlister triple semigroup",
+[IsMcAlisterTripleSemigroup and IsWholeFamily],
+function(S)
+  local YY_XX, comps, gr;
+  YY_XX := McAlisterTripleSemigroupSemilatticeVertexLabelInverseMap(S);
+  # Convert components to vertices of Y, rather than their labels in X.
+  comps := List(McAlisterTripleSemigroupComponents(S).comps, c -> YY_XX{c});
+  gr := QuotientDigraph(McAlisterTripleSemigroupSemilattice(S), comps);
+  return DigraphRemoveAllMultipleEdges(gr);
+end);
+
+InstallMethod(McAlisterTripleSemigroupSemilatticeVertexLabelInverseMap,
+"for a McAlister triple semigroup",
+[IsMcAlisterTripleSemigroup and IsWholeFamily],
+function(S)
+  local XX, YY, XX_YY, YY_XX, i;
+  XX := McAlisterTripleSemigroupPartialOrder(S);
+  YY := McAlisterTripleSemigroupSemilattice(S);
+  XX_YY := DigraphVertexLabels(YY);
+  if XX_YY <> DigraphVertices(XX) then
+    YY_XX := ListWithIdenticalEntries(DigraphNrVertices(XX), 0);
+    for i in [1 .. Length(XX_YY)] do
+      YY_XX[XX_YY[i]] := i;
+    od;
+  else
+    return XX_YY;
+  fi;
+  return YY_XX;
+end);
+
+InstallMethod(String, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
 function(S)
   local G, X, Y;
+  if not IsWholeFamily(S) then
+    return Concatenation("Semigroup(", String(GeneratorsOfSemigroup(S)));
+  fi;
   G := McAlisterTripleSemigroupGroup(S);
   X := McAlisterTripleSemigroupPartialOrder(S);
   Y := McAlisterTripleSemigroupSemilattice(S);
@@ -185,8 +229,8 @@ function(S)
                        String(X), ", ", String(DigraphVertexLabels(Y)), ")");
 end);
 
-InstallMethod(PrintObj, "for a McAlister triple semigroup",
-[IsMcAlisterTripleSemigroup],
+InstallMethod(PrintObj, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
 function(S)
   Print(String(S));
   return;
@@ -200,6 +244,15 @@ function(S)
   local G;
   G := McAlisterTripleSemigroupGroup(S);
   return Concatenation("<McAlister triple semigroup over ", ViewString(G), ">");
+end);
+
+InstallMethod(ViewString, "for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  local G;
+  G := McAlisterTripleSemigroupGroup(S);
+  return Concatenation("<McAlister triple subsemigroup over ",
+                       ViewString(G), ">");
 end);
 
 InstallMethod(IsomorphismSemigroups, "for two McAlister triple semigroups",
@@ -251,6 +304,337 @@ function(S, T)
   fi;
 
   return fail;
+end);
+
+InstallMethod(McAlisterTripleSemigroupGroup,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return McAlisterTripleSemigroupGroup(MTSEParent(Representative(S)));
+end);
+
+InstallMethod(McAlisterTripleSemigroupPartialOrder,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return McAlisterTripleSemigroupPartialOrder(MTSEParent(Representative(S)));
+end);
+
+InstallMethod(McAlisterTripleSemigroupSemilattice,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return McAlisterTripleSemigroupSemilattice(MTSEParent(Representative(S)));
+end);
+
+InstallMethod(McAlisterTripleSemigroupAction,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return McAlisterTripleSemigroupAction(MTSEParent(Representative(S)));
+end);
+
+InstallMethod(McAlisterTripleSemigroupActionHomomorphism,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return MTSActionHomomorphism(MTSEParent(Representative(S)));
+end);
+
+InstallMethod(McAlisterTripleSemigroupUnderlyingAction,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return MTSUnderlyingAction(MTSEParent(Representative(S)));
+end);
+
+InstallMethod(McAlisterTripleSemigroupComponents,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return MTSComponents(MTSEParent(Representative(S)));
+end);
+
+InstallMethod(McAlisterTripleSemigroupQuotientDigraph,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return MTSQuotientDigraph(MTSEParent(Representative(S)));
+end);
+
+InstallMethod(McAlisterTripleSemigroupSemilatticeVertexLabelInverseMap,
+"for a McAlister triple subsemigroup",
+[IsMcAlisterTripleSubsemigroup],
+function(S)
+  return MTSSemilatticeVertexLabelInverseMap(MTSEParent(Representative(S)));
+end);
+
+SEMIGROUPS.MTSSmallGen := function(S)
+  local G, Sl, X_Y, Y_X, comps, RepAct, _Stab, act, gens, po, top, sl, above, c,
+  stab, check, orbs, stabs, found, Gcj, j, nbrs, r, i, cat, pos, combined,
+  new_orbs, g, n, sizes, Gc1, alpha, gs, u, nbr, v, o, orb;
+
+   G      := McAlisterTripleSemigroupGroup(S);
+   Sl     := McAlisterTripleSemigroupSemilattice(S);
+   X_Y    := DigraphVertexLabels(Sl);
+   Y_X    := McAlisterTripleSemigroupSemilatticeVertexLabelInverseMap(S);
+   comps  := McAlisterTripleSemigroupComponents(S).comps;
+
+   if McAlisterTripleSemigroupUnderlyingAction(S) = OnPoints then
+     RepAct := {a, b} -> RepresentativeAction(G, b, a);
+     _Stab  := {a} -> Stabilizer(G, a);
+   else
+     # Can't use McAlisterTripleSemigroupAction because it is an anti-action
+     # but not an action and produces unexpected results with some of these
+     # methods.
+     act    := McAlisterTripleSemigroupUnderlyingAction(S);
+     RepAct := {a, b} -> RepresentativeAction(G, b, a, act);
+     gens   := Generators(G);
+     _Stab  := {a} -> Stabilizer(G, a, act);
+   fi;
+
+   # We use reflexive transitive reductions so we can only check neighbours
+   # u > v such that there is no w where u > w > v.
+   gens := [];
+   po   := MTSQuotientDigraph(S);  # Vertex i corresponds to comps[i].
+   po   := DigraphReflexiveTransitiveReduction(po);
+   top  := Reversed(DigraphTopologicalSort(po));  # Order D-classes top first.
+   sl   := DigraphReflexiveTransitiveReduction(Sl);
+   SetDigraphVertexLabels(sl, DigraphVertexLabels(Sl));  # Preserve labelling.
+   for i in [1 .. Length(top)] do
+     above := Filtered(top{[1 .. i - 1]}, j -> Y_X[j] in InNeighboursOfVertex(po,
+              top[i]));
+     c := comps[top[i]];
+
+     if IsEmpty(above) then  # Add generating set for this D-class.
+       stab := GeneratorsOfGroup(_Stab(c[1]));
+       for g in stab do
+         Add(gens, MTSE(S, c[1], g));  # Add gens of maximal subgroup of R-class.
+       od;
+       if Length(c) > 1 then  # Add reps from H-classes of R-class.
+         for j in [1 .. Length(c) - 1] do
+           Add(gens, MTSE(S, c[j], RepAct(c[j + 1], c[j])));
+         od;
+       elif IsEmpty(stab) then  # If D-class is just a single element, add it.
+         Add(gens, MTSE(S, c[1], One(G)));
+       fi;
+       Add(gens, MTSE(S, c[Length(c)], RepAct(c[1], c[Length(c)])));
+
+     else  # We may have already generated some elements of this D-class.
+
+       check := false;  # Check stays false until we know we have generated at
+                        # least one element in this D-class.
+
+       # Figure out which subsections of the D-class are generated
+       # stabs are maximal subgroups in these subsections
+       # orbs are lambda values, correspond to vertex labels of MTSSemilattice.
+       orbs  := [];
+       stabs := [];
+       found := [];
+       for u in c do
+         if not u in found then
+           Gcj := _Stab(u);
+           Add(orbs, [u]);
+           Add(found, u);
+           Add(stabs, Group(()));
+           j    := Length(orbs);
+           nbrs := List(InNeighboursOfVertex(sl, Y_X[u]), v -> X_Y[v]);
+           for nbr in nbrs do
+             for v in Difference(c, found) do
+               if ForAny(Elements(RightCoset(Gcj, RepAct(v, u))),
+                         x -> MTSAction(S)(nbr, x) in X_Y) then
+                 Add(orbs[j], v);
+               fi;
+             od;
+
+             r := RightCosets(Gcj, stabs[j]);
+             i := 1;
+             while i <= Length(r) do  # TODO: make this faster
+               if r[i] = RightCoset(stabs[j], One(Gcj)) then
+                 i := i + 1;
+               elif MTSAction(S)(nbr, Representative(r[i])) in X_Y then
+                 stabs[j] := ClosureGroup(stabs[j], Representative(r[i]));
+                 r        := RightCosets(Gcj, stabs[j]);
+                 i        := 1;
+               else
+                 i := i + 1;
+               fi;
+             od;
+           od;
+           found := Union(orbs);
+         fi;
+       od;
+
+       # 1 Combine intersecting orbits.
+       cat := Concatenation(orbs);
+       while not IsDuplicateFreeList(cat) do
+         i   := 0;
+         pos := [];
+         while not Size(pos) > 1 do
+           i   := i + 1;
+           pos := Positions(cat, cat[i]);
+         od;
+
+         combined := [];
+         new_orbs := [];
+         for o in orbs do
+           if cat[i] in o then
+             Append(combined, o);
+           else
+             Add(new_orbs, o);
+           fi;
+         od;
+         Add(new_orbs, Set(combined));
+         orbs := new_orbs;
+         cat  := Concatenation(orbs);
+       od;
+
+       # 2 Add generators to link orbits.
+       if Size(orbs) <> 1 then
+         for orb in orbs{[2 .. Length(orbs)]} do
+           g := MTSE(S, orbs[1][1], RepAct(orb[1], orbs[1][1]));
+           Add(gens, g);
+           Add(gens, g ^ -1);  # Could add less gens here
+           check := true;
+         od;
+       fi;
+
+       # 3 Determine (and add) missing generators of maximal subgroup.
+       n     := Size(Gcj);
+       sizes := List(stabs, Size);
+       Gc1   := _Stab(orbs[1][1]);
+       if not n in sizes then
+         for i in [1 .. Size(stabs) - 1] do
+           if IsSubgroup(stabs[1], stabs[i]) then
+             continue;
+           fi;
+           alpha    := RepAct(orbs[i][1], orbs[1][1]);
+           gs := List(GeneratorsOfGroup(stabs[i]),
+                      g -> (alpha ^ -1) * g * alpha);
+           stabs[1] := ClosureGroup(stabs[1], gs);
+           if stabs[1] = Gc1 then
+             break;
+           fi;
+         od;
+
+         # 3.1 If they are missing then add them.
+         for g in GeneratorsOfGroup(Gc1) do
+           if not g in stabs[1] then
+             Add(gens, MTSE(S, orbs[1][1], g));
+             check := true;
+           fi;
+         od;
+       fi;
+
+       # If we haven't added anything yet and nothing is generated by
+       # higher D-classes then add an element.
+       if not check and Length(nbrs) = 1 then
+         Add(gens, MTSE(S, orbs[1][1], One(G)));
+       fi;
+
+     fi;
+   od;
+   return SmallSemigroupGeneratingSet(gens);
+end;
+
+InstallMethod(IsomorphismSemigroup,
+"for IsMcAlisterTripleSemigroup and a semigroup",
+[IsMcAlisterTripleSemigroup, IsSemigroup],
+function(filt, S)
+  local Es, iso_pg, G, H, map, xx, M, iso, yy, ids, cong, grp, hom, map_G, Dcl,
+  n, cosets, x, xiny, yinx, D, s, R, e, Ge, h, y_pos, x_pos, act, ah, edgy,
+  act2, i;
+
+  if not IsEUnitaryInverseSemigroup(S) then
+    ErrorNoReturn("Semigroups: IsomorphismSemigroup: usage,\n",
+                  "the semigroup is not E-unitary,");
+  fi;
+
+  Es := IdempotentGeneratedSubsemigroup(S);
+  if Size(Es) = 1 then
+    iso_pg := IsomorphismPermGroup(S);
+    G      := Range(iso_pg);
+    map    := g -> PermList(Concatenation([1], ListPerm(g) + 1));
+    H      := Group(List(Generators(G), map));
+    map    := MappingByFunction(G, H, map);
+    xx     := Digraph([[1]]);
+    M      := McAlisterTripleSemigroup(H, xx, xx);
+
+    iso := function(s)
+      return MTSE(M, 1, (s ^ iso_pg) ^ map);
+    end;
+    return MappingByFunction(S, M, iso);
+  fi;
+
+  yy  := Digraph(NaturalPartialOrder(Es));
+  ids := Elements(Es);
+
+  cong   := MinimumGroupCongruence(S);
+  grp    := S / cong;
+  iso_pg := IsomorphismPermGroup(grp);  # This takes a long time, e.g. Sym5.
+  G      := Range(iso_pg);
+  if not IsEmpty(SmallGeneratingSet(G)) then
+    G := Group(SmallGeneratingSet(G));
+  fi;
+  hom   := QuotientSemigroupHomomorphism(grp);
+  map_G := CompositionMapping(iso_pg, hom);
+
+  Dcl    := DClasses(S);
+  n      := NrDClasses(S);
+  cosets := [];
+  x      := [];
+  xiny   := [];
+  yinx   := [];
+  for i in [1 .. n] do
+    D  := Dcl[i];
+    s  := Representative(D);
+    R  := RClass(D, s);
+    e  := LeftOne(s);
+    Ge := Group(List(SmallGeneratingSet(Group(Elements(HClass(D, e)))), g -> g ^
+          map_G));
+    cosets[i] := RightCosets(G, Ge);
+    Append(x, Set(cosets[i], q -> [i, q]));
+    for H in HClasses(R) do
+      h     := Representative(H);
+      y_pos := Position(ids, RightOne(h));
+      x_pos := Position(x, [i, Ge * (h ^ map_G)]);
+
+      yinx[y_pos] := x_pos;
+      xiny[x_pos] := y_pos;
+    od;
+  od;
+
+  act := function(a, g)
+    local b;
+    b := x[a];
+    return Position(x, [b[1], b[2] * g]);
+  end;
+
+  ah   := ActionHomomorphism(G, [1 .. Size(x)], act);
+  edgy := List(DigraphEdges(yy), e -> [yinx[e[1]], yinx[e[2]]]);
+  xx   := EdgeOrbitsDigraph(Image(ah), edgy, Size(x));
+  xx   := DigraphReflexiveTransitiveClosure(xx);
+  yy   := DigraphReflexiveTransitiveClosure(yy);
+  SetDigraphVertexLabels(yy, yinx);
+
+  act2 := function(a, g)
+    return a ^ (g ^ ah);
+  end;
+
+  M := McAlisterTripleSemigroup(G, xx, yy, act2);
+
+  iso := function(s)
+    return MTSE(M, yinx[Position(ids, LeftOne(s))], s ^ map_G);
+  end;
+
+  return MappingByFunction(S, M, iso);
+
+end);
+
+InstallMethod(IsWholeFamily, "for a McAlister triple semigroup",
+[IsMcAlisterTripleSemigroupElementCollection],
+function(C)
+  return Size(Elements(C)[1]![3]) = Size(C);
 end);
 
 #############################################################################
@@ -354,160 +738,6 @@ InstallMethod(\^, "for a McAlister triple semigroup element and a negative int",
               [IsMcAlisterTripleSemigroupElement, IsNegInt],
 function(x, i)
   return InverseOp(x ^ - i);
-end);
-
-#############################################################################
-# Implementing IsomorphismSemigroup for IsMcAlisterTripleSemigroup
-#############################################################################
-SEMIGROUPS.EUISPrincipalRightIdeal := function(S, e)
-  local elements;
-  elements := ShallowCopy(Elements(S));
-  Apply(elements, x -> e * x);
-  return DuplicateFreeList(elements);
-end;
-
-SEMIGROUPS.McAlisterTripleSemigroupSemilatticeIsomorphism := function(S, cong)
-  local iso, s, YY;
-
-  iso := function(s)
-    local ideal;
-    ideal := SEMIGROUPS.EUISPrincipalRightIdeal(S, s);
-    return Set(ideal, x -> [InverseOp(x) * x,
-                            CongruenceClassOfElement(cong, x)]);
-  end;
-
-  YY := Set(Idempotents(S), e -> iso(e));
-  return MappingByFunction(S, Domain(YY), iso);
-end;
-
-SEMIGROUPS.McAlisterTripleSemigroupConstructPartialOrder := function(S, Y, G)
-  local g, A, sc, out;
-
-  out := ShallowCopy(Y);
-  for g in G do  # TODO: if Ag = A then should not check powers of g
-    for A in Y do
-      sc := ShallowCopy(A);
-      sc := Set(sc, x -> [x[1], g * x[2]]);
-      if not sc in out then
-        Append(out, [sc]);
-        out := Set(out);
-      fi;
-    od;
-  od;
-
-  return out;
-end;
-
-SEMIGROUPS.McAlisterTripleSemigroupConstructAction := function(xx, map)
-  local map2, act, pt, g;
-
-  map2 := InverseGeneralMapping(map);
-  act := function(pt, g)
-    local out;
-    out := Set(ShallowCopy(xx[pt]), x -> [x[1], (g ^ map2) * x[2]]);
-    return Position(xx, out);
-  end;
-
-  return act;
-end;
-
-SEMIGROUPS.McAlisterTripleSemigroupConstructStandardPartialOrder := function(x)
-  local  sizes, vertices, adjacency, a, i, j, intr;
-
-  sizes := ShallowCopy(x);
-  Apply(sizes, a -> Size(a));
-  vertices := [1 .. Size(x)];
-  adjacency := [];
-
-  for i in vertices do
-    Append(adjacency, [[i]]);
-  od;
-
-  for i in vertices do
-    for j in vertices do
-      if i < j then
-        # ignore symmetric pairs
-        intr := Intersection(x[i], x[j]);
-        if Size(intr) = sizes[i] then
-          Append(adjacency[j], [i]);
-        elif Size(intr) = sizes[j] then
-          Append(adjacency[i], [j]);
-        fi;
-      fi;
-    od;
-  od;
-
-  Perform(adjacency, Sort);
-
-  return Digraph(adjacency);
-end;
-
-InstallMethod(IsomorphismMcAlisterTripleSemigroup,
-"for a semigroup",
-[IsSemigroup],
-function(S)
-  local cong, grp, map_y, map_yy, map_g, yy, xx,
-        labels, x, y, iso, anti_act, act, M;
-
-  if not IsEUnitaryInverseSemigroup(S) then
-    ErrorNoReturn("Semigroups: IsomorphismSemigroup: usage,\n",
-                  "the semigroup is not E-unitary,");
-  fi;
-
-  cong := MinimumGroupCongruence(S);
-  grp := S / cong;
-  # This is G.
-  map_yy := SEMIGROUPS.McAlisterTripleSemigroupSemilatticeIsomorphism(S, cong);
-  yy := Set(Image(map_yy));
-  # Construct Y as in Howie.
-  xx := SEMIGROUPS.McAlisterTripleSemigroupConstructPartialOrder(S, yy, grp);
-  # Construct X as in Howie.
-
-  # Next we create the digraphs x and y for the McAlister triple semigroup.
-  x := SEMIGROUPS.McAlisterTripleSemigroupConstructStandardPartialOrder(xx);
-  # The elements of yy may not be the first elements of xx.
-  map_y := function(a)
-    return Position(xx, a);
-  end;
-  map_y := MappingByFunction(Domain(yy), Domain(Set([1 .. Size(xx)])), map_y);
-
-  labels := ShallowCopy(yy);
-  Apply(labels, a -> Position(xx, a));
-  y := InducedSubdigraph(x, labels);
-  SetDigraphVertexLabels(y, labels);
-
-  # The semigroup quotient group is not a group object, so find an isomorphism.
-  map_g := IsomorphismPermGroup(grp);
-  map_g := CompositionMapping(
-             SmallerDegreePermutationRepresentation(Image(map_g)), map_g);
-
-  # Create the action of Image(map_g) on x - this is the action of G on X.
-  anti_act := SEMIGROUPS.McAlisterTripleSemigroupConstructAction(xx, map_g);
-  act := function(pt, g)
-    return(anti_act(pt, g ^ -1));
-  end;
-
-  M := McAlisterTripleSemigroup(Range(map_g), x, y, act);
-  iso := function(s)
-    local t;
-    t := s;
-    return MTSE(M, (t ^ map_yy) ^ map_y,
-               CongruenceClassOfElement(cong, s) ^ map_g);
-  end;
-  return MappingByFunction(S, M, iso);
-end);
-
-InstallMethod(IsomorphismSemigroup,
-"for IsMcAlisterTripleSemigroup and a semigroup",
-[IsMcAlisterTripleSemigroup, IsSemigroup],
-function(filt, S)
-  return IsomorphismMcAlisterTripleSemigroup(S);
-end);
-
-InstallMethod(IsWholeFamily, "for a McAlister triple semigroup",
-[IsMcAlisterTripleSemigroupElementCollection],
-function(C)
-  return Size(Elements(C)[1]![3]) = Size(C);
 end);
 
 InstallMethod(ChooseHashFunction, "for McAlister triple semigroup elements",
@@ -664,5 +894,9 @@ end;
 # 8) Improve IsomorphismSemigroup method.
 # 9) Improve 'if not IsSubgroup(AutomorphismGroup(X), Image(hom)) then' line of
 # McAlisterTripleSemigroup
+# 10) Implement function that turns MTS over a non-perm group into one that is
+# over a perm group.
+# 11) Add to documentation of DigraphReverse returns a digraph where vertex i in
+# the reverse is adjacent to j in the reverse when j is adjacent to i in the
+# original
 ###############################################################################
-

--- a/gap/semigroups/semieunit.gi
+++ b/gap/semigroups/semieunit.gi
@@ -739,6 +739,22 @@ function(x, i)
   return InverseOp(x ^ - i);
 end);
 
+InstallMethod(LeftOne, "for a McAlister triple semigroup element rep",
+[IsMcAlisterTripleSemigroupElementRep],
+function(x)
+  local S;
+  S := MTSEParent(x);
+  return MTSE(S, x[1], One(MTSGroup(S)));
+end);
+
+InstallMethod(RightOne, "for a McAlister triple semigroup element rep",
+[IsMcAlisterTripleSemigroupElementRep],
+function(x)
+  local S;
+  S := MTSEParent(x);
+  return MTSE(S, MTSAction(S)(x[1], x[2] ^ -1), One(MTSGroup(S)));
+end);
+
 InstallMethod(ChooseHashFunction, "for McAlister triple semigroup elements",
 [IsMcAlisterTripleSemigroupElement, IsInt],
 function(x, hashlen)

--- a/gap/semigroups/semieunit.gi
+++ b/gap/semigroups/semieunit.gi
@@ -164,9 +164,9 @@ InstallMethod(McAlisterTripleSemigroupComponents,
 function(S)
   local G, XX, YY, act, comps, id, next, o, v;
 
-  G := McAlisterTripleSemigroupGroup(S);
-  XX := McAlisterTripleSemigroupPartialOrder(S);
-  YY := McAlisterTripleSemigroupSemilattice(S);
+  G   := McAlisterTripleSemigroupGroup(S);
+  XX  := McAlisterTripleSemigroupPartialOrder(S);
+  YY  := McAlisterTripleSemigroupSemilattice(S);
   act := McAlisterTripleSemigroupAction(S);
 
   comps := [];
@@ -178,7 +178,7 @@ function(S)
       o := Intersection(Orbit(G, v, act), DigraphVertexLabels(YY));
       Add(comps, o);
       id{o} := ListWithIdenticalEntries(Length(o), next);
-      next := next + 1;
+      next  := next + 1;
     fi;
   od;
   return rec(comps := comps, id := id);
@@ -192,7 +192,7 @@ function(S)
   YY_XX := McAlisterTripleSemigroupSemilatticeVertexLabelInverseMap(S);
   # Convert components to vertices of Y, rather than their labels in X.
   comps := List(McAlisterTripleSemigroupComponents(S).comps, c -> YY_XX{c});
-  gr := QuotientDigraph(McAlisterTripleSemigroupSemilattice(S), comps);
+  gr    := QuotientDigraph(McAlisterTripleSemigroupSemilattice(S), comps);
   return DigraphRemoveAllMultipleEdges(gr);
 end);
 
@@ -201,8 +201,8 @@ InstallMethod(McAlisterTripleSemigroupSemilatticeVertexLabelInverseMap,
 [IsMcAlisterTripleSemigroup and IsWholeFamily],
 function(S)
   local XX, YY, XX_YY, YY_XX, i;
-  XX := McAlisterTripleSemigroupPartialOrder(S);
-  YY := McAlisterTripleSemigroupSemilattice(S);
+  XX    := McAlisterTripleSemigroupPartialOrder(S);
+  YY    := McAlisterTripleSemigroupSemilattice(S);
   XX_YY := DigraphVertexLabels(YY);
   if XX_YY <> DigraphVertices(XX) then
     YY_XX := ListWithIdenticalEntries(DigraphNrVertices(XX), 0);
@@ -217,6 +217,7 @@ end);
 
 InstallMethod(String, "for a McAlister triple subsemigroup",
 [IsMcAlisterTripleSubsemigroup],
+RankFilter(IsInverseSemigroup and HasGeneratorsOfSemigroup),
 function(S)
   local G, X, Y;
   if not IsWholeFamily(S) then
@@ -287,7 +288,7 @@ function(S, T)
   # automorphism of McAlisterTripleSemilattice(T). Composing this with
   # iso_x will restrict to an isomorphism from (the labels of) YS to YT.
   if not im_YS = DigraphVertexLabels(YT) then
-    A := AutomorphismGroup(XT);
+    A   := AutomorphismGroup(XT);
     rep := RepresentativeAction(A, im_YS, DigraphVertexLabels(YT), OnSets);
     if rep = fail then
       return fail;
@@ -508,7 +509,7 @@ SEMIGROUPS.MTSSmallGen := function(S)
              continue;
            fi;
            alpha    := RepAct(orbs[i][1], orbs[1][1]);
-           gs := List(GeneratorsOfGroup(stabs[i]),
+           gs       := List(GeneratorsOfGroup(stabs[i]),
                       g -> (alpha ^ -1) * g * alpha);
            stabs[1] := ClosureGroup(stabs[1], gs);
            if stabs[1] = Gc1 then
@@ -829,15 +830,15 @@ InstallMethod(EUnitaryInverseCover,
 [IsInverseSemigroup and IsPartialPermCollection],
 function(S)
   local gens, deg, units, G, P, embed, id, cover_gens, s, g, cover, i;
-  gens := GeneratorsOfSemigroup(S);
-  deg := DegreeOfPartialPermSemigroup(S);
+  gens  := GeneratorsOfSemigroup(S);
+  deg   := DegreeOfPartialPermSemigroup(S);
   units := [];
   for s in gens do
     Add(units, SEMIGROUPS.PartialPermExtendToPerm(s, deg));
   od;
   G := InverseSemigroup(units);
 
-  P := DirectProduct(S, G);
+  P     := DirectProduct(S, G);
   embed := SemigroupDirectProductInfo(P).embedding;
   if not IsMonoid(S) then
     id := PartialPerm([1 .. deg]);
@@ -890,7 +891,7 @@ function(S)
                   "the argument must be an inverse semigroup,");
   fi;
   iso := IsomorphismPartialPermSemigroup(S);
-  T := Range(iso);
+  T   := Range(iso);
   cov := EUnitaryInverseCover(T);
   return CompositionMapping(InverseGeneralMapping(iso), cov);
 end);

--- a/tst/standard/semieunit.tst
+++ b/tst/standard/semieunit.tst
@@ -146,8 +146,7 @@ gap> String(elms[1]);
 "MTSE(McAlisterTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digraph( [ [ 1 ],\
  [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ]), 1, ())"
 gap> OneImmutable(M);
-Error, Semigroups: OneImutable (for McAlister triple semigroup): usage,
-the argument must be a monoid,
+fail
 gap> M1 := McAlisterTripleSemigroup(G, x, [1, 2]);;
 gap> OneImmutable(M1);
 (2, ())

--- a/tst/standard/semieunit.tst
+++ b/tst/standard/semieunit.tst
@@ -102,11 +102,12 @@ gap> ps := InverseSemigroup([PartialPerm([2, 3, 4, 5], [1, 3, 5, 4]),
 > PartialPerm([2, 3, 4, 5], [1, 4, 5, 3])]);;
 gap> Mps := IsomorphismSemigroup(IsMcAlisterTripleSemigroup, ps);;
 gap> Image(Mps);
-[ (1, ()), (1, (2,3)), (1, (1,2)), (1, (1,2,3)), (1, (1,3,2)), (1, (1,3)), 
-  (2, ()), (2, (2,3)), (2, (1,2,3)), (2, (1,3)), (3, ()), (3, (2,3)), 
-  (3, (1,2)), (3, (1,3,2)) ]
+[ (1, ()), (1, (1,2)(3,6)(4,5)), (1, (1,4)(2,6)(3,5)), (1, (1,6,5)(2,4,3)), 
+  (3, ()), (3, (1,3)(2,5)(4,6)), (3, (1,4)(2,6)(3,5)), (3, (1,5,6)(2,3,4)), 
+  (4, ()), (4, (1,2)(3,6)(4,5)), (4, (1,3)(2,5)(4,6)), (4, (1,4)(2,6)(3,5)), 
+  (4, (1,5,6)(2,3,4)), (4, (1,6,5)(2,4,3)) ]
 gap> AsSemigroup(IsMcAlisterTripleSemigroup, ps);
-<McAlister triple semigroup over Group([ (2,3), (1,2,3) ])>
+<McAlister triple semigroup over Group([ (1,5,6)(2,3,4), (1,4)(2,6)(3,5) ])>
 gap> ps := InverseSemigroup([PartialPerm([1, 4, 6, 7], [1, 4, 6, 7]),
 >   PartialPerm([2, 3, 6, 7], [2, 3, 6, 7]), PartialPerm([6, 7], [6, 7]),
 >   PartialPerm([2, 3, 5, 6, 7], [2, 3, 5, 6, 7]),
@@ -114,13 +115,30 @@ gap> ps := InverseSemigroup([PartialPerm([1, 4, 6, 7], [1, 4, 6, 7]),
 >   PartialPerm([2, 3, 6, 7], [1, 4, 7, 6]), PartialPerm([6, 7], [7, 6])]);;
 gap> Mps := IsomorphismSemigroup(IsMcAlisterTripleSemigroup, ps);;
 gap> Image(Mps);
-[ (1, ()), (1, (1,2)), (2, ()), (3, ()), (3, (1,2)), (5, ()), (5, (1,2)) ]
+[ (1, ()), (1, (1,2)), (2, ()), (2, (1,2)), (3, ()), (3, (1,2)), (4, ()) ]
 gap> Elements(Range(Mps));
-[ (1, ()), (1, (1,2)), (2, ()), (3, ()), (3, (1,2)), (5, ()), (5, (1,2)) ]
-gap> IsWholeFamily(Image(Mps));
+[ (1, ()), (1, (1,2)), (2, ()), (2, (1,2)), (3, ()), (3, (1,2)), (4, ()) ]
+gap> IsWholeFamily(Range(Mps));
 true
 gap> AsSemigroup(IsMcAlisterTripleSemigroup, ps);
 <McAlister triple semigroup over Group([ (1,2) ])>
+
+#T# McAlister triple subsemigroup methods
+gap> S := Semigroup(Image(Mps){[1 .. 3]});
+<McAlister triple subsemigroup over Group([ (1,2) ])>
+gap> attr := [MTSSemilattice, MTSGroup, MTSPartialOrder, MTSAction,
+> MTSActionHomomorphism, MTSUnderlyingAction, MTSComponents,
+> MTSQuotientDigraph, MTSSemilatticeVertexLabelInverseMap];;
+gap> M := Range(Mps);;
+gap> ForAll(attr, A -> A(S) = A(M));
+true
+gap> Print(S, "\n");
+Semigroup([ MTSE(McAlisterTripleSemigroup(Group( [ (1,2) ] ), Digraph( [ [ 1, \
+3 ], [ 2, 3 ], [ 3 ], [ 2, 3, 4 ], [ 1, 3, 5 ] ] ), [ 3, 2, 4, 1 ]), 1, ()), M\
+TSE(McAlisterTripleSemigroup(Group( [ (1,2) ] ), Digraph( [ [ 1, 3 ], [ 2, 3 ]\
+, [ 3 ], [ 2, 3, 4 ], [ 1, 3, 5 ] ] ), [ 3, 2, 4, 1 ]), 1, (1,2)), MTSE(McAlis\
+terTripleSemigroup(Group( [ (1,2) ] ), Digraph( [ [ 1, 3 ], [ 2, 3 ], [ 3 ], [\
+ 2, 3, 4 ], [ 1, 3, 5 ] ] ), [ 3, 2, 4, 1 ]), 2, ()) ]
 
 #T# AsSemigroup with bad input
 gap> T := Semigroup([PartialPerm([1], [3]),
@@ -144,7 +162,7 @@ true
 gap> elms := Enumerator(M);;
 gap> String(elms[1]);
 "MTSE(McAlisterTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digraph( [ [ 1 ],\
- [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ]), 1, ())"
+ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ]), 2, (3,4,5))"
 gap> OneImmutable(M);
 fail
 gap> M1 := McAlisterTripleSemigroup(G, x, [1, 2]);;
@@ -288,7 +306,8 @@ gap> S := McAlisterTripleSemigroup(Group((4, 5)),
 gap> IsFInverseSemigroup(S);
 false
 
-#T# EUnitaryInverseCover
+#T# EUnitaryInverseCover 
+#TODO: Add checks that these covers are idempotent separating homomorphisms
 gap> S := InverseMonoid([PartialPermNC([1, 3], [1, 3]),
 > PartialPermNC([1, 2], [3, 1]), PartialPermNC([1, 2], [3, 2])]);;
 gap> cov := EUnitaryInverseCover(S);;
@@ -310,6 +329,13 @@ gap> S := Semigroup([Bipartition([[1, 3, -1, -2, -3], [2]]),
 gap> EUnitaryInverseCover(S);
 Error, Semigroups: EUnitaryInverseCover: usage,
 the argument must be an inverse semigroup,
+gap> S := InverseSemigroup([PartialPerm([1, 2, 4], [4, 3, 2]),
+> PartialPerm([1, 3], [3, 4])]);;
+gap> cov := EUnitaryInverseCover(S);;
+gap> IsEUnitaryInverseSemigroup(Source(cov));
+true
+gap> S = Range(cov);
+true
 
 #T# SEMIGROUPS_UnbindVariables
 gap> Unbind(A);

--- a/tst/standard/semieunit.tst
+++ b/tst/standard/semieunit.tst
@@ -101,11 +101,8 @@ documentation for more detail,
 gap> ps := InverseSemigroup([PartialPerm([2, 3, 4, 5], [1, 3, 5, 4]),
 > PartialPerm([2, 3, 4, 5], [1, 4, 5, 3])]);;
 gap> Mps := IsomorphismSemigroup(IsMcAlisterTripleSemigroup, ps);;
-gap> Image(Mps);
-[ (1, ()), (1, (1,2)(3,6)(4,5)), (1, (1,4)(2,6)(3,5)), (1, (1,6,5)(2,4,3)), 
-  (3, ()), (3, (1,3)(2,5)(4,6)), (3, (1,4)(2,6)(3,5)), (3, (1,5,6)(2,3,4)), 
-  (4, ()), (4, (1,2)(3,6)(4,5)), (4, (1,3)(2,5)(4,6)), (4, (1,4)(2,6)(3,5)), 
-  (4, (1,5,6)(2,3,4)), (4, (1,6,5)(2,4,3)) ]
+gap> Range(Mps);
+<McAlister triple semigroup over Group([ (1,5,6)(2,3,4), (1,4)(2,6)(3,5) ])>
 gap> AsSemigroup(IsMcAlisterTripleSemigroup, ps);
 <McAlister triple semigroup over Group([ (1,5,6)(2,3,4), (1,4)(2,6)(3,5) ])>
 gap> ps := InverseSemigroup([PartialPerm([1, 4, 6, 7], [1, 4, 6, 7]),
@@ -114,17 +111,22 @@ gap> ps := InverseSemigroup([PartialPerm([1, 4, 6, 7], [1, 4, 6, 7]),
 >   PartialPerm([1, 4, 6, 7], [2, 3, 7, 6]),
 >   PartialPerm([2, 3, 6, 7], [1, 4, 7, 6]), PartialPerm([6, 7], [7, 6])]);;
 gap> Mps := IsomorphismSemigroup(IsMcAlisterTripleSemigroup, ps);;
-gap> Image(Mps);
-[ (1, ()), (1, (1,2)), (2, ()), (2, (1,2)), (3, ()), (3, (1,2)), (4, ()) ]
-gap> Elements(Range(Mps));
-[ (1, ()), (1, (1,2)), (2, ()), (2, (1,2)), (3, ()), (3, (1,2)), (4, ()) ]
+gap> Range(Mps);
+<McAlister triple semigroup over Group([ (1,2) ])>
+gap> Elements(Range(Mps));;
 gap> IsWholeFamily(Range(Mps));
 true
 gap> AsSemigroup(IsMcAlisterTripleSemigroup, ps);
 <McAlister triple semigroup over Group([ (1,2) ])>
+gap> G := Semigroup(PartialPerm([1, 2, 3], [2, 3, 1]));;
+gap> iso := IsomorphismSemigroup(IsMcAlisterTripleSemigroup, G);
+MappingByFunction( <partial perm group of size 3, rank 3 with 1 generator>
+, <McAlister triple semigroup over Group([ (2,3,
+4) ])>, function( s ) ... end )
+gap> PartialPerm([1, 2, 3], [2, 3, 1]) ^ iso;;
 
 #T# McAlister triple subsemigroup methods
-gap> S := Semigroup(Image(Mps){[1 .. 3]});
+gap> S := Semigroup(Elements(Range(Mps)){[1, 2, 3]});
 <McAlister triple subsemigroup over Group([ (1,2) ])>
 gap> attr := [MTSSemilattice, MTSGroup, MTSPartialOrder, MTSAction,
 > MTSActionHomomorphism, MTSUnderlyingAction, MTSComponents,
@@ -132,13 +134,13 @@ gap> attr := [MTSSemilattice, MTSGroup, MTSPartialOrder, MTSAction,
 gap> M := Range(Mps);;
 gap> ForAll(attr, A -> A(S) = A(M));
 true
-gap> Print(S, "\n");
-Semigroup([ MTSE(McAlisterTripleSemigroup(Group( [ (1,2) ] ), Digraph( [ [ 1, \
-3 ], [ 2, 3 ], [ 3 ], [ 2, 3, 4 ], [ 1, 3, 5 ] ] ), [ 3, 2, 4, 1 ]), 1, ()), M\
-TSE(McAlisterTripleSemigroup(Group( [ (1,2) ] ), Digraph( [ [ 1, 3 ], [ 2, 3 ]\
-, [ 3 ], [ 2, 3, 4 ], [ 1, 3, 5 ] ] ), [ 3, 2, 4, 1 ]), 1, (1,2)), MTSE(McAlis\
-terTripleSemigroup(Group( [ (1,2) ] ), Digraph( [ [ 1, 3 ], [ 2, 3 ], [ 3 ], [\
- 2, 3, 4 ], [ 1, 3, 5 ] ] ), [ 3, 2, 4, 1 ]), 2, ()) ]
+gap> Print(Semigroup(Elements(M1){[1, 2, 3]}), "\n");
+Semigroup([ MTSE(McAlisterTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digrap\
+h( [ [ 1 ], [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ]), 1, ()), M\
+TSE(McAlisterTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digraph( [ [ 1 ], [\
+ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ]), 1, (4,5)), MTSE(McAlis\
+terTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digraph( [ [ 1 ], [ 1, 2 ], [\
+ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ]), 1, (3,4)) ]
 
 #T# AsSemigroup with bad input
 gap> T := Semigroup([PartialPerm([1], [3]),
@@ -149,10 +151,8 @@ the semigroup is not E-unitary,
 
 #T# Other McAlisterTripleSemigroup tests
 gap> G := SymmetricGroup([2 .. 5]);;
-gap> x := Digraph([[1], [1, 2], [1, 3], [1, 4], [1, 5]]);
-<digraph with 5 vertices, 9 edges>
-gap> y := Digraph([[1], [1, 2], [1, 3], [1, 4]]);
-<digraph with 4 vertices, 7 edges>
+gap> x := Digraph([[1], [1, 2], [1, 3], [1, 4], [1, 5]]);;
+gap> y := Digraph([[1], [1, 2], [1, 3], [1, 4]]);;
 gap> M := McAlisterTripleSemigroup(G, x, y, OnPoints);
 <McAlister triple semigroup over Sym( [ 2 .. 5 ] )>
 gap> IsIsomorphicSemigroup(M, McAlisterTripleSemigroup(G, x, x));
@@ -160,14 +160,16 @@ false
 gap> IsInverseSemigroup(Semigroup(GeneratorsOfSemigroup(M)));
 true
 gap> elms := Enumerator(M);;
-gap> String(elms[1]);
-"MTSE(McAlisterTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digraph( [ [ 1 ],\
- [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ]), 2, (3,4,5))"
+gap> String(elms[1]){[1 .. 40]};
+"MTSE(McAlisterTripleSemigroup(SymmetricG"
 gap> OneImmutable(M);
 fail
 gap> M1 := McAlisterTripleSemigroup(G, x, [1, 2]);;
 gap> OneImmutable(M1);
 (2, ())
+gap> x1 := DigraphFromDiSparse6String(".P__@_@_@__D_D_D__H_H_H_@DH_@DHL_@DHL_@DHLp?`abcdefghijklmno");;
+gap> y1 := InducedSubdigraph(x1, [1, 2, 3, 4, 6, 10, 11, 14, 15]);;
+gap> McAlisterTripleSemigroup(AutomorphismGroup(x1), x1, y1);;
 
 #T# McAlister triple semigroup elements
 gap> MTSE(M, 4, (2, 4)(3, 5)) * MTSE(M, 4, (2, 5, 3, 4));
@@ -235,7 +237,7 @@ gap> M7 := McAlisterTripleSemigroup(Group((5, 6)), x4, x4);;
 gap> IsomorphismSemigroups(M6, M7);
 fail
 
-#T# IsomorphicSemigroups with bad input
+#T# IsomorphismSemigroups with bad input
 gap> x1 := Digraph([[1], [1, 2], [1, 3]]);;
 gap> G := Group((2, 3));;
 gap> M1 := McAlisterTripleSemigroup(G, x1, x1);;
@@ -260,8 +262,7 @@ fail
 #T# IsomorphismSemigroups, where RepresentativeAction fails
 gap> gr := DigraphFromDigraph6String("+H_A?GC_Q@G~wA?G");
 <digraph with 9 vertices, 20 edges>
-gap> G := Group((1, 2, 3)(4, 5, 6), (8, 9));
-Group([ (1,2,3)(4,5,6), (8,9) ])
+gap> G := Group((1, 2, 3)(4, 5, 6), (8, 9));;
 gap> S1 := McAlisterTripleSemigroup(G, gr, [1, 4, 5, 7, 8]);
 <McAlister triple semigroup over Group([ (1,2,3)(4,5,6), (8,9) ])>
 gap> S2 := McAlisterTripleSemigroup(G, gr, [3, 6, 7, 8, 9]);

--- a/tst/standard/semieunit.tst
+++ b/tst/standard/semieunit.tst
@@ -119,10 +119,7 @@ true
 gap> AsSemigroup(IsMcAlisterTripleSemigroup, ps);
 <McAlister triple semigroup over Group([ (1,2) ])>
 gap> G := Semigroup(PartialPerm([1, 2, 3], [2, 3, 1]));;
-gap> iso := IsomorphismSemigroup(IsMcAlisterTripleSemigroup, G);
-MappingByFunction( <partial perm group of size 3, rank 3 with 1 generator>
-, <McAlister triple semigroup over Group([ (2,3,
-4) ])>, function( s ) ... end )
+gap> iso := IsomorphismSemigroup(IsMcAlisterTripleSemigroup, G);;
 gap> PartialPerm([1, 2, 3], [2, 3, 1]) ^ iso;;
 
 #T# McAlister triple subsemigroup methods

--- a/tst/standard/semieunit.tst
+++ b/tst/standard/semieunit.tst
@@ -178,6 +178,10 @@ gap> M = MTSEParent(MTSE(M, 1, (4, 5)));
 true
 gap> M = McAlisterTripleSemigroupElementParent(MTSE(M, 1, (4, 5)));
 true
+gap> LeftOne(MTSE(M, 4, (2, 4)(3, 5))) = MTSE(M, 4, ());
+true
+gap> RightOne(MTSE(M, 4, (2, 4)(3, 5))) = MTSE(M, 2, ());
+true
 gap> MTSE(M, 10, (2, 3, 4, 5));
 Error, Semigroups: McAlisterTripleSemigroupElement: usage,
 second argument should be a vertex label of the join-semilattice of the McAlis\

--- a/tst/standard/setup.tst
+++ b/tst/standard/setup.tst
@@ -29,6 +29,9 @@ gap> IsGeneratorsOfActingSemigroup(Elements(R));
 true
 gap> IsGeneratorsOfActingSemigroup(SLM(2, 2));
 true
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3]), Digraph([[1], [1, 2], [1, 3]]), [1, 2]);;
+gap> IsGeneratorsOfActingSemigroup(M);
+true
 
 # ActionDegree
 
@@ -54,6 +57,11 @@ gap> ActionDegree(MultiplicativeZero(R));
 gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[()]]);;
 gap> Set(R, ActionDegree);
 [ 0, 1, 3, 4 ]
+
+# ActionDegree, for a MTS element
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3]), Digraph([[1], [1, 2], [1, 3]]), [1, 2]);;
+gap> ActionDegree(M.1);
+0
 
 # ActionDegree, for a matrix over finite field object
 gap> ActionDegree(Matrix(GF(2 ^ 2),
@@ -85,6 +93,11 @@ gap> ActionDegree([R.1, MultiplicativeZero(R)]);
 gap> ActionDegree([MultiplicativeZero(R)]);
 0
 
+# ActionDegree, for an MTS element collection
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3]), Digraph([[1], [1, 2], [1, 3]]), [1, 2]);;
+gap> ActionDegree(Generators(M));
+0
+
 # ActionDegree, for a matrix object collection
 gap> ActionDegree([Matrix(GF(2),
 >                         [[0 * Z(2), 0 * Z(2)], [0 * Z(2), 0 * Z(2)]]),
@@ -114,6 +127,11 @@ gap> GeneratorsOfSemigroup(R);;
 gap> ActionDegree(R);
 3
 gap> ActionDegree(Semigroup(MultiplicativeZero(R)));
+0
+
+# ActionDegree, for an MTS subsemigroup
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3]), Digraph([[1], [1, 2], [1, 3]]), [1, 2]);;
+gap> ActionDegree(Semigroup(Representative(M)));
 0
 
 # ActionDegree, for a matrix over finite field semigroup
@@ -171,6 +189,16 @@ gap> rank(RMSElement(R, 1, (2, 3), 1));
 gap> rank(MultiplicativeZero(R));
 0
 
+# ActionRank, for an MTS semigroup and subsemigroup
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3]), Digraph([[1], [1, 2], [1, 3]]), [1, 2]);;
+gap> rank := ActionRank(M);;
+gap> rank(Representative(M));
+0
+gap> S := Semigroup(Representative(M));;
+gap> rank := ActionRank(S);;
+gap> rank(Representative(S));
+0
+
 # ActionRank, for a matrix over FF
 gap> x := Matrix(GF(2), [[0 * Z(2), 0 * Z(2)], [0 * Z(2), Z(2) ^ 0]]);;
 gap> ActionRank(x, 10);
@@ -203,6 +231,11 @@ gap> R := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
 gap> MinActionRank(R);
 0
 
+# MinActionRank, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> MinActionRank(M);
+1
+
 # MinActionRank for a matrix over FF semigroup
 gap> MinActionRank(GLM(2, 2));
 0
@@ -233,6 +266,13 @@ gap> R := ReesZeroMatrixSemigroup(Group([()]), [[(), (), 0], [(), (), ()],
 gap> LambdaOrbOpts(R);
 rec(  )
 gap> RhoOrbOpts(R);
+rec(  )
+
+# Rho/lambdaOrbOpts, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> LambdaOrbOpts(M);
+rec(  )
+gap> RhoOrbOpts(M);
 rec(  )
 
 # Rho/LambdaOrbOpts for a matrix over FF semigroup
@@ -305,6 +345,37 @@ gap> x(1, s);
 gap> x(2, s);
 1
 
+# Rho/LambdaAct, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> r := MTSE(M, 1, (3, 4));;
+gap> s := MTSE(M, 3, (2, 3));;
+gap> x := LambdaAct(M);;
+gap> x(3, s);
+2
+gap> x(2, s);
+1
+gap> x(2, r);
+1
+gap> x(3, r);
+1
+gap> x(1, r);
+1
+gap> x(0, r);
+1
+gap> x := RhoAct(M);;
+gap> x(3, s);
+1
+gap> x(2, s);
+3
+gap> x(2, r);
+1
+gap> x(3, r);
+1
+gap> x(1, r);
+1
+gap> x(0, r);
+1
+
 # Rho/LambdaAct, for a matrix over FF semigroup
 gap> r := Matrix(GF(2), [[Z(2) ^ 0, Z(2) ^ 0], [Z(2) ^ 0, 0 * Z(2)]]);;
 gap> s := Matrix(GF(2), [[Z(2) ^ 0, Z(2) ^ 0], [0 * Z(2), 0 * Z(2)]]);;
@@ -346,6 +417,13 @@ gap> LambdaOrbSeed(R);
 -1
 gap> RhoOrbSeed(R);
 -1
+
+# Rho/LambdaOrbSeed, for an MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> LambdaOrbSeed(M);
+0
+gap> RhoOrbSeed(M);
+0
 
 # Rho/LambdaOrbSeed, for a matrix over FF semigroup
 gap> LambdaOrbSeed(GLM(2, 2));
@@ -398,6 +476,19 @@ gap> x(MultiplicativeZero(S));
 0
 gap> x(RMSElement(S, 1, (1, 3), 2));
 1
+
+# Rho/LambdaFunc, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> x := LambdaFunc(M);;
+gap> x(MTSE(M, 1, ()));
+1
+gap> x(MTSE(M, 2, (2, 3)));
+3
+gap> x := RhoFunc(M);;
+gap> x(MTSE(M, 1, ()));
+1
+gap> x(MTSE(M, 2, (2, 3)));
+2
 
 # Rho/LambdaFunc, for a matrix over FF semigroup
 gap> S := GLM(2, 3);;
@@ -453,6 +544,23 @@ gap> x(0);
 0
 gap> x(1);
 4
+
+# Rho/LambdaRank, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> x := LambdaRank(M);;
+gap> x(1);
+2
+gap> x(2);
+1
+gap> x(0);
+0
+gap> x := RhoRank(M);;
+gap> x(1);
+2
+gap> x(2);
+1
+gap> x(0);
+0
 
 # Rho/LambdaRank, for a matrix over FF semigroup
 gap> S := GLM(2, 3);;
@@ -517,6 +625,19 @@ gap> x(0, S.1);
 gap> x(2, S.1);
 (2,(),1)
 
+# Rho/LambdaInverse, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> x := LambdaInverse(M);;
+gap> x(2, MTSE(M, 1, ()));
+(1, ())
+gap> x(2, MTSE(M, 2, (2, 3)));
+(3, (2,3))
+gap> x := RhoInverse(M);;
+gap> x(2, MTSE(M, 1, ()));
+(1, ())
+gap> x(2, MTSE(M, 2, (2, 3)));
+(3, (2,3))
+
 # Rho/LambdaInverse, for a matrix over FF semigroup
 gap> S := GLM(2, 2);;
 gap> x := LambdaInverse(S);;
@@ -573,6 +694,17 @@ infinity
 gap> RhoBound(S)(5);
 120
 
+# Rho/LambdaBound, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> LambdaBound(M)(5);
+6
+gap> LambdaBound(M)(10000);
+6
+gap> RhoBound(M)(5);
+6
+gap> RhoBound(M)(10000);
+6
+
 # Rho/LambdaBound, for a matrix over FF semigroup
 gap> S := GLM(2, 2);;
 gap> LambdaBound(S)(1000);
@@ -618,6 +750,13 @@ gap> LambdaIdentity(S)(2);
 gap> RhoIdentity(S)(2);
 ()
 
+# Rho/LambdaIdentity, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> LambdaIdentity(M)(2);
+()
+gap> RhoIdentity(M)(2);
+()
+
 # Rho/LambdaIdentity, for a matrix over FF semigroup
 gap> S := SLM(2, 2);;
 gap> LambdaIdentity(S)(2);
@@ -651,6 +790,14 @@ gap> x(RMSElement(R, 1, (1, 3, 2), 1), RMSElement(R, 1, (1, 2, 3), 1));
 gap> x(MultiplicativeZero(R), MultiplicativeZero(R));
 ()
 
+# LambdaPerm, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> x := LambdaPerm(M);;
+gap> x(MTSE(M, 1, (2, 3, 4)), MTSE(M, 2, (2, 3)));
+(2,4)
+gap> x(MTSE(M, 2, ()), MTSE(M, 2, (2, 3)));
+(2,3)
+
 # LambdaPerm, for a matrix over FF semigroup
 gap> x := LambdaPerm(GLM(2, 3));;
 gap> x(Matrix(GF(3), [[Z(3) ^ 0, Z(3) ^ 0], [0 * Z(3), 0 * Z(3)]]),
@@ -679,6 +826,16 @@ gap> x(Bipartition([[1, -1, -2], [2], [3, -3]]),
 gap> R := ReesZeroMatrixSemigroup(Group((1, 2, 3)), [[(), 0], [0, ()]]);;
 gap> x := LambdaConjugator(R);;
 gap> x(RMSElement(R, 1, (1, 3, 2), 1), RMSElement(R, 1, (1, 2, 3), 2));
+()
+
+# LambdaConjugator, for an MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> x := LambdaConjugator(M);;
+gap> x(MTSE(M, 1, (2, 3, 4)), MTSE(M, 2, (2, 3)));
+fail
+gap> x(MTSE(M, 2, ()), MTSE(M, 2, (2, 3)));
+(2,3)
+gap> x(MTSE(M, 3, ()), MTSE(M, 2, (2, 3)));
 ()
 
 # LambdaConjugator, for a matrix over FF semigroup
@@ -757,6 +914,31 @@ true
 gap> y(2, 2);
 (2,(1,2),2)
 
+# IdempotentTester and IdempotentCreator, for an MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> x := IdempotentTester(M);;
+gap> y := IdempotentCreator(M);;
+gap> x(1, 1);
+true
+gap> x(2, 1);
+false
+gap> x(2, 2);
+true
+gap> x(3, 2);
+false
+gap> x(3, 3);
+true
+gap> y(2, 2);
+(2, ())
+gap> y(1, 2);
+(1, ())
+gap> y(1, 1);
+(1, ())
+gap> y(3, 2);
+(3, ())
+gap> y(3, 3);
+(3, ())
+
 # IdempotentTester and IdempotentCreator, for a matrix over FF semigroup
 gap> S := GLM(2, 3);;
 gap> x := IdempotentTester(S);;
@@ -804,6 +986,16 @@ gap> x(MultiplicativeZero(R), ());
 gap> x(RMSElement(R, 1, (), 1), ());
 (1,(),1)
 
+# StabilizerAction, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> x := StabilizerAction(M);;
+gap> x(MTSE(M, 1, ()), ());
+(1, ())
+gap> x(MTSE(M, 2, (2, 3)), (2, 3));
+(2, ())
+gap> x(MTSE(M, 3, ()), (2, 4, 3));
+(3, (2,4,3))
+
 # StabilizerAction, for a matrix over FF semigroup
 gap> S := GLM(2, 3);;
 gap> x := StabilizerAction(S);;
@@ -830,6 +1022,11 @@ true
 # IsActingSemigroupWithFixedDegreeMultiplication, for an RZMS
 gap> S := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
 gap> IsActingSemigroupWithFixedDegreeMultiplication(Semigroup(S));
+false
+
+# IsActingSemigroupWithFixedDegreeMultiplication, for a MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> IsActingSemigroupWithFixedDegreeMultiplication(Semigroup(M));
 false
 
 # IsActingSemigroupWithFixedDegreeMultiplication, for a matrix over FF semigroup
@@ -870,10 +1067,20 @@ true
 # SchutzGpMembership, for an RZMS
 gap> R := ReesZeroMatrixSemigroup(Group((1, 2, 3)), [[()]]);;
 gap> R := Semigroup(Elements(R));;
-gap> o := LambdaOrb(S);; Enumerate(o);;
-gap> schutz := LambdaOrbStabChain(o, 2);;
+gap> o := LambdaOrb(R);; Enumerate(o);;
+gap> schutz := LambdaOrbStabChain(o, 3);;
 gap> SchutzGpMembership(R)(schutz, ());
 true
+
+# SchutzGpMembership, for an MTS
+gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
+gap> M := Semigroup(Elements(M));;
+gap> o := LambdaOrb(M);; Enumerate(o);;
+gap> schutz := LambdaOrbStabChain(o, 3);;
+gap> SchutzGpMembership(M)(schutz, ());
+true
+
+# gap> SchutzGpMembership(M)(schutz, ()); TODO: THIS DOESN'T WORK!
 
 # SchutzGpMembership, for a matrix over FF semigroup
 gap> S := Monoid([
@@ -901,6 +1108,10 @@ gap> FakeOne(PartitionMonoid(1));
 
 # FakeOne, for an RZMS
 gap> FakeOne(ReesZeroMatrixSemigroup(Group(()), [[()]]));
+<universal fake one>
+
+# FakeOne, for a MTS
+gap> FakeOne(McAlisterTripleSemigroup(Group(()), Digraph([[1]]), [1]));
 <universal fake one>
 
 # FakeOne, for a matrix over FF semigroup


### PR DESCRIPTION
This PR integrates McAlister triple semigroups with the acting semigroups framework. It also includes various fixes, and improvements to:

- IsomorphismSemigroup when used to find an isomorphism from an E-unitary inverse semigroup to a McAlisterTripleSemigroup.
- McAlisterTripleSemigroup - replaced a check involving IsSubgroup and AutomorphismGroup by one which checks if generators are automorphisms.
- EUnitaryInverse cover - now uses DirectProduct functionality which has recently been added to Semigroups.

It also adds various attributes of the form MTSX which are synonyms for McAlsiterTripleSemigroupX.  FInally there is now a McAlisterTripleSubsemigroup attribute and functionality for these objects.