### PR TITLE
Rename 'IsDecomposableSemigroup' to 'IsSurjectiveSemigroup'

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1206,7 +1206,7 @@ gap> GeneratorsSmallest(T);
     <A>S</A>. An element of <A>S</A> is <E>indecomposable</E> if it is not
     decomposable. <P/>
     
-    See also <Ref Prop="IsDecomposableSemigroup" />. <P/>
+    See also <Ref Prop="IsSurjectiveSemigroup" />. <P/>
 
     Note that any generating set for <A>S</A> contains each indecomposable
     element of <A>S</A>. Thus <C>IndecomposableElements(<A>S</A>)</C> is a

--- a/doc/properties.xml
+++ b/doc/properties.xml
@@ -1133,38 +1133,38 @@ false]]></Example>
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="IsDecomposableSemigroup">
+<#GAPDoc Label="IsSurjectiveSemigroup">
   <ManSection>
-    <Prop Name="IsDecomposableSemigroup" Arg="S"/>
+    <Prop Name="IsSurjectiveSemigroup" Arg="S"/>
     <Returns><K>true</K> or <K>false</K>.</Returns>
     <Description>
-      A semigroup is decomposable if each of its elements can be written as a
-      product of two elements in the semigroup.
-      <C>IsDecomposableSemigroup(<A>S</A>)</C> returns <K>true</K> if the
-      semigroup <A>S</A> is decomposable, and <K>false</K> if it is not. <P/>
+      A semigroup is <E>surjective</E> if each of its elements can be written as
+      a product of two elements in the semigroup.
+      <C>IsSurjectiveSemigroup(<A>S</A>)</C> returns <K>true</K> if the
+      semigroup <A>S</A> is surjective, and <K>false</K> if it is not. <P/>
 
       See also <Ref Attr="IndecomposableElements" />. <P/>
 
-      Note that every monoid, and every regular semigroup, is decomposable.
+      Note that every monoid, and every regular semigroup, is surjective.
 
       <Example><![CDATA[
 gap> S := FullTransformationMonoid(100);
 <full transformation monoid of degree 100>
-gap> IsDecomposableSemigroup(S);
+gap> IsSurjectiveSemigroup(S);
 true
 gap> F := FreeSemigroup(3);;
 gap> P := F / [[F.1, F.2 * F.1], [F.3 ^ 3, F.3]];
 <fp semigroup on the generators [ s1, s2, s3 ]>
-gap> IsDecomposableSemigroup(P);
+gap> IsSurjectiveSemigroup(P);
 false
 gap> I := SingularTransformationMonoid(5);
 <regular transformation semigroup ideal of degree 5 with 1 generator>
-gap> IsDecomposableSemigroup(I);
+gap> IsSurjectiveSemigroup(I);
 true
 gap> M := MonogenicSemigroup(IsBipartitionSemigroup, 3, 2);
 <commutative non-regular block bijection semigroup of size 4, 
  degree 6 with 1 generator>
-gap> IsDecomposableSemigroup(M);
+gap> IsSurjectiveSemigroup(M);
 false]]></Example>
     </Description>
   </ManSection>

--- a/doc/z-chap15.xml
+++ b/doc/z-chap15.xml
@@ -23,7 +23,7 @@
     <#Include Label = "IsCommutativeSemigroup">
     <#Include Label = "IsCompletelyRegularSemigroup">
     <#Include Label = "IsCongruenceFreeSemigroup">
-    <#Include Label = "IsDecomposableSemigroup">
+    <#Include Label = "IsSurjectiveSemigroup">
     <#Include Label = "IsGroupAsSemigroup">
     <#Include Label = "IsIdempotentGenerated">
     <#Include Label = "IsLeftSimple">

--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -948,7 +948,7 @@ InstallMethod(IndecomposableElements, "for a semigroup",
 function(S)
   local out, D;
 
-  if HasIsDecomposableSemigroup(S) and IsDecomposableSemigroup(S) then
+  if HasIsSurjectiveSemigroup(S) and IsSurjectiveSemigroup(S) then
     return [];
   fi;
   out := [];

--- a/gap/attributes/attrfp.gi
+++ b/gap/attributes/attrfp.gi
@@ -12,7 +12,7 @@ InstallMethod(IndecomposableElements, "for an fp semigroup", [IsFpSemigroup],
 function(S)
   local gens, rels, decomposable, uf, lens, pos1, pos2, t1, t2, x, rel;
 
-  if HasIsDecomposableSemigroup(S) then
+  if HasIsSurjectiveSemigroup(S) then
     return [];
   fi;
 

--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -95,7 +95,7 @@ InstallTrueMethod(IsFinite, IsMonogenicSemigroup and IsRegularSemigroup);
 InstallTrueMethod(IsGroupAsSemigroup,
                   IsMonogenicSemigroup and IsRegularSemigroup);
 
-DeclareProperty("IsDecomposableSemigroup", IsSemigroup);
-InstallTrueMethod(IsDecomposableSemigroup, IsRegularSemigroup);
-InstallTrueMethod(IsDecomposableSemigroup, IsMonoidAsSemigroup);
-InstallTrueMethod(IsDecomposableSemigroup, IsIdempotentGenerated);
+DeclareProperty("IsSurjectiveSemigroup", IsSemigroup);
+InstallTrueMethod(IsSurjectiveSemigroup, IsRegularSemigroup);
+InstallTrueMethod(IsSurjectiveSemigroup, IsMonoidAsSemigroup);
+InstallTrueMethod(IsSurjectiveSemigroup, IsIdempotentGenerated);

--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -1769,6 +1769,6 @@ end);
 InstallMethod(IsSemigroupWithAdjoinedZero, "for a semigroup", [IsSemigroup],
 x -> UnderlyingSemigroupOfSemigroupWithAdjoinedZero(x) <> fail);
 
-InstallMethod(IsDecomposableSemigroup, "for a semigroup",
+InstallMethod(IsSurjectiveSemigroup, "for a semigroup",
 [IsSemigroup],
 S -> IsEmpty(IndecomposableElements(S)));

--- a/gap/semigroups/semidp.gi
+++ b/gap/semigroups/semidp.gi
@@ -199,7 +199,7 @@ SEMIGROUPS.DirectProductOp := function(S, degree, convert, combine, restrict)
 
   D := create(out);
   SetIndecomposableElements(D, indecomp_out);
-  SetIsDecomposableSemigroup(D, IsEmpty(indecomp_out));
+  SetIsSurjectiveSemigroup(D, IsEmpty(indecomp_out));
   if ForAny(gens_new, IsEmpty) then
     SetMinimalSemigroupGeneratingSet(D, indecomp_out);
   fi;

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1723,7 +1723,7 @@ gap> S := FullTransformationMonoid(3);
 <full transformation monoid of degree 3>
 gap> S := Semigroup(GeneratorsOfMonoid(S));
 <transformation semigroup of degree 3 with 3 generators>
-gap> HasIsDecomposableSemigroup(S);
+gap> HasIsSurjectiveSemigroup(S);
 false
 gap> IndecomposableElements(S);
 [  ]
@@ -1731,7 +1731,7 @@ gap> S := Semigroup(S);
 <transformation semigroup of degree 3 with 3 generators>
 gap> IsMonoidAsSemigroup(S);
 true
-gap> HasIsDecomposableSemigroup(S) and IsDecomposableSemigroup(S);
+gap> HasIsSurjectiveSemigroup(S) and IsSurjectiveSemigroup(S);
 true
 gap> HasIndecomposableElements(S);
 false

--- a/tst/standard/attrfp.tst
+++ b/tst/standard/attrfp.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("semigroups", false);;
 #
 gap> SEMIGROUPS.StartTest();
 
-#T# properties: IndecomposableSemigroup, for an fp semigroup, 1
+#T# properties: IndecomposableElements, for an fp semigroup, 1
 gap> F := FreeSemigroup(1);
 <free semigroup on the generators [ s1 ]>
 gap> S := F / [];;
@@ -35,7 +35,7 @@ gap> S := F / [[F.1 ^ 3, F.1]];
 <fp semigroup on the generators [ s1 ]>
 gap> IsMonoidAsSemigroup(S);
 true
-gap> HasIsDecomposableSemigroup(S);
+gap> HasIsSurjectiveSemigroup(S);
 true
 gap> IndecomposableElements(S);
 [  ]

--- a/tst/standard/properties.tst
+++ b/tst/standard/properties.tst
@@ -1895,37 +1895,37 @@ true
 gap> IsFinite(S) and IsGroupAsSemigroup(S);
 true
 
-# properties: IsDecomposableSemigroup, for an fp semigroup, 1
+# properties: IsSurjectiveSemigroup, for an fp semigroup, 1
 gap> F := FreeSemigroup(1);
 <free semigroup on the generators [ s1 ]>
 gap> S := F / [];;
-gap> IsDecomposableSemigroup(S);
+gap> IsSurjectiveSemigroup(S);
 false
 gap> S := F / [[F.1, F.1]];
 <fp semigroup on the generators [ s1 ]>
-gap> IsDecomposableSemigroup(S);
+gap> IsSurjectiveSemigroup(S);
 false
 gap> S := F / [[F.1 ^ 3, F.1]];
 <fp semigroup on the generators [ s1 ]>
-gap> IsDecomposableSemigroup(S);
+gap> IsSurjectiveSemigroup(S);
 true
 gap> S := F / [[F.1 ^ 3, F.1 ^ 2]];
 <fp semigroup on the generators [ s1 ]>
-gap> IsDecomposableSemigroup(S);
+gap> IsSurjectiveSemigroup(S);
 false
 gap> F := FreeSemigroup(3);
 <free semigroup on the generators [ s1, s2, s3 ]>
 gap> S := F / [[F.2, F.1], [F.2 ^ 3, F.2], [F.2, F.3]];
 <fp semigroup on the generators [ s1, s2, s3 ]>
-gap> IsDecomposableSemigroup(S);
+gap> IsSurjectiveSemigroup(S);
 true
 
-# properties: IsDecomposableSemigroup, for a transformation semigroup, 1
+# properties: IsSurjectiveSemigroup, for a transformation semigroup, 1
 gap> S := MonogenicSemigroup(6, 2);;
-gap> IsDecomposableSemigroup(S);
+gap> IsSurjectiveSemigroup(S);
 false
 gap> S := FullTransformationMonoid(3);;
-gap> IsDecomposableSemigroup(S);
+gap> IsSurjectiveSemigroup(S);
 true
 
 # SEMIGROUPS_UnbindVariables


### PR DESCRIPTION
In my viva, Nik Ruskuc pointed out that decomposable is not a good name for a semigroup `S` that satisfies `S^2 = S`. Instead, he suggested `surjective' as a better name (along with several others). It makes sense because a semigroup satisfies S^2 = S if its multiplication is surjective. This is the name that I have moved to in my PhD thesis.

Since `IsDecomposableSemigroup` was never included in a released version of the package, there should be no problems with renaming it.