### PR TITLE
Update some testing details and create teststandard.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -285,7 +285,7 @@ AvailabilityTest := function()
 end,
 
 Autoload := false,
-TestFile := "tst/testinstall.tst",
+TestFile := "tst/teststandard.g",
 Keywords := ["transformation semigroups", "partial permutations",
              "inverse semigroups", "Green's relations",
              "free inverse semigroup", "partition monoid", "bipartitions",

--- a/gap/tools/utils.gi
+++ b/gap/tools/utils.gi
@@ -160,6 +160,10 @@ SEMIGROUPS.TestDir := function(dir, arg)
     for name in RecNames(arg[1]) do
       opts.testOptions.(name) := arg[1].(name);
     od;
+    # To allow the option from tst/teststandard.g to be processed
+    if "suppressStatusMessage" in RecNames(arg[1]) then
+      opts.suppressStatusMessage := arg[1].suppressStatusMessage;
+    fi;
   elif Length(arg) <> 0 then
     ErrorNoReturn("there must be no arguments, or the argument ",
                   "must be a opts");

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -1,0 +1,18 @@
+#############################################################################
+##
+#W  teststandard.g
+#Y  Copyright (C) 2018                                      Wilf A. Wilson
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+LoadPackage("semigroups", false);;
+if SemigroupsTestStandard(rec(suppressStatusMessage := true)) then
+  Print("#I  No errors detected while testing\n\n");
+  QUIT_GAP(0);
+else
+  Print("#I  Errors detected while testing\n\n");
+  QUIT_GAP(1);
+fi;
+FORCE_QUIT_GAP(1); # if we ever get here, there was an error


### PR DESCRIPTION
This is prompted by #517: it would be nice if the `TestFile` specified in our `PackageInfo.g` file actually ran `SemigroupsTestStandard`, which provides almost comprehensive code coverage, and runs fairly quickly, as opposed to `SemigroupsTestInstall`, which does not systematically cover the whole package. This is especially useful because @alex-konovalov uses the `TestFile` from `PackageInfo.g` in some of his automated testing.

To do so, I have created a file called `tst/testinstall.g`, which runs `SemigroupsTestStandard`. @alex-konovalov requested that we find a way to make `SemigroupsTestStandard` print the line `#I  No errors detected while testing` only once, because his testing setup cannot handle multiple occurrences of this line. This prompted me to investigate what `SemigroupsTestStandard` does a bit more.

`SemigroupsTestStandard` uses GAP's library function `TestDirectory`, via `SEMIGROUPS.TestDir`. `TestDirectory` allows for options, including turning off those automatic `#I  No errors detected while testing` lines. Doing so led me to discover that `SEMIGROUPS.TestDir` ~~was not correctly passing its options to `TestDirectory`.~~ does not allow the user to specify options to `TestDirectory`; only to `Test` calls that are children of `TestDirectory`.

I've now allowed `SEMIGROUPS.TestDir` to pass a `suppressStatusMessage` option to `TestDirectory`, so now `tst/teststandard.g` provides the solution to #517.