### PR TITLE
Fix iterators for free inverse semigroups (issue #536) and some new methods for free inverse semigroups

### DIFF
--- a/doc/z-chap10.xml
+++ b/doc/z-chap10.xml
@@ -45,9 +45,10 @@
     inverse semigroup: a unique canonical form.  Suppose an element of a free
     inverse semigroup is given as a Munn tree. Let <M>L</M> be the set of words
     corresponding to the shortest paths from the start vertex to the leaves of
-    the tree. Also let <M>w</M> be a word corresponding to the shortest path
-    from start to terminal vertices. The word <M>vv ^ {-1}</M> is an idempotent
-    for every <M>v</M> in <M>L</M>.  The canonical form is given by multiplying
+    the tree. Also let <M>w</M> be the word corresponding to the shortest path
+    from the start vertex to the terminal vertex. The word <M>vv ^ {-1}</M> is an
+    idempotent for every <M>v</M> in <M>L</M>.
+    The canonical form is given by multiplying
     these idempotents, in shortlex order, and then postmultiplying by <M>w</M>.
     For example, consider the word <M>xyy ^ {-1}xx ^ {-1}x ^ {-1}</M> again.
     The words corresponding to the paths to the leaves are in this case

--- a/gap/attributes/isomorph.gi
+++ b/gap/attributes/isomorph.gi
@@ -107,7 +107,7 @@ function(S, T)
   else
     rmsS := S;
   fi;
-  # Take an isomorphism of T to an RMS if appropriate
+  # Take an isomorphism of T to an RMS if appropriate
   if not (IsReesMatrixSemigroup(T) and IsWholeFamily(T)
       and IsPermGroup(UnderlyingSemigroup(T))) then
     invT := IsomorphismReesMatrixSemigroupOverPermGroup(T);
@@ -144,7 +144,7 @@ function(S, T)
   else
     rmsS := S;
   fi;
-  # Take an isomorphism of T to an RZMS if appropriate
+  # Take an isomorphism of T to an RZMS if appropriate
   if not (IsReesZeroMatrixSemigroup(T) and IsWholeFamily(T)
       and IsPermGroup(UnderlyingSemigroup(T))) then
     invT := IsomorphismReesZeroMatrixSemigroupOverPermGroup(T);

--- a/gap/attributes/maximal.gi
+++ b/gap/attributes/maximal.gi
@@ -1149,7 +1149,7 @@ function(S, opts)
     TryNextMethod();
   fi;
 
-  opts := ShallowCopy(opts);  # in case <opts> is immutable
+  opts := ShallowCopy(opts);  # in case <opts> is immutable
 
   # Bind default options
   if not IsBound(opts.number) then

--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -25,7 +25,7 @@
 # IsRectangularGroup, IsBandOfGroups, IsFreeBand, IsFreeSemilattice,
 # IsFreeNormalBand, , IsFundamentalInverseSemigp,
 # IsFullSubsemigroup (of an inverse semigroup), IsFactorizableInverseMonoid,
-# IsFInverseSemigroup, IsSemigroupWithCentralIdempotents, IsLeftUnipotent,
+# IsFInverseSemigroup, IsSemigroupWithCentralIdempotents, IsLeftUnipotent,
 # IsRightUnipotent, IsSemigroupWithClosedIdempotents, .
 
 # same method for ideals, works for finite and infinite

--- a/gap/greens/gren.gi
+++ b/gap/greens/gren.gi
@@ -226,7 +226,7 @@ InstallMethod(GreensRRelation, "for an enumerable semigroup",
 [IsEnumerableSemigroupRep],
 function(S)
   local fam, rel;
-  if IsActingSemigroup(S) then
+  if IsActingSemigroup(S) or (HasIsFinite(S) and not IsFinite(S)) then
     TryNextMethod();
   fi;
   fam := GeneralMappingsFamily(ElementsFamily(FamilyObj(S)),
@@ -251,7 +251,7 @@ InstallMethod(GreensLRelation, "for an enumerable semigroup",
 [IsEnumerableSemigroupRep],
 function(S)
   local fam, rel;
-  if IsActingSemigroup(S) then
+  if IsActingSemigroup(S) or (HasIsFinite(S) and not IsFinite(S)) then
     TryNextMethod();
   fi;
   fam := GeneralMappingsFamily(ElementsFamily(FamilyObj(S)),
@@ -276,7 +276,7 @@ InstallMethod(GreensDRelation, "for an enumerable semigroup",
 [IsEnumerableSemigroupRep],
 function(S)
   local fam, data, rel;
-  if IsActingSemigroup(S) then
+  if IsActingSemigroup(S) or (HasIsFinite(S) and not IsFinite(S)) then
     TryNextMethod();
   fi;
   fam := GeneralMappingsFamily(ElementsFamily(FamilyObj(S)),
@@ -302,7 +302,7 @@ InstallMethod(GreensHRelation, "for an enumerable semigroup",
 [IsEnumerableSemigroupRep],
 function(S)
   local fam, data, rel;
-  if IsActingSemigroup(S) then
+  if IsActingSemigroup(S) or (HasIsFinite(S) and not IsFinite(S)) then
     TryNextMethod();
   fi;
   fam := GeneralMappingsFamily(ElementsFamily(FamilyObj(S)),

--- a/gap/main/fropin.gi
+++ b/gap/main/fropin.gi
@@ -163,7 +163,6 @@ function(S)
               words := []);
 
   data.report     := SEMIGROUPS.OptionsRec(S).report;
-  data.batch_size := SEMIGROUPS.OptionsRec(S).batch_size;
   hashlen         := SEMIGROUPS.OptionsRec(S).hashlen;
 
   data.gens := ShallowCopy(GeneratorsOfSemigroup(S));

--- a/scripts/make-deps.py
+++ b/scripts/make-deps.py
@@ -40,12 +40,12 @@ for name in PACKAGES:
             dirs.append(pkg)
     dirs.sort()
     if len(dirs) == 0:
-        print 'ERROR: can\'t find ' + name
+        print('ERROR: can\'t find ' + name)
         continue
     os.chdir(dirs[-1])
-    print '\n', _LINE_OF_HASHES
-    print '\033[35mmaking ' + os.getcwd() + ' . . .  \033[0m'
-    print _LINE_OF_HASHES, '\n'
+    print('\n', _LINE_OF_HASHES)
+    print('\033[35mmaking ' + os.getcwd() + ' . . .  \033[0m')
+    print(_LINE_OF_HASHES, '\n')
     bash = ['make clean', './configure', 'make']
     for x in bash:
         subprocess.call(x, shell=True)

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -379,9 +379,8 @@ true
 
 # attr: RightCayleyGraphSemigroup, infinite
 gap> LeftCayleyGraphSemigroup(FreeInverseSemigroup(2));
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `CayleyGraphDualSemigroup' on 1 argument\
-s
+Error, Semigroups: LeftCayleyGraphSemigroup: usage,
+the first argument (a semigroup) must be finite,
 
 # attr: IsomorphismReesMatrixSemigroup
 gap> D := GreensDClassOfElement(Semigroup(

--- a/tst/standard/freeinverse.tst
+++ b/tst/standard/freeinverse.tst
@@ -91,6 +91,8 @@ gap> iter := Iterator(FreeInverseSemigroup(["a", "b"]));
 gap> for i in [1 .. 10] do
 > NextIterator(iter);
 > od;
+gap> NextIterator(iter);
+b*a^-1
 gap> IsDoneIterator(iter);
 false
 

--- a/tst/standard/fropin.tst
+++ b/tst/standard/fropin.tst
@@ -93,8 +93,7 @@ Error, Semigroups: FROPIN: usage,
 the argument must be a semigroup with at least 1 generator,
 gap> S := RegularBooleanMatMonoid(3);;
 gap> FROPIN(S);
-rec( batch_size := 8192, 
-  elts := [ Matrix(IsBooleanMat, [[1, 0, 0], [0, 1, 0], [0, 0, 1]]), 
+rec( elts := [ Matrix(IsBooleanMat, [[1, 0, 0], [0, 1, 0], [0, 0, 1]]), 
       Matrix(IsBooleanMat, [[0, 1, 0], [1, 0, 0], [0, 0, 1]]), 
       Matrix(IsBooleanMat, [[0, 1, 0], [0, 0, 1], [1, 0, 0]]), 
       Matrix(IsBooleanMat, [[1, 0, 0], [0, 1, 0], [1, 0, 1]]), 
@@ -122,8 +121,7 @@ rec( batch_size := 8192,
 gap> Size(S);
 506
 gap> FROPIN(S);
-rec( batch_size := 8192, 
-  elts := [ Matrix(IsBooleanMat, [[1, 0, 0], [0, 1, 0], [0, 0, 1]]), 
+rec( elts := [ Matrix(IsBooleanMat, [[1, 0, 0], [0, 1, 0], [0, 0, 1]]), 
       Matrix(IsBooleanMat, [[0, 1, 0], [1, 0, 0], [0, 0, 1]]), 
       Matrix(IsBooleanMat, [[0, 1, 0], [0, 0, 1], [1, 0, 0]]), 
       Matrix(IsBooleanMat, [[1, 0, 0], [0, 1, 0], [1, 0, 1]]), 

--- a/tst/standard/fropin.tst
+++ b/tst/standard/fropin.tst
@@ -471,6 +471,35 @@ gap> MinimalFactorization(S, Transformation([1, 1, 1, 1]));
 Error, Semigroups: MinimalFactorization:
 the second argument <x> is not an element of the first argument <S>,
 
+# Display
+gap> Display(Semigroup(Matrix(IsMaxPlusMatrix, [[-2, 2], [0, -1]]))); "";
+<partially enumerated semigroup with 0 elements, 0 rules, max word length 0>""
+gap> Display(S); "";
+<fully enumerated semigroup with 27 elements, 20 rules, max word length 6>""
+
+# IsFinite
+gap> S := Semigroup(Matrix(IsMaxPlusMatrix, [[-2, 2], [0, -1]]));;
+gap> IsFinite(S);
+false
+gap> S := Semigroup(Matrix(IsIntegerMatrix, [[1, 0], [0, -1]]));;
+gap> IsFinite(S);
+true
+
+# MultiplicationTable
+gap> S := ReesMatrixSemigroup(Group([(1, 2)]), [[(), (1, 2)], [(), ()]]);;
+gap> MultiplicationTable(S);
+[ [ 1, 2, 3, 4, 3, 4, 1, 2 ], [ 1, 2, 3, 4, 1, 2, 3, 4 ], 
+  [ 3, 4, 1, 2, 1, 2, 3, 4 ], [ 3, 4, 1, 2, 3, 4, 1, 2 ], 
+  [ 5, 6, 7, 8, 7, 8, 5, 6 ], [ 5, 6, 7, 8, 5, 6, 7, 8 ], 
+  [ 7, 8, 5, 6, 5, 6, 7, 8 ], [ 7, 8, 5, 6, 7, 8, 5, 6 ] ]
+
+# PositionCanonical (for a group)
+gap> G := Group((1, 2, 3), (1, 2));;
+gap> IsEnumerableSemigroupRep(G);
+true
+gap> PositionCanonical(G, (1, 3, 2));
+3
+
 #
 gap> SEMIGROUPS.StopTest();
 gap> STOP_TEST("Semigroups package: standard/fropin.tst");


### PR DESCRIPTION
I think that this resolves Issue #536.

This PR removes the previous iterator code for free inverse semigroups. The code did not function as it was intended. If I understand it correctly it was attempting to enumerate canonical forms for elements of the free inverse semigroup, which are words of the form:

> w_1 w_1 ^ -1 w_2 w_2 ^ -1 ... w_k w_k ^ -1 u 

where w_1, w_2, ..., w_k, u are words in the free group with the same number of generators as the free inverse semigroup. The previous approach (when fixed) essentially iterated through all such expressions. Unfortunately, distinct expressions of the above form do not yield distinct elements of the free inverse semigroup. In fact, of the first 10,000 values iterated through, there were only 119 distinct elements.

In this PR, I have:

1. Fixed (I think) the iterator code, then realised it doesn't work.
2. Commented the iterator code out, in case it can be fixed later.
3. Added methods for Random, \<, and, ChooseHashFunction for free
   inverse semigroups and their elements.
4. Make `FreeInverseSemigroup`s belong to `IsEnumerableSemigroupRep`
4. Tweaked the doc and comments slightly.
5. Add some missing HasIsFinite and not IsFinite to Green's classes.
6. FreeInverseSemigroups know they are infinite now.
7. Do some other minor cleaning up.