### PR TITLE
freeinverse: use non-impl. dep.  free group iterator

### DIFF
--- a/gap/fp/freeinverse.gi
+++ b/gap/fp/freeinverse.gi
@@ -45,8 +45,11 @@ function(iter)
   FG_NextIterator := function(iter)
     local word, output, i;
 
-    NextIterator(iter);
-    word := iter!.word;
+    word := ExtRepOfObj(NextIterator(iter));
+    if IsEmpty(word) then
+      word := ExtRepOfObj(NextIterator(iter));
+    fi;
+
     output := GeneratorsOfInverseSemigroup(semigroup)[word[1]] ^ word[2];
     i := 3;
     while i < Length(word) do


### PR DESCRIPTION
This PR resolves Issue #532 by not using implementation dependent features of the free group iterator. 

Disclaimer: I haven't checked if this really resolves the issue when RCWA is loaded. 