### PR TITLE
Accommodate changes in GAP affecting method ranks

### DIFF
--- a/gap/ideals/ideals.gi
+++ b/gap/ideals/ideals.gi
@@ -82,7 +82,7 @@ end);
 InstallMethod(ViewString,
 "for a semigroup ideal with ideal generators",
 [IsSemigroupIdeal and HasGeneratorsOfSemigroupIdeal],
-1,  # to beat the library method
+4,  # to beat the library method
 _ViewStringForSemigroupsIdeals);
 
 InstallMethod(ViewString,

--- a/gap/semigroups/semigraph.gi
+++ b/gap/semigroups/semigraph.gi
@@ -13,6 +13,7 @@ InstallMethod(AsMonoid, "for a graph inverse semigroup",
 
 InstallMethod(ViewString, "for a graph inverse semigroup",
 [IsGraphInverseSemigroup],
+RankFilter(IsGroupAsSemigroup),  # to beat library method for groups as semigrps
 function(S)
   local n, str;
 

--- a/gap/semigroups/semirms.gi
+++ b/gap/semigroups/semirms.gi
@@ -365,6 +365,7 @@ InstallMethod(ViewString,
 "for a Rees 0-matrix subsemigroup ideal with ideal generators",
 [IsReesZeroMatrixSubsemigroup and IsSemigroupIdeal and
  HasGeneratorsOfSemigroupIdeal],
+3,  # to beat ViewString for a semigroup ideal with ideal generators
 function(I)
   local str, nrgens;
 

--- a/tst/standard/grpffmat.tst
+++ b/tst/standard/grpffmat.tst
@@ -56,10 +56,9 @@ gap> G := Group(GeneratorsOfSemigroup(G));
 <group of 2x2 matrices over GF(2) with 3 generators>
 gap> IsMatrixOverFiniteFieldGroup(G);
 true
-gap> map := IsomorphismPermGroup(G);
-MappingByFunction( <group of 2x2 matrices over GF(2) with 
-3 generators>, Group([ (), (2,3), (1,
-2) ]), function( x ) ... end, function( x ) ... end )
+gap> map := IsomorphismPermGroup(G);;
+gap> IsomorphismGroups(Range(map), SymmetricGroup(3)) <> fail;
+true
 gap> BruteForceInverseCheck(map);
 true
 gap> BruteForceIsoCheck(map);

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -2680,10 +2680,16 @@ Transformation( [ 3, 3, 3 ] )
 # Test IsomorphismTransformationSemigroup for an ideal
 gap> S := FullTransformationMonoid(3);
 <full transformation monoid of degree 3>
-gap> map := IsomorphismTransformationSemigroup(MinimalIdeal(S));
-MappingByFunction( <simple transformation semigroup ideal of degree 3 with
-  1 generator>, <regular transformation semigroup ideal of degree 3 with
- 1 generator>, function( x ) ... end, function( x ) ... end )
+gap> x := MinimalIdeal(S);
+<simple transformation semigroup ideal of degree 3 with 1 generator>
+gap> map := IsomorphismTransformationSemigroup(x);;
+gap> x := Range(map);;
+gap> IsSimpleSemigroup(x);
+true
+gap> Size(x) = 3;
+true
+gap> x;
+<simple transformation semigroup ideal of size 3, degree 3 with 1 generator>
 gap> BruteForceInverseCheck(map);
 true
 gap> BruteForceIsoCheck(map);


### PR DESCRIPTION
Some changes in GAP `master` branch mean that the ranks of certain filters have changed (see https://github.com/gap-system/gap/issues/2818), which means that some rank adjustments related to the Semigroups package are not correct. To ensure compatibility with all versions of GAP I've made some changes.

If I have done everything correctly, then the only failure in Travis will be GAP's `tst/testinstall/triviso.tst`; this should be fixed if https://github.com/gap-system/gap/pull/2819 is merged into GAP's master branch.

This will therefore basically resolve #522.