### PR TITLE
ideals: resolve Issue 530 (IsFactorisableInverseMonoid)

### DIFF
--- a/gap/ideals/ideals.gi
+++ b/gap/ideals/ideals.gi
@@ -418,9 +418,8 @@ end);
 InstallMethod(IsFactorisableInverseMonoid, "for an inverse semigroup ideal",
 [IsSemigroupIdeal and IsInverseSemigroup],
 function(I)
-
   if I = SupersemigroupOfIdeal(I) then
     return IsFactorisableInverseMonoid(SupersemigroupOfIdeal(I));
   fi;
-  return false;
+  return IsFactorisableInverseMonoid(InverseSemigroup(GeneratorsOfSemigroup(I)));
 end);

--- a/tst/standard/ideals.tst
+++ b/tst/standard/ideals.tst
@@ -300,7 +300,18 @@ true
 gap> I := MinimalIdeal(I);
 <bipartition group of degree 4>
 gap> IsFactorisableInverseMonoid(I);
-false
+true
+
+# IsFactorisableInverseMonoid
+gap> S := SymmetricInverseMonoid(5);;
+gap> I := MinimalIdeal(S);;
+gap> IsFactorisableInverseMonoid(I);
+true
+gap> J := InverseMonoid(I);;
+gap> I = J;
+true
+gap> IsFactorisableInverseMonoid(J);
+true
 
 #
 gap> SEMIGROUPS.StopTest();


### PR DESCRIPTION
`IsFactorisableInverseMonoid` applied to an ideal returned false negatives,
whenever the ideal was a factorisable inverse monoid but was not equal to its supersemigroup.