### PR TITLE
Adjust for compatibility with all packages loaded

### DIFF
--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -1066,7 +1066,7 @@ end);
 # same method for ideals
 
 InstallMethod(IsOrthodoxSemigroup, "for a semigroup",
-[IsSemigroup], 1,  # to beat the Smallsemi method
+[IsSemigroup], SUM_FLAGS,  # to beat the Smallsemi method
 function(S)
   local e, m, i, j;
 

--- a/tst/standard/freeinverse.tst
+++ b/tst/standard/freeinverse.tst
@@ -91,8 +91,6 @@ gap> iter := Iterator(FreeInverseSemigroup(["a", "b"]));
 gap> for i in [1 .. 10] do
 > NextIterator(iter);
 > od;
-gap> NextIterator(iter);
-a*b
 gap> IsDoneIterator(iter);
 false
 

--- a/tst/standard/properties.tst
+++ b/tst/standard/properties.tst
@@ -790,12 +790,14 @@ gap> GreensDClasses(S);;
 gap> IsInverseSemigroup(S);
 false
 
-# properties: IsInverseSemigroup, infinite, 4
-gap> S := FreeSemigroup(2);;
-gap> IsInverseSemigroup(S);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `CayleyGraphDualSemigroup' on 1 argument\
-s
+# WW: This is removed since, at the moment, a different no method found error
+# is given depending on which packages are loaded
+## properties: IsInverseSemigroup, infinite, 4
+#gap> S := FreeSemigroup(2);;
+#gap> IsInverseSemigroup(S);
+#Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+#Error, no 2nd choice method found for `CayleyGraphDualSemigroup' on 1 argument\
+#s
 
 # properties: IsLeftSimple, non-regular, 1
 gap> S := RegularBooleanMatMonoid(3);


### PR DESCRIPTION
With this PR ~and an adjustment to a filter in `smallsemi` that I mentioned in https://github.com/gap-packages/Semigroups/issues/543#issuecomment-425429322~, the next release of the Semigroups package should pass in Alexander's tests where all the packages are loaded.

Not that this required me to adjust an iterator test for free inverse semigroups; @james-d-mitchell has adjusted this code and presumably the tests, so it would be best to merge this after that fix has been pushed (in case this will need rebasing).

I added `SUM_FLAGS` to the method rank of `IsOrthodoxSemigroup` so that Semigroups beats smallsemi. Ideally `1` should be enough of an adjustment to make this happen, but until the current GAP master branch, method rank stuff was broken in GAP, and this is the simplest way to avoid the brokenness of GAP.

Doing this avoids needing to make changes to `smallsemi`.