### PR TITLE
Make method selection-related tweaks to accommodate GAP fixes

### DIFF
--- a/gap/greens/gree.gi
+++ b/gap/greens/gree.gi
@@ -244,9 +244,8 @@ InstallMethod(GreensJClassOfElementNC,
 # Green's classes of an element of a semigroup
 
 InstallMethod(GreensRClassOfElement,
-"for a finite semigroup and multiplicative element",
+"for a possibly finite semigroup and multiplicative element",
 [IsSemigroup, IsMultiplicativeElement],
-RankFilter(IsFinite),
 function(S, x)
   if not IsFinite(S) then
     TryNextMethod();
@@ -254,10 +253,14 @@ function(S, x)
   return EquivalenceClassOfElement(GreensRRelation(S), x);
 end);
 
-InstallMethod(GreensLClassOfElement,
+InstallMethod(GreensRClassOfElement,
 "for a finite semigroup and multiplicative element",
+[IsSemigroup and IsFinite, IsMultiplicativeElement],
+{S, x} -> EquivalenceClassOfElement(GreensRRelation(S), x));
+
+InstallMethod(GreensLClassOfElement,
+"for a possibly finite semigroup and multiplicative element",
 [IsSemigroup, IsMultiplicativeElement],
-RankFilter(IsFinite),
 function(S, x)
   if not IsFinite(S) then
     TryNextMethod();
@@ -265,10 +268,14 @@ function(S, x)
   return EquivalenceClassOfElement(GreensLRelation(S), x);
 end);
 
-InstallMethod(GreensHClassOfElement,
+InstallMethod(GreensLClassOfElement,
 "for a finite semigroup and multiplicative element",
+[IsSemigroup and IsFinite, IsMultiplicativeElement],
+{S, x} -> EquivalenceClassOfElement(GreensLRelation(S), x));
+
+InstallMethod(GreensHClassOfElement,
+"for a possibly finite semigroup and multiplicative element",
 [IsSemigroup, IsMultiplicativeElement],
-RankFilter(IsFinite),
 function(S, x)
   if not IsFinite(S) then
     TryNextMethod();
@@ -276,16 +283,25 @@ function(S, x)
   return EquivalenceClassOfElement(GreensHRelation(S), x);
 end);
 
-InstallMethod(GreensDClassOfElement,
+InstallMethod(GreensHClassOfElement,
 "for a finite semigroup and multiplicative element",
+[IsSemigroup and IsFinite, IsMultiplicativeElement],
+{S, x} -> EquivalenceClassOfElement(GreensHRelation(S), x));
+
+InstallMethod(GreensDClassOfElement,
+"for a possibly finite semigroup and multiplicative element",
 [IsSemigroup, IsMultiplicativeElement],
-RankFilter(IsFinite),
 function(S, x)
   if not IsFinite(S) then
     TryNextMethod();
   fi;
   return EquivalenceClassOfElement(GreensDRelation(S), x);
 end);
+
+InstallMethod(GreensDClassOfElement,
+"for a finite semigroup and multiplicative element",
+[IsSemigroup and IsFinite, IsMultiplicativeElement],
+{S, x} -> EquivalenceClassOfElement(GreensDRelation(S), x));
 
 # Green's class of a Green's class (coarser from finer)
 

--- a/gap/ideals/idealact.gi
+++ b/gap/ideals/idealact.gi
@@ -85,6 +85,9 @@ end);
 InstallMethod(GreensDClasses, "for a regular acting semigroup ideal rep",
 [IsSemigroupIdeal and IsRegularActingSemigroupRep],
 function(I)
+  if IsInverseActingSemigroupRep(I) then
+    TryNextMethod();
+  fi;
   Enumerate(SemigroupIdealData(I));
   return SemigroupIdealData(I)!.dorbit;
 end);
@@ -94,6 +97,9 @@ InstallMethod(PartialOrderOfDClasses,
 [IsSemigroupIdeal and IsRegularActingSemigroupRep],
 function(I)
   local data;
+  if IsInverseActingSemigroupRep(I) then
+    TryNextMethod();
+  fi;
   data := SemigroupIdealData(I);
   Enumerate(data);
   return data!.poset;
@@ -103,6 +109,9 @@ InstallMethod(DClassReps, "for a regular acting semigroup ideal rep",
 [IsSemigroupIdeal and IsRegularActingSemigroupRep],
 function(I)
   local data;
+  if IsInverseActingSemigroupRep(I) then
+    TryNextMethod();
+  fi;
   data := SemigroupIdealData(I);
   Enumerate(data);
   return List(data!.dorbit, Representative);
@@ -745,6 +754,10 @@ InstallMethod(\in,
 function(x, I)
   local data, ht, xx, o, l, lookfunc, m, lambdarhoht,
         schutz, ind, reps;
+
+  if IsInverseActingSemigroupRep(I) then
+    TryNextMethod();
+  fi;
 
   if ElementsFamily(FamilyObj(I)) <> FamilyObj(x)
       or (IsActingSemigroupWithFixedDegreeMultiplication(I)

--- a/gap/semigroups/semipperm.gi
+++ b/gap/semigroups/semipperm.gi
@@ -21,7 +21,8 @@ function(list, S)
     ErrorNoReturn("Semigroups: DirectProductOp: usage,\n",
                   "the first argument must be a non-empty list,");
   elif ForAny(list,
-              T -> not (IsPartialPermMonoid(T) and IsInverseMonoid(T))) then
+              T -> not (IsPartialPermMonoid(T) and IsInverseMonoid(T)))
+      or ForAll(list, IsGroup) then
     TryNextMethod();
   fi;
 

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -63,7 +63,8 @@ function(list, S)
   if IsEmpty(list) then
     ErrorNoReturn("Semigroups: DirectProductOp: usage,\n",
                   "the first argument must be a non-empty list,");
-  elif ForAny(list, T -> not IsTransformationMonoid(T)) then
+  elif ForAny(list, T -> not IsTransformationMonoid(T))
+      or ForAll(list, IsGroup) then
     TryNextMethod();
   fi;
 
@@ -91,7 +92,8 @@ function(list, S)
     ErrorNoReturn("Semigroups: DirectProductOp: usage,\n",
                   "the first argument must be a non-empty list,");
   elif not ForAll(list, T -> IsTransformationSemigroup(T)
-                             and IsMonoidAsSemigroup(T)) then
+                             and IsMonoidAsSemigroup(T))
+      or ForAll(list, IsGroup) then
     TryNextMethod();
   fi;
 
@@ -131,7 +133,8 @@ function(list, S)
     # is detected there.
     ErrorNoReturn("Semigroups: DirectProductOp: usage,\n",
                   "the first argument must be a non-empty list,");
-  elif ForAny(list, T -> not IsTransformationSemigroup(T)) then
+  elif ForAny(list, T -> not IsTransformationSemigroup(T))
+      or ForAll(list, IsGroup) then
     TryNextMethod();
   fi;
 

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1632,19 +1632,8 @@ gap> IsReesMatrixSemigroup(W);
 true
 gap> IsomorphismSemigroups(S, S);
 ((), IdentityMapping( Group( [ () ] ) ), [ (), () ])
-gap> IsomorphismSemigroups(W, W);
-CompositionMapping( MappingByFunction( <Rees matrix semigroup 1x1 over 
-  Group(())>, <Rees matrix semigroup 1x1 over Group(())>
- , function( v ) ... end, function( u ) ... end ), CompositionMapping( 
-((), IdentityMapping( Group( [ () ] ) ), [ (), () ]), MappingByFunction( 
-<Rees matrix semigroup 1x1 over Group(())>, <Rees matrix semigroup 1x1 over 
-  Group(())>, function( u ) ... end, function( v ) ... end ) ) )
-gap> IsomorphismSemigroups(S, W);
-CompositionMapping( MappingByFunction( <Rees matrix semigroup 1x1 over 
-  Group(())>, <Rees matrix semigroup 1x1 over Group(())>
- , function( v ) ... end, function( u ) ... end ),
- ((), GroupHomomorphismByImages( Group( [ () ] ), Group( [ () ] ), [  ], 
-[  ] ), [ (), () ]) )
+gap> IsomorphismSemigroups(W, W) = IdentityMapping(W);
+true
 gap> IsomorphismSemigroups(W, S);
 CompositionMapping( ((), GroupHomomorphismByImages( Group( [ () ] ), Group( 
 [ () ] ), [  ], [  ] ), [ (), () ]), MappingByFunction( 


### PR DESCRIPTION
I've made some adjustments so that GAP's `testinstall` tests in GAP `master` pass when all packages are loaded.

In particular,

* I've changed it so that the direct product code does not apply when the arguments all satisfy `IsGroup`.
* I've added `GreensXClassOfElement` methods that include the filter `IsFinite`, to beat the GAP library ones that we do not expect to be applied when the Semigroups package is loaded
* Sometimes, with all packages loaded, the methods for `IsSemigroupIdeal and IsRegularActingSemigroupRep` would have higher ranks than those for `IsInverseActingSemigroupRep`, even though we would want the latter to apply to ideals in that representation. I've added some `TryNextMethod` calls to avoid this problem.

Overall, the work to accommodate the fixed method ordering in GAP is not complete. There are still diffs in GAP's `testbugfix` suite when all packages are loaded. Furthermore, the Semigroups package tests do not run. Hopefully it'll only require small changes like these to fix everything.