### PR TITLE
Improve methods for multiplicative zeroes

### DIFF
--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -420,14 +420,10 @@ InstallMethod(MultiplicativeZero, "for a semigroup",
 function(S)
   local D, rep, gens;
 
-  if not IsFinite(S) then
-    TryNextMethod();
-  elif IsSemigroupIdeal(S)
+  if IsSemigroupIdeal(S)
       and HasMultiplicativeZero(SupersemigroupOfIdeal(S)) then
     return MultiplicativeZero(SupersemigroupOfIdeal(S));
-  fi;
-
-  if HasMinimalDClass(S) then
+  elif HasMinimalDClass(S) then
     D := MinimalDClass(S);
     if HasSize(D) then
       if IsTrivial(D) then
@@ -435,10 +431,10 @@ function(S)
       fi;
       return fail;
     fi;
-  fi;
-
-  if IsSemigroupIdeal(S) then
+  elif IsSemigroupIdeal(S) then
     return MultiplicativeZero(SupersemigroupOfIdeal(S));
+  elif not IsFinite(S) then
+    TryNextMethod();
   fi;
 
   rep := RepresentativeOfMinimalIdeal(S);

--- a/gap/elements/elements.gi
+++ b/gap/elements/elements.gi
@@ -1,7 +1,7 @@
 ############################################################################
 ##
 ##  elements.gi
-##  Copyright (C) 2016                                      Wilf A. Wilson
+##  Copyright (C) 2016-18                                   Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -110,4 +110,12 @@ function(x)
     pow := pow + per;
   od;
   return pow;
+end);
+
+InstallMethod(IsMultiplicativeZero,
+"for a semigroup with multiplicative zero and multiplicative element",
+[IsSemigroup and HasMultiplicativeZero, IsMultiplicativeElement],
+SUM_FLAGS,
+function(S, x)
+  return MultiplicativeZero(S) <> fail and x = MultiplicativeZero(S);
 end);

--- a/gap/elements/elements.gi
+++ b/gap/elements/elements.gi
@@ -116,6 +116,4 @@ InstallMethod(IsMultiplicativeZero,
 "for a semigroup with multiplicative zero and multiplicative element",
 [IsSemigroup and HasMultiplicativeZero, IsMultiplicativeElement],
 SUM_FLAGS,
-function(S, x)
-  return MultiplicativeZero(S) <> fail and x = MultiplicativeZero(S);
-end);
+{S, x} -> MultiplicativeZero(S) <> fail and x = MultiplicativeZero(S));

--- a/gap/ideals/ideals.gi
+++ b/gap/ideals/ideals.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  ideals.gi
-##  Copyright (C) 2013-15                                James D. Mitchell
+##  Copyright (C) 2013-18                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -412,7 +412,7 @@ function(I)
   fi;
 
   gens := GeneratorsOfSemigroupIdeal(I);
-  return MultiplicativeZero(I) = gens[1] and ForAll(gens, x -> gens[1] = x);
+  return ForAll(gens, x -> gens[1] = x) and IsMultiplicativeZero(I, gens[1]);
 end);
 
 InstallMethod(IsFactorisableInverseMonoid, "for an inverse semigroup ideal",
@@ -442,4 +442,19 @@ function(S)
   # All non-empty sets of pairwise incomparable D-classes
   cliques := DigraphCliques(gr);
   return List(cliques, clique -> SemigroupIdeal(S, reps{clique}));
+end);
+
+InstallMethod(IsMultiplicativeZero,
+"for a semigroup ideal and multiplicative element",
+[IsSemigroupIdeal, IsMultiplicativeElement],
+function(I, x)
+  local gens;
+  if not x in I then
+    return false;
+  elif HasGeneratorsOfSemigroup(I) then
+    gens := GeneratorsOfSemigroup(I);
+  else
+    gens := GeneratorsOfSemigroup(SupersemigroupOfIdeal(I));
+  fi;
+  return ForAll(gens, g -> g * x = x and x * g = x);
 end);

--- a/tst/standard/elements.tst
+++ b/tst/standard/elements.tst
@@ -87,6 +87,15 @@ gap> SmallestIdempotentPower(GeneratorsOfMagma(FreeMagma(1))[1]);
 Error, Semigroups: SmallestIdempotentPower: usage,
 the argument <x> must be the generator of a semigroup,
 
+# elements: IsMultiplicativeZero
+gap> S := SymmetricInverseMonoid(3);;
+gap> x := MultiplicativeZero(S);
+<empty partial perm>
+gap> IsMultiplicativeZero(S, x);
+true
+gap> IsMultiplicativeZero(S, PartialPerm([1]));
+false
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(x);
 

--- a/tst/standard/ideals.tst
+++ b/tst/standard/ideals.tst
@@ -340,6 +340,34 @@ gap> ideals := Ideals(S);;
 gap> Size(ideals);
 179
 
+# MultiplicativeZero
+gap> S := FreeSemigroup(2);;
+gap> I := SemigroupIdeal(S, S.1);;
+gap> IsTrivial(I);
+false
+gap> MultiplicativeZero(I);
+fail
+gap> S := FreeSemigroup(2);;
+gap> I := SemigroupIdeal(S, S.2 * S.1);;
+gap> MultiplicativeZero(I);
+fail
+gap> S := SymmetricInverseMonoid(3);;
+gap> I := SemigroupIdeal(S, PartialPerm([2, 1]));;
+gap> MultiplicativeZero(I);
+<empty partial perm>
+
+# IsMultiplicativeZero
+gap> S := SingularTransformationMonoid(3);;
+gap> IsMultiplicativeZero(S, IdentityTransformation);
+false
+gap> GeneratorsOfSemigroup(S);;
+gap> IsMultiplicativeZero(S, Transformation([1, 1, 1]));
+false
+gap> S := SemigroupIdeal(SymmetricInverseSemigroup(3), PartialPerm([2]));;
+gap> GeneratorsOfSemigroup(S);;
+gap> IsMultiplicativeZero(S, EmptyPartialPerm());
+true
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(A);
 gap> Unbind(I);


### PR DESCRIPTION
I identified some ways of the methods in the package for `IsMultiplicativeZero` and `MultiplicativeZero`, particularly in relation to ideals.

* If a semigroup `S` already knows its multiplicative zero (or knows that it doesn't have one), then `IsMultiplicativeZero(S, x)` should just test `x` against this known (non-)element.
* In `IsTrivial` for a semigroup ideal, we should check whether all the ideal generators are equal first (easy) before testing whether the unique generator is the multiplicative zero (potentially hard).
* An ideal contains a zero if and only if its parent semigroup contains the same zero – for finite or infinite semigroups. Therefore, for `IsMultiplicativeZero` for an ideal and an element, if we don't have semigroup generators for the ideal, then we can just check whether the element is a zero of the parent semigroup.
* Similarly, `MultiplicativeZero` for an ideal can return `MultiplicativeZero` of the parent semigroup.