### PR TITLE
Add an IsFinite filter to a method for \= for a semigroup and an ideal

### DIFF
--- a/gap/ideals/ideals.gi
+++ b/gap/ideals/ideals.gi
@@ -161,9 +161,9 @@ function(I, J)
     and ForAll(GeneratorsOfSemigroup(J), x -> x in I);
 end);
 
-InstallMethod(\=, "for a semigroup ideal and semigroup with generators",
+InstallMethod(\=, "for a semigroup ideal and finite semigroup with generators",
 [IsSemigroupIdeal and HasGeneratorsOfSemigroupIdeal,
- IsSemigroup and HasGeneratorsOfSemigroup],
+ IsSemigroup and HasGeneratorsOfSemigroup and IsFinite],
 function(I, S)
   if ForAll(GeneratorsOfSemigroup(S), x -> x in I) then
     if S = Parent(I) then


### PR DESCRIPTION
There is a method in `gap/ideals/ideals.gi` which tests the equality of an ideal and a semigroup; the test is only mathematically valid if the semigroup is finite, so this PR add this as a filter to the method.

See issue #508, which is resolved by this PR.

I can't really add a test for this; but this is tested by GAP's test `tst/testinstall/domain.tst`; see #508 again for more details.

If you'd prefer a different solution to this @james-d-mitchell then please let me know and I'll see what I can do.