### PR TITLE
Require IsSemigroup in the filters for the IsCommutative TrueMethod

### DIFF
--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -84,7 +84,7 @@ InstallTrueMethod(IsRegularSemigroup, IsRegularStarSemigroup);
 InstallTrueMethod(IsInverseSemigroup, IsGroup);
 InstallTrueMethod(IsInverseSemigroup, IsBlockGroup and IsRegularSemigroup);
 InstallTrueMethod(IsCommutativeSemigroup, IsZeroSemigroup);
-InstallTrueMethod(IsCommutativeSemigroup, IsCommutative);
+InstallTrueMethod(IsCommutativeSemigroup, IsCommutative and IsSemigroup);
 InstallTrueMethod(IsCommutative, IsCommutativeSemigroup);
 InstallTrueMethod(IsTrivial,
                   IsLeftZeroSemigroup and IsRightZeroSemigroup);


### PR DESCRIPTION
It make sense to add `IsSemigroup` to `InstallTrueMethod(IsCommutativeSemigroup, IsCommutative);` to be safe; see #519.