### PR TITLE
Update Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ addons:
       - libtool
 
 # Matrix
-#                    | GAP: master  | GAP: stable-4.9 | GAP: required |
-#--------------------+--------------+-----------------+---------------+
-# packages:   master |       64-bit |   64 - & 32-bit |             - |
-# packages:   newest |       64-bit |          64-bit |             - |
-# packages: required |       32-bit |      (coverage) |             - |
+#       GAP version: | master |  stable-4.10 | stable-4.9 | required |
+#--------------------+--------+--------------+------------+----------+
+# packages:   master | 64-bit |            - |          - |        - |
+# packages:   newest | 64-bit | 64- & 32-bit |          - |        - |
+# packages: required | 32-bit |   (coverage) |     64-bit |        - |
 
-# Plus: linting, and code coverage
+# Plus: linting
 
 matrix:
   include:
@@ -65,16 +65,16 @@ matrix:
 
     - env:
       - SUITE=test
-      - GAP=stable-4.9
-      - PACKAGES=master
+      - GAP=stable-4.10
+      - PACKAGES=newest
       - ABI=64
       sudo:
         required
 
     - env:
       - SUITE=test
-      - GAP=stable-4.9
-      - PACKAGES=master
+      - GAP=stable-4.10
+      - PACKAGES=newest
       - ABI=32
       sudo:
         required
@@ -82,14 +82,14 @@ matrix:
     - env:
       - SUITE=test
       - GAP=stable-4.9
-      - PACKAGES=newest
+      - PACKAGES=required
       - ABI=64
       sudo:
         required
 
     - env:
       - SUITE=coverage
-      - GAP=stable-4.9
+      - GAP=stable-4.10
       - PACKAGES=required
       - ABI=64
       - THRESHOLD=95

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
 #--------------------+--------+--------------+------------+----------+
 # packages:   master | 64-bit |            - |          - |        - |
 # packages:   newest | 64-bit | 64- & 32-bit |          - |        - |
-# packages: required | 32-bit |   (coverage) |     64-bit |        - |
+# packages: required | 32-bit |   (coverage) |     64-bit |   64-bit |
 
 # Plus: linting
 
@@ -82,6 +82,14 @@ matrix:
     - env:
       - SUITE=test
       - GAP=stable-4.9
+      - PACKAGES=required
+      - ABI=64
+      sudo:
+        required
+
+    - env:
+      - SUITE=test
+      - GAP=required
       - PACKAGES=required
       - ABI=64
       sudo:

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -2,50 +2,61 @@
 set -e
 set -o pipefail
 
-# Create the testlog and remember its location
 cd ../..
-touch testlog.txt
+
+# Remember some important locations
+GAP_DIR=`pwd`
+SEMI_DIR="$GAP_DIR/pkg/semigroups"
+GAP="$GAP_DIR/bin/gap.sh"
+# Create the testlog and remember its location
+touch $GAP_DIR/testlog.txt
 TESTLOG="`pwd`/testlog.txt"
 
 if [ "$SUITE" == "lint" ]; then
 
-  cd $HOME/gap/pkg/semigroups
-
+  echo -e "\nLinting with gaplint and cpplint..."
+  cd $SEMI_DIR
   gaplint `grep "^\s\+gaplint" Makefile.am | cut -d " " -f2-`
   cpplint --extensions=c,cc,h `grep "^\s\+cpplint" Makefile.am | cut -d " " -f2-`
 
-else
+elif [ "$SUITE" == "coverage" ]; then
 
-  GAP_DIR=`pwd`
-  cd $GAP_DIR/pkg/semigroups
-
-  if [ "$SUITE" == "coverage" ]; then
-
-    echo -e "\nPerforming code coverage tests..."
-    for TESTFILE in tst/standard/*.tst; do
-      FILENAME=${TESTFILE##*/}
-      if [ ! `grep -E "$FILENAME" .covignore` ]; then
-        $GAP_DIR/pkg/semigroups/scripts/travis-coverage.py $TESTFILE $THRESHOLD | tee -a $TESTLOG
-      else
-        echo -e "\033[35mignoring $FILENAME, since it is listed in .covignore\033[0m"
-      fi
-    done
-
-  else
-    # Run the SaveWorkspace tests
-    cd tst/workspaces
-    echo -e "\nRunning SaveWorkspace tests..."
-    echo "LoadPackage(\"semigroups\", false); SemigroupsTestInstall(); Test(\"save-workspace.tst\"); quit; quit; quit;" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee -a $TESTLOG
-    echo "Test(\"load-workspace.tst\"); SemigroupsTestInstall(); quit; quit; quit;" | $GAP_DIR/bin/gap.sh -L test-output.w -A -r -m 1g -T 2>&1 | tee -a $TESTLOG
-    rm test-output.w
-    cd ../..
-    # Run all tests and manual examples
-    echo -e "\nRunning tests and manual examples..."
-    echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples();" | $GAP_DIR/bin/gap.sh -A -r -m 1g -T 2>&1 | tee -a $TESTLOG
-    if [ ! "$ABI" == "32" ]; then
-      echo "LoadPackage(\"semigroups\"); Read(\"$GAP_DIR/tst/testinstall.g\");" | $GAP_DIR/bin/gap.sh -A -x 80 -r -m 100m -o 1g -K 2g -T 2>&1 | tee -a $TESTLOG
+  echo -e "\nPerforming code coverage tests..."
+  for TEST in $SEMI_DIR/tst/standard/*.tst; do
+    FILENAME=${TEST##*/}
+    if [ ! `grep -E "$FILENAME" .covignore` ]; then
+      $SEMI_DIR/scripts/travis-coverage.py $TEST $THRESHOLD | tee -a $TESTLOG
+    else
+      echo -e "\033[35mignoring $FILENAME, which is listed in .covignore\033[0m"
     fi
+  done
+elif [ "$SUITE" == "test" ]; then
+
+  cd $SEMI_DIR/tst/workspaces
+  echo -e "\nRunning SaveWorkspace tests..."
+  echo "LoadPackage(\"semigroups\"); SemigroupsTestInstall(); Test(\"save-workspace.tst\"); quit; quit; quit;" |
+    $GAP -A -r -m 1g -T 2>&1 | tee -a $TESTLOG
+  echo -e "\nRunning LoadWorkspace tests..."
+  echo "Test(\"load-workspace.tst\"); SemigroupsTestInstall(); quit; quit; quit;" |
+    $GAP -L test-output.w -A -x 80 -r -m 1g -T 2>&1 | tee -a $TESTLOG
+
+  echo -e "\nRunning Semigroups package standard tests and manual examples..."
+  echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples();" |
+    $GAP -A -x 80 -r -m 1g -T 2>&1 | tee -a $TESTLOG
+
+  # Run GAP tests, but only in 64-bit, since they're far too slow in 32-bit
+  if [ "$ABI" == "64" ]; then
+    echo -e "\nRunning GAP's testinstall tests with Semigroups loaded..."
+    echo "LoadPackage(\"semigroups\"); Read(\"$GAP_DIR/tst/testinstall.g\");" |
+      $GAP -A -x 80 -r -m 100m -o 1g -K 2g -T 2>&1 | tee -a $TESTLOG
+
+    #echo -e "\nRunning GAP's testbugfix tests with Semigroups loaded..."
+    #echo "LoadPackage(\"semigroups\"); Read(\"$GAP_DIR/tst/testbugfix.g\");" |
+    #  $GAP -A -x 80 -r -m 100m -o 1g -K 2g -T 2>&1 | tee -a $TESTLOG
   fi
+else
+  echo -e "\nUnrecognised test suite"
+  exit 1
 fi
 
 ( ! grep -E "Diff|brk>|#E|Error|Errors detected|# WARNING|fail|Syntax warning|Couldn't open saved workspace|insufficient|WARNING in|FAILED|Total errors found:" $TESTLOG )


### PR DESCRIPTION
I've updated the Travis setup:

- _We now run the tests against the required version of GAP, with the required version of packages._ Whenever this job fails for non-trivial reasons, but tests with newer versions of GAP/packages pass, then we should simply increase the required versions as appropriate.
- _All but one job against GAP `stable-4.9` is now against `stable-4.10`._ I believe that there is unlikely to be another release from the `stable-4.9` branch; the next round of releases will come from `stable-4.10`. So it makes sense to move these jobs.
- _I have cleaned up `scripts/travis-test.sh`_, but not changed what tests it does. I have added a (commented out) line which runs the GAP testbugfix tests, because I might want to incorporate this in the future. But I don't want to do that yet; see https://github.com/gap-system/gap/issues/2809.