### PR TITLE
Add CanonicalMatrix and CanonicalRees(Zero)MatrixSemigroup

### DIFF
--- a/doc/isorms.xml
+++ b/doc/isorms.xml
@@ -267,39 +267,6 @@ gap> ImagesElm(map, RMSElement(R, 1, (2, 8), 2));
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="ReesZeroMatrixSemigroupCanonicalLabelling">
-  <ManSection>
-    <Attr Name = "ReesZeroMatrixSemigroupCanonicalLabelling"
-      Label = "for a Rees zero matrix semigroup" Arg = "S"/>
-    <Returns>
-      A matrix with entries from a group or 0.
-    </Returns>
-
-    <Description>
-      If <A>S</A> is a Rees zero matrix group then
-      <C>ReesZeroMatrixSemigroupCanonicalLabelling</C> returns a matrix <C>M</C>
-      with entries in <C>G</C> - the <Ref Attr="IsUnderlyingSemigroup"/>
-      of <A>S</A>, such that the Rees zero matrix semigroup defined by
-      <C>ReesZeroMatrixSemigroup(G, M)</C> is isomorphic to <A>S</A>. Furthermore
-      the output <C>M</C> is canonical in the sense that for any two inputs
-      which are isomorphic Rees zero matrix semigroups the output of this function
-      is the same. <P/>
-
-      <Example><![CDATA[
-gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3),
-> [[(), (1, 3, 2)], [(), ()]]);;
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(S);
-[ [ (), () ], [ (), (1,2,3) ] ]
-gap> T := ReesZeroMatrixSemigroup(SymmetricGroup(3),
-> [[(1, 2, 3), ()], [(), ()]]);;
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(T);
-[ [ (), () ], [ (), (1,2,3) ] ]
-gap> IsIsomorphicSemigroup(S, T);
-true]]></Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc>
-
 <#GAPDoc Label="CanonicalReesZeroMatrixSemigroup">
   <ManSection>
     <Attr Name = "CanonicalReesZeroMatrixSemigroup" 
@@ -310,10 +277,17 @@ true]]></Example>
     </Returns>
 
     <Description>
-      This returns the Rees (zero) matrix semigroup <C>T</C> which has the same 
-      <Ref Attr="UnderlyingSemigroup"/> as <A>S</A> but the <Ref Attr="Matrix"/>
-      of <C>T</C> is the <Ref Filt="ReesZeroMatrixSemigroupCanonicalLabelling"/>
-      of <A>S</A>.
+      If <A>S</A> is a Rees 0-matrix semigroup then 
+      <C>CanonicalReesZeroMatrixSemigroup</C> returns an isomorphic Rees
+      0-matrix semigroup <C>T</C> with the same
+      <Ref Attr="IsUnderlyingSemigroup"/> as <A>S</A> but the
+      <Ref Attr="Matrix"/> of <C>T</C> has been canonicalized. The output
+      <C>T</C> is canonical in the sense that for any two inputs
+      which are isomorphic Rees zero matrix semigroups the output of this
+      function is the same.<P/>
+      CanonicalReesMatrixSemigroup works the same but for Rees matrix
+      semigroups.
+
       <Example><![CDATA[
 gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3),
 > [[(), (1, 3, 2)], [(), ()]]);;
@@ -322,8 +296,6 @@ gap> T := CanonicalReesZeroMatrixSemigroup(S);
 gap> Matrix(S);
 [ [ (), (1,3,2) ], [ (), () ] ]
 gap> Matrix(T);
-[ [ (), () ], [ (), (1,2,3) ] ]
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(S);
 [ [ (), () ], [ (), (1,2,3) ] ]]]></Example>
     </Description>
   </ManSection>

--- a/doc/isorms.xml
+++ b/doc/isorms.xml
@@ -266,3 +266,74 @@ gap> ImagesElm(map, RMSElement(R, 1, (2, 8), 2));
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="CanonicalMatrix">
+  <ManSection>
+    <Oper Name = "CanonicalMatrix" Label = "for a list and a group" Arg = "mat, G"/>
+    <Attr Name = "CanonicalMatrix" Label = "for a Rees zero matrix semigroup"
+      Arg = "S"/>
+    <Attr Name = "CanonicalMatrix" Label = "for a Rees matrix semigroup"
+      Arg = "S"/>
+
+    <Returns>
+      A matrix with entries from <A>G</A> or 0.
+    </Returns>
+
+    <Description>
+      If <A>G</A> is a group and <A>mat</A> is a matrix with entries in
+      <A>G</A> or 0 then <C>CanonicalMatrix</C> returns a matrix <C>M</C> with
+      entries in <A>G</A> such that the Rees zero matrix semigroup defined by
+      <C>ReesZeroMatrixSemigroup(<A>G</A>, M)</C> is isomorphic to
+      <C>ReesZeroMatrixSemigroup(<A>G</A>, <A>mat</A>)</C>. Furthermore the
+      output <C>M</C>is canonical in the sense that for any two <A>mat</A> which
+      define isomorphic Rees zero matrix semigroups the output of this function
+      is the same. <P/>
+
+      If there is only one argument <A>S</A> which is a Rees zero matrix
+      semigroup or a Rees matrix semigroup then this function returns
+      <C>CanonicalMatrix(Matrix(<A>S</A>), UnderlyingSemigroup(<A>S</A>))</C>.
+
+      <Example><![CDATA[
+gap> S := ReesMatrixSemigroup(SymmetricGroup(3), [[(), (1, 3, 2)], [(), ()]]);;
+gap> CanonicalMatrix(S);
+[ [ (), () ], [ (), (1,2,3) ] ]
+gap> T := ReesMatrixSemigroup(SymmetricGroup(3), [[(1, 2, 3), ()], [(), ()]]);;
+gap> CanonicalMatrix(T);
+[ [ (), () ], [ (), (1,2,3) ] ]
+gap> IsIsomorphicSemigroup(S, T);
+true
+gap> CanonicalMatrix([[(), ()], [(), (1, 2, 3)]]. SymmetricGroup(3));
+[ [ (), () ], [ (), (1,2,3) ] ]]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="CanonicalReesZeroMatrixSemigroup">
+  <ManSection>
+    <Attr Name = "CanonicalReesZeroMatrixSemigroup" 
+      Label = "for a Rees zero matrix semigroup" Arg = "S"/>
+    <Attr Name = "CanonicalReesMatrixSemigroup" 
+      Label = "for a Rees matrix semigroup" Arg = "S"/>
+
+    <Returns>
+      A Rees zero matrix semigroup.
+    </Returns>
+
+    <Description>
+      This returns the Rees (zero) matrix semigroup <C>T</C> which has the same 
+      <Ref Attr="IsUnderlyingSemigroup"/> as <A>S</A> but the
+      <Ref Attr="Matrix"/> of <C>T</C> is the <Ref Filt="CanonicalMatrix"/>
+      of <A>S</A>.
+      <Example><![CDATA[
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[(), (1, 3, 2)], [(), ()]]);;
+gap> T := CanonicalReesZeroMatrixSemigroup(S);
+<Rees 0-matrix semigroup 2x2 over Sym( [ 1 .. 3 ] )>
+gap> Matrix(S);
+[ [ (), (1,3,2) ], [ (), () ] ]
+gap> Matrix(T);
+[ [ (), () ], [ (), (1,2,3) ] ]
+gap> CanonicalMatrix(S);
+[ [ (), () ], [ (), (1,2,3) ] ]]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/isorms.xml
+++ b/doc/isorms.xml
@@ -285,7 +285,7 @@ gap> ImagesElm(map, RMSElement(R, 1, (2, 8), 2));
       <C>T</C> is canonical in the sense that for any two inputs
       which are isomorphic Rees zero matrix semigroups the output of this
       function is the same.<P/>
-      CanonicalReesMatrixSemigroup works the same but for Rees matrix
+      <Ref Attr="CanonicalReesMatrixSemigroup"/> works the same but for Rees matrix
       semigroups.
 
       <Example><![CDATA[

--- a/doc/isorms.xml
+++ b/doc/isorms.xml
@@ -269,8 +269,8 @@ gap> ImagesElm(map, RMSElement(R, 1, (2, 8), 2));
 
 <#GAPDoc Label="CanonicalReesZeroMatrixSemigroup">
   <ManSection>
-    <Attr Name = "CanonicalReesZeroMatrixSemigroup" 
-      Label = "for a Rees zero matrix semigroup" Arg = "S"/>
+    <Attr Name = "CanonicalReesZeroMatrixSemigroup" Arg = "S"/>
+    <Attr Name = "CanonicalReesMatrixSemigroup" Arg = "S"/>
 
     <Returns>
       A Rees zero matrix semigroup.
@@ -285,7 +285,7 @@ gap> ImagesElm(map, RMSElement(R, 1, (2, 8), 2));
       <C>T</C> is canonical in the sense that for any two inputs
       which are isomorphic Rees zero matrix semigroups the output of this
       function is the same.<P/>
-      <Ref Attr="CanonicalReesMatrixSemigroup"/> works the same but for Rees matrix
+      <C>CanonicalReesMatrixSemigroup</C> works the same but for Rees matrix
       semigroups.
 
       <Example><![CDATA[

--- a/doc/isorms.xml
+++ b/doc/isorms.xml
@@ -267,43 +267,55 @@ gap> ImagesElm(map, RMSElement(R, 1, (2, 8), 2));
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="CanonicalMatrix">
+<#GAPDoc Label="ReesZeroMatrixSemigroupCanonicalLabelling">
   <ManSection>
-    <Oper Name = "CanonicalMatrix" Label = "for a list and a group" Arg = "mat, G"/>
-    <Attr Name = "CanonicalMatrix" Label = "for a Rees zero matrix semigroup"
-      Arg = "S"/>
-    <Attr Name = "CanonicalMatrix" Label = "for a Rees matrix semigroup"
-      Arg = "S"/>
-
+    <Attr Name = "ReesZeroMatrixSemigroupCanonicalLabelling"
+      Label = "for a Rees zero matrix semigroup" Arg = "S"/>
     <Returns>
-      A matrix with entries from <A>G</A> or 0.
+      A matrix with entries from a group or 0.
     </Returns>
 
     <Description>
-      If <A>G</A> is a group and <A>mat</A> is a matrix with entries in
-      <A>G</A> or 0 then <C>CanonicalMatrix</C> returns a matrix <C>M</C> with
-      entries in <A>G</A> such that the Rees zero matrix semigroup defined by
-      <C>ReesZeroMatrixSemigroup(<A>G</A>, M)</C> is isomorphic to
-      <C>ReesZeroMatrixSemigroup(<A>G</A>, <A>mat</A>)</C>. Furthermore the
-      output <C>M</C>is canonical in the sense that for any two <A>mat</A> which
-      define isomorphic Rees zero matrix semigroups the output of this function
+      If <A>S</A> is a Rees zero matrix group then
+      <C>ReesZeroMatrixSemigroupCanonicalLabelling</C> returns a matrix <C>M</C>
+      with entries in <C>G</C> - the <Ref Attr="IsUnderlyingSemigroup"/>
+      of <A>S</A>, such that the Rees zero matrix semigroup defined by
+      <C>ReesZeroMatrixSemigroup(G, M)</C> is isomorphic to <A>S</A>. Furthermore
+      the output <C>M</C> is canonical in the sense that for any two inputs
+      which are isomorphic Rees zero matrix semigroups the output of this function
       is the same. <P/>
 
-      If there is only one argument <A>S</A> which is a Rees zero matrix
-      semigroup or a Rees matrix semigroup then this function returns
-      <C>CanonicalMatrix(Matrix(<A>S</A>), UnderlyingSemigroup(<A>S</A>))</C>.
-
       <Example><![CDATA[
-gap> S := ReesMatrixSemigroup(SymmetricGroup(3), [[(), (1, 3, 2)], [(), ()]]);;
-gap> CanonicalMatrix(S);
-[ [ (), () ], [ (), (1,2,3) ] ]
-gap> T := ReesMatrixSemigroup(SymmetricGroup(3), [[(1, 2, 3), ()], [(), ()]]);;
-gap> CanonicalMatrix(T);
+gap> S := ReesMatrixSemigroup(SymmetricGroup(3),
+> [[(), (1, 3, 2)], [(), ()]]);;
+gap> Print(S);
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(S);
+> [ [ (), () ], [ (), (1,2,3) ] ]
+gap> T := ReesMatrixSemigroup(SymmetricGroup(3),
+[[(1, 2, 3), ()], [(), ()]]);;
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(T);
 [ [ (), () ], [ (), (1,2,3) ] ]
 gap> IsIsomorphicSemigroup(S, T);
-true
-gap> CanonicalMatrix([[(), ()], [(), (1, 2, 3)]]. SymmetricGroup(3));
-[ [ (), () ], [ (), (1,2,3) ] ]]]></Example>
+true]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="OnReesZeroMatrixSemigroups">
+  <ManSection>
+    <Oper Name = "OnReesZeroMatrixSemigroups"
+      Label = "for a Rees zero matrix semigroup and a perm" Arg = "S, g"/>
+    <Returns>
+      A Rees zero matrix semigroup.
+    </Returns>
+
+    <Description>
+      If <A>S</A> is a Rees zero matrix group and <A>g</A> is a permutation
+      satisfying certain properties then <C>OnReesZeroMatrixSemigroups</C>
+      returns a Rees zero matrix semigroup <C>T</C> with the same 
+      <Ref Attr="IsUnderlyingSemigroup"/>.
+      <Example><![CDATA[
+]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -312,8 +324,6 @@ gap> CanonicalMatrix([[(), ()], [(), (1, 2, 3)]]. SymmetricGroup(3));
   <ManSection>
     <Attr Name = "CanonicalReesZeroMatrixSemigroup" 
       Label = "for a Rees zero matrix semigroup" Arg = "S"/>
-    <Attr Name = "CanonicalReesMatrixSemigroup" 
-      Label = "for a Rees matrix semigroup" Arg = "S"/>
 
     <Returns>
       A Rees zero matrix semigroup.
@@ -321,18 +331,19 @@ gap> CanonicalMatrix([[(), ()], [(), (1, 2, 3)]]. SymmetricGroup(3));
 
     <Description>
       This returns the Rees (zero) matrix semigroup <C>T</C> which has the same 
-      <Ref Attr="IsUnderlyingSemigroup"/> as <A>S</A> but the
-      <Ref Attr="Matrix"/> of <C>T</C> is the <Ref Filt="CanonicalMatrix"/>
+      <Ref Attr="UnderlyingSemigroup"/> as <A>S</A> but the <Ref Attr="Matrix"/>
+      of <C>T</C> is the <Ref Filt="ReesZeroMatrixSemigroupCanonicalLabelling"/>
       of <A>S</A>.
       <Example><![CDATA[
-gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3), [[(), (1, 3, 2)], [(), ()]]);;
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3),
+> [[(), (1, 3, 2)], [(), ()]]);;
 gap> T := CanonicalReesZeroMatrixSemigroup(S);
 <Rees 0-matrix semigroup 2x2 over Sym( [ 1 .. 3 ] )>
 gap> Matrix(S);
 [ [ (), (1,3,2) ], [ (), () ] ]
 gap> Matrix(T);
 [ [ (), () ], [ (), (1,2,3) ] ]
-gap> CanonicalMatrix(S);
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(S);
 [ [ (), () ], [ (), (1,2,3) ] ]]]></Example>
     </Description>
   </ManSection>

--- a/doc/isorms.xml
+++ b/doc/isorms.xml
@@ -286,36 +286,16 @@ gap> ImagesElm(map, RMSElement(R, 1, (2, 8), 2));
       is the same. <P/>
 
       <Example><![CDATA[
-gap> S := ReesMatrixSemigroup(SymmetricGroup(3),
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup(3),
 > [[(), (1, 3, 2)], [(), ()]]);;
-gap> Print(S);
 gap> ReesZeroMatrixSemigroupCanonicalLabelling(S);
-> [ [ (), () ], [ (), (1,2,3) ] ]
-gap> T := ReesMatrixSemigroup(SymmetricGroup(3),
-[[(1, 2, 3), ()], [(), ()]]);;
+[ [ (), () ], [ (), (1,2,3) ] ]
+gap> T := ReesZeroMatrixSemigroup(SymmetricGroup(3),
+> [[(1, 2, 3), ()], [(), ()]]);;
 gap> ReesZeroMatrixSemigroupCanonicalLabelling(T);
 [ [ (), () ], [ (), (1,2,3) ] ]
 gap> IsIsomorphicSemigroup(S, T);
 true]]></Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc>
-
-<#GAPDoc Label="OnReesZeroMatrixSemigroups">
-  <ManSection>
-    <Oper Name = "OnReesZeroMatrixSemigroups"
-      Label = "for a Rees zero matrix semigroup and a perm" Arg = "S, g"/>
-    <Returns>
-      A Rees zero matrix semigroup.
-    </Returns>
-
-    <Description>
-      If <A>S</A> is a Rees zero matrix group and <A>g</A> is a permutation
-      satisfying certain properties then <C>OnReesZeroMatrixSemigroups</C>
-      returns a Rees zero matrix semigroup <C>T</C> with the same 
-      <Ref Attr="IsUnderlyingSemigroup"/>.
-      <Example><![CDATA[
-]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/z-chap18.xml
+++ b/doc/z-chap18.xml
@@ -51,7 +51,6 @@
     <#Include Label = "ImagesElm">
     <#Include Label = "ReesZeroMatrixSemigroupCanonicalLabelling">
     <#Include Label = "CanonicalReesZeroMatrixSemigroup">
-    <#Include Label = "OnReesZeroMatrixSemigroups">
 
     <!--********************************************************************-->
 

--- a/doc/z-chap18.xml
+++ b/doc/z-chap18.xml
@@ -49,7 +49,6 @@
     <#Include Label = "ELM_LIST">
     <#Include Label = "CompositionMapping2">
     <#Include Label = "ImagesElm">
-    <#Include Label = "ReesZeroMatrixSemigroupCanonicalLabelling">
     <#Include Label = "CanonicalReesZeroMatrixSemigroup">
 
     <!--********************************************************************-->

--- a/doc/z-chap18.xml
+++ b/doc/z-chap18.xml
@@ -49,6 +49,9 @@
     <#Include Label = "ELM_LIST">
     <#Include Label = "CompositionMapping2">
     <#Include Label = "ImagesElm">
+    <#Include Label = "ReesZeroMatrixSemigroupCanonicalLabelling">
+    <#Include Label = "CanonicalReesZeroMatrixSemigroup">
+    <#Include Label = "OnReesZeroMatrixSemigroups">
 
     <!--********************************************************************-->
 

--- a/gap/attributes/isorms.gd
+++ b/gap/attributes/isorms.gd
@@ -40,7 +40,7 @@ DeclareAttribute("IsomorphismReesMatrixSemigroupOverPermGroup", IsSemigroup);
 DeclareAttribute("IsomorphismReesZeroMatrixSemigroupOverPermGroup",
                  IsSemigroup);
 
-DeclareAttribute("ReesZeroMatrixSemigroupCanonicalLabelling",
-                 IsReesZeroMatrixSemigroup);
 DeclareAttribute("CanonicalReesZeroMatrixSemigroup",
                  IsReesZeroMatrixSemigroup);
+DeclareAttribute("CanonicalReesMatrixSemigroup",
+                 IsReesMatrixSemigroup);

--- a/gap/attributes/isorms.gd
+++ b/gap/attributes/isorms.gd
@@ -42,7 +42,5 @@ DeclareAttribute("IsomorphismReesZeroMatrixSemigroupOverPermGroup",
 
 DeclareAttribute("ReesZeroMatrixSemigroupCanonicalLabelling",
                  IsReesZeroMatrixSemigroup);
-DeclareOperation("OnReesZeroMatrixSemigroups",
-                 [IsReesZeroMatrixSemigroup, IsPerm]);
 DeclareAttribute("CanonicalReesZeroMatrixSemigroup",
                  IsReesZeroMatrixSemigroup);

--- a/gap/attributes/isorms.gd
+++ b/gap/attributes/isorms.gd
@@ -40,10 +40,9 @@ DeclareAttribute("IsomorphismReesMatrixSemigroupOverPermGroup", IsSemigroup);
 DeclareAttribute("IsomorphismReesZeroMatrixSemigroupOverPermGroup",
                  IsSemigroup);
 
-DeclareOperation("CanonicalMatrix", [IsList, IsPermGroup]);
-DeclareAttribute("CanonicalMatrix", IsReesZeroMatrixSemigroup);
-DeclareAttribute("CanonicalMatrix", IsReesMatrixSemigroup);
+DeclareAttribute("ReesZeroMatrixSemigroupCanonicalLabelling",
+                 IsReesZeroMatrixSemigroup);
+DeclareOperation("OnReesZeroMatrixSemigroups",
+                 [IsReesZeroMatrixSemigroup, IsPerm]);
 DeclareAttribute("CanonicalReesZeroMatrixSemigroup",
                  IsReesZeroMatrixSemigroup);
-DeclareAttribute("CanonicalReesMatrixSemigroup",
-                 IsReesMatrixSemigroup);

--- a/gap/attributes/isorms.gd
+++ b/gap/attributes/isorms.gd
@@ -39,3 +39,11 @@ DeclareProperty("IsAutomorphismGroupOfRMSOrRZMS", IsGroup and IsFinite);
 DeclareAttribute("IsomorphismReesMatrixSemigroupOverPermGroup", IsSemigroup);
 DeclareAttribute("IsomorphismReesZeroMatrixSemigroupOverPermGroup",
                  IsSemigroup);
+
+DeclareOperation("CanonicalMatrix", [IsList, IsPermGroup]);
+DeclareAttribute("CanonicalMatrix", IsReesZeroMatrixSemigroup);
+DeclareAttribute("CanonicalMatrix", IsReesMatrixSemigroup);
+DeclareAttribute("CanonicalReesZeroMatrixSemigroup",
+                 IsReesZeroMatrixSemigroup);
+DeclareAttribute("CanonicalReesMatrixSemigroup",
+                 IsReesMatrixSemigroup);

--- a/gap/attributes/isorms.gi
+++ b/gap/attributes/isorms.gi
@@ -1275,3 +1275,202 @@ function(S)
              return RMSElement(S, x![1], func(x![2], invG), x![3]);
            end);
 end);
+
+# Go from a triple in I x J x {1 .. |G| + 1} to an integer in
+# [1 .. |I| * |J| * (|G| + 1)]. Inverse of Unflatten3DPoint.
+SEMIGROUPS.Flatten3DPoint := function(dimensions, point)
+  return (point[1] - 1) * dimensions[2] * dimensions[3] +
+    (point[2] - 1) * dimensions[3] + (point[3] - 1) + 1;
+end;
+
+# Go from an integer in [1 .. |I| * |J| * (|G| + 1)] to an element of
+# I x J x {1 .. |G| + 1}. Inverse of Flatten3DPoint.
+SEMIGROUPS.Unflatten3DPoint := function(dimensions, value)
+   local ret;
+   ret    := [];
+   value  := value - 1;
+   ret[3] := value mod dimensions[3] + 1;
+   value  := value - (ret[3] - 1);
+   value  := value / dimensions[3];
+   ret[2] := value mod dimensions[2] + 1;
+   value  := value - (ret[2] - 1);
+   ret[1] := value / dimensions[2] + 1;
+   return ret;
+end;
+
+# Unflatten the entries of a set representing a matrix over a 0-group and return
+# the corresponding matrix. Inverse of ZeroGroupMatrixToSet.
+SEMIGROUPS.SetToZeroGroupMatrix := function(set, nr_rows, nr_cols, G)
+  local 0G, mat, dim, point, x;
+  0G  := Concatenation([0], Enumerator(G));
+  mat := List([1 .. nr_rows], a -> EmptyPlist(nr_cols));
+  dim := [nr_rows, nr_cols, Size(G) + 1];
+  for x in set do
+    point                   := SEMIGROUPS.Unflatten3DPoint(dim, x);
+    mat[point[1]][point[2]] := 0G[point[3]];
+  od;
+  return mat;
+end;
+
+# Flatten the entries of a matrix over a 0-group and return as a set of
+# integers. Inverse of SetToZeroGroupMatrix.
+SEMIGROUPS.ZeroGroupMatrixToSet := function(mat, nr_rows, nr_cols, G)
+  local set, dim, i, j;
+  set := [];
+  dim := [nr_rows, nr_cols, Size(G) + 1];
+  for i in [1 .. nr_rows] do
+    for j in [1 .. nr_cols] do
+      if mat[i][j] = 0 then
+        Add(set, SEMIGROUPS.Flatten3DPoint(dim, [i, j, 1]));
+      else
+        Add(set,
+          SEMIGROUPS.Flatten3DPoint(dim, [i, j, 1 + Position(Enumerator(G),
+                                                             mat[i][j])]));
+      fi;
+    od;
+  od;
+  return set;
+end;
+
+# The representation of the group ((G \wr S_m) \times (G \wr S_n)) \rtimes
+# Aut(G) acting on [1 .. |I| * |J| * (|G| + 1)] where the integers correspond to
+# entries of a J x I matrix with entries from the 0-group G_0.
+SEMIGROUPS.RZMSMatrixIsomorphismGroup := function(nr_rows, nr_cols, G)
+  local ApplyPermWholeDimension, ApplyPermSingleAssignDimension, dim, S, rows,
+  cols, gens, elms, rmlt, grswaps, lmlt, gcswaps, auto;
+
+  ApplyPermWholeDimension := function(dimensions, dim, perm)
+    local map, point, i;
+      map := [];
+      for i in [1 .. Product(dimensions)] do
+        point      := SEMIGROUPS.Unflatten3DPoint(dimensions, i);
+        point[dim] := point[dim] ^ perm;
+        map[i]     := SEMIGROUPS.Flatten3DPoint(dimensions, point);
+      od;
+    return PermList(map);
+  end;
+
+  ApplyPermSingleAssignDimension  := function(dimensions, dim,
+                                              perm, fixdim, fixval)
+    local map, point, i;
+    map := [];
+    for i in [1 .. Product(dimensions)] do
+      point := SEMIGROUPS.Unflatten3DPoint(dimensions, i);
+      if point[fixdim] = fixval then
+        point[dim] := point[dim] ^ perm;
+      fi;
+      map[i] := SEMIGROUPS.Flatten3DPoint(dimensions, point);
+    od;
+    return PermList(map);
+  end;
+
+  dim := [nr_rows, nr_cols, Size(G) + 1];
+  # Row Swaps
+  S    := SymmetricGroup(nr_rows);
+  rows := List(GeneratorsOfGroup(S),
+               x -> ApplyPermWholeDimension(dim, 1, x));
+
+  # Col swaps
+  S    := SymmetricGroup(nr_cols);
+  cols := List(GeneratorsOfGroup(S),
+               x -> ApplyPermWholeDimension(dim, 2, x));
+
+  gens := GeneratorsOfGroup(G);
+  elms := ShallowCopy(Enumerator(G));
+
+  # Apply g to each row (left multiplication by inverse):
+  rmlt := List(gens, g -> PermList(Concatenation([1],
+          1 + List(elms, e -> Position(elms, g ^ -1 * e)))));
+  grswaps := List(rmlt, g -> ApplyPermSingleAssignDimension(dim, 3, g, 1, 1));
+
+  # Apply g to each col (right multiplication):
+  lmlt := List(gens, g -> PermList(Concatenation([1],
+          1 + List(elms, e -> Position(elms, e * g)))));
+  gcswaps := List(lmlt, g -> ApplyPermSingleAssignDimension(dim, 3, g, 2, 1));
+
+  # Automorphisms of G
+  S    := AutomorphismGroup(G);
+  auto := Filtered(GeneratorsOfGroup(S), x -> not IsInnerAutomorphism(x));
+  auto := List(auto, x -> List(Enumerator(G), a ->
+          Position(Enumerator(G), a ^ x)));
+  Apply(auto, a -> PermList(Concatenation([1], a + 1)));
+  auto := List(auto, x -> ApplyPermWholeDimension(dim, 3, x));
+
+  # The RZMS matrix isomorphism group
+  return Group(Flat([rows, cols, grswaps, gcswaps, auto]));
+end;
+
+InstallMethod(CanonicalMatrix,
+"for a list and a group",
+[IsList, IsPermGroup],
+function(M, G)
+  local m, n, setM, GG;
+  m := Length(M);
+  n := Length(M[1]);
+  if not ForAll(M{[2 .. m]}, row -> Length(row) = n) then
+    ErrorNoReturn("Semigroups: CanonicalMatrix: usage,\n",
+                  "the first argument must be a list of lists of identical ",
+                  "length,");
+  elif not ForAll(M, row -> ForAll(row, x -> x in G or x = 0)) then
+    ErrorNoReturn("Semigroups: CanonicalMatrix: usage,\n",
+                  "the first argument must be a list of lists containing only",
+                  " elements of the group (which is the second argument) ",
+                  "or zero,");
+  fi;
+  setM := SEMIGROUPS.ZeroGroupMatrixToSet(M, m, n, G);
+  GG   := SEMIGROUPS.RZMSMatrixIsomorphismGroup(m, n, G);
+  return SEMIGROUPS.SetToZeroGroupMatrix(SmallestImageSet(GG, setM), m, n, G);
+end);
+
+InstallMethod(CanonicalMatrix,
+"for a Rees zero matrix semigroup",
+[IsReesZeroMatrixSemigroup],
+function(S)
+  if not IsGroup(UnderlyingSemigroup(S)) then
+    ErrorNoReturn("Semigroups: CanonicalMatrix: usage,\n",
+                  "the argument must be a Rees zero matrix semigroup with ",
+                  "underlying semigroup which is a group,");
+  fi;
+  return CanonicalMatrix(Matrix(S), UnderlyingSemigroup(S));
+end);
+
+InstallMethod(CanonicalReesZeroMatrixSemigroup,
+"for a Rees zero matrix semigroup",
+[IsReesZeroMatrixSemigroup],
+function(S)
+  local G;
+  G := UnderlyingSemigroup(S);
+  if not IsGroup(G) then
+    ErrorNoReturn("Semigroups: CanonicalMatrix: usage,\n",
+                  "the argument must be a Rees zero matrix semigroup with ",
+                  "underlying semigroup which is a group,");
+  fi;
+  return ReesZeroMatrixSemigroup(G, CanonicalMatrix(Matrix(S), G));
+end);
+
+InstallMethod(CanonicalMatrix,
+"for a Rees matrix semigroup",
+[IsReesMatrixSemigroup],
+function(S)
+  if not IsGroup(UnderlyingSemigroup(S)) then
+    ErrorNoReturn("Semigroups: CanonicalMatrix: usage,\n",
+                  "the argument must be a Rees matrix semigroup with ",
+                  "underlying semigroup which is a group,");
+  fi;
+  return CanonicalMatrix(Matrix(S), UnderlyingSemigroup(S));
+end);
+
+# TODO: two RZMS created from canonical matrixes are not equal in GAP
+InstallMethod(CanonicalReesMatrixSemigroup,
+"for a Rees matrix semigroup",
+[IsReesMatrixSemigroup],
+function(S)
+  local G;
+  G := UnderlyingSemigroup(S);
+  if not IsGroup(G) then
+    ErrorNoReturn("Semigroups: CanonicalMatrix: usage,\n",
+                  "the argument must be a Rees matrix semigroup with ",
+                  "underlying semigroup which is a group,");
+  fi;
+  return ReesMatrixSemigroup(G, CanonicalMatrix(Matrix(S), G));
+end);

--- a/gap/attributes/isorms.gi
+++ b/gap/attributes/isorms.gi
@@ -1418,75 +1418,8 @@ function(S)
   n    := Length(M[1]);
   setM := ZeroGroupMatrixToSet(M, m, n, G);
   GG   := RZMSMatrixIsomorphismGroup(m, n, G);
-  return ReesZeroMatrixSemigroup(G, SetToZeroGroupMatrix(
-                                 SmallestImageSet(GG, setM), m, n, G));
-end);
-
-InstallMethod(OnReesZeroMatrixSemigroups,
-"for a Rees zero matrix semigroup and a perm",
-[IsReesZeroMatrixSemigroup, IsPerm],
-function(S, g)
-  local Flatten3DPoint, Unflatten3DPoint, SetToZeroGroupMatrix,
-  ZeroGroupMatrixToSet, G, M, m, n, setM;
-  Flatten3DPoint := function(dimensions, point)
-    return (point[1] - 1) * dimensions[2] * dimensions[3] +
-      (point[2] - 1) * dimensions[3] + (point[3] - 1) + 1;
-  end;
-
-  Unflatten3DPoint := function(dimensions, value)
-     local ret;
-     ret    := [];
-     value  := value - 1;
-     ret[3] := value mod dimensions[3] + 1;
-     value  := value - (ret[3] - 1);
-     value  := value / dimensions[3];
-     ret[2] := value mod dimensions[2] + 1;
-     value  := value - (ret[2] - 1);
-     ret[1] := value / dimensions[2] + 1;
-     return ret;
-  end;
-
-  SetToZeroGroupMatrix := function(set, nr_rows, nr_cols, G)
-    local 0G, mat, dim, point, x;
-    0G  := Concatenation([0], Enumerator(G));
-    mat := List([1 .. nr_rows], a -> EmptyPlist(nr_cols));
-    dim := [nr_rows, nr_cols, Size(G) + 1];
-    for x in set do
-      point                   := Unflatten3DPoint(dim, x);
-      mat[point[1]][point[2]] := 0G[point[3]];
-    od;
-    return mat;
-  end;
-
-  ZeroGroupMatrixToSet := function(mat, nr_rows, nr_cols, G)
-    local set, dim, i, j;
-    set := [];
-    dim := [nr_rows, nr_cols, Size(G) + 1];
-    for i in [1 .. nr_rows] do
-      for j in [1 .. nr_cols] do
-        if mat[i][j] = 0 then
-          Add(set, Flatten3DPoint(dim, [i, j, 1]));
-        else
-          Add(set,
-            Flatten3DPoint(dim, [i, j, 1 + Position(Enumerator(G),
-                                                               mat[i][j])]));
-        fi;
-      od;
-    od;
-    return set;
-  end;
-
-  G    := UnderlyingSemigroup(S);
-  if not IsGroup(UnderlyingSemigroup(S)) then
-    ErrorNoReturn("Semigroups: OnReesZeroMatrixSemigroups: usage,\n",
-                  "the first argument must be a Rees zero matrix semigroup ",
-                  "with underlying semigroup which is a group,");
-  fi;
-  M    := Matrix(S);
-  m    := Length(M);
-  n    := Length(M[1]);
-  setM := OnSets(ZeroGroupMatrixToSet(M, m, n, G), g);
-  return ReesZeroMatrixSemigroup(G, SetToZeroGroupMatrix(setM, m, n, G));
+  return Matrix(ReesZeroMatrixSemigroup(G, SetToZeroGroupMatrix(
+                CanonicalImage(GG, setM, OnSets), m, n, G)));
 end);
 
 InstallMethod(CanonicalReesZeroMatrixSemigroup,

--- a/gap/attributes/isorms.gi
+++ b/gap/attributes/isorms.gi
@@ -1276,8 +1276,8 @@ function(S)
            end);
 end);
 
-InstallMethod(ReesZeroMatrixSemigroupCanonicalLabelling,
-"for a Rees zero matrix semigroup and a perm",
+InstallMethod(CanonicalReesZeroMatrixSemigroup,
+"for a Rees zero matrix semigroup",
 [IsReesZeroMatrixSemigroup],
 function(S)
   local Flatten3DPoint, Unflatten3DPoint, SetToZeroGroupMatrix,
@@ -1409,7 +1409,7 @@ function(S)
   M    := Matrix(S);
   G    := UnderlyingSemigroup(S);
   if not IsGroup(UnderlyingSemigroup(S)) then
-    ErrorNoReturn("Semigroups: ReesZeroMatrixSemigroupCanonicalLabelling: ",
+    ErrorNoReturn("Semigroups: CanonicalReesZeroMatrixSemigroup: ",
                   "usage,\n",
                   "the argument must be a Rees zero matrix semigroup with ",
                   "underlying semigroup which is a group,");
@@ -1418,21 +1418,22 @@ function(S)
   n    := Length(M[1]);
   setM := ZeroGroupMatrixToSet(M, m, n, G);
   GG   := RZMSMatrixIsomorphismGroup(m, n, G);
-  return Matrix(ReesZeroMatrixSemigroup(G, SetToZeroGroupMatrix(
-                CanonicalImage(GG, setM, OnSets), m, n, G)));
+  return ReesZeroMatrixSemigroup(G, SetToZeroGroupMatrix(
+                                 CanonicalImage(GG, setM, OnSets), m, n, G));
 end);
 
-InstallMethod(CanonicalReesZeroMatrixSemigroup,
+InstallMethod(CanonicalReesMatrixSemigroup,
 "for a Rees zero matrix semigroup",
-[IsReesZeroMatrixSemigroup],
+[IsReesMatrixSemigroup],
 function(S)
-  local G;
-  G := UnderlyingSemigroup(S);
+  local G, mat;
+  G   := UnderlyingSemigroup(S);
   if not IsGroup(G) then
-    ErrorNoReturn("Semigroups: CanonicalReesZeroMatrixSemigroup: usage,\n",
-                  "the argument must be a Rees zero matrix semigroup with ",
+    ErrorNoReturn("Semigroups: CanonicalReesMatrixSemigroup: usage,\n",
+                  "the argument must be a Rees matrix semigroup with ",
                   "underlying semigroup which is a group,");
   fi;
-  return ReesZeroMatrixSemigroup(G,
-    ReesZeroMatrixSemigroupCanonicalLabelling(S));
+  mat := Matrix(CanonicalReesZeroMatrixSemigroup(
+           ReesZeroMatrixSemigroup(G, Matrix(S))));
+  return ReesMatrixSemigroup(G, mat);
 end);

--- a/tst/standard/isorms.tst
+++ b/tst/standard/isorms.tst
@@ -966,7 +966,7 @@ true
 gap> BruteForceInverseCheck(iso);
 true
 
-# ReesZeroMatrixSemigroupCanonicalLabelling and CanonicalReesZeroMatrixSemigroup
+# CanonicalReesZeroMatrixSemigroup
 gap> S := ReesZeroMatrixSemigroup(SymmetricGroup([1 .. 4]),
 > [[(), (2, 3), (2, 3, 4)], [(1, 2)(3, 4), (), (1, 2, 4, 3)],
 > [(1, 4, 2), (1, 3)(2, 4), ()]]);;
@@ -975,9 +975,9 @@ gap> T := ReesZeroMatrixSemigroup(SymmetricGroup([1 .. 4]),
 > [(), (1, 3)(2, 4), (1, 3, 4, 2)]]);;
 gap> mat := [[(), (), ()], [(1, 4), (), (2, 4)],
 > [(), (1, 3), (1, 4, 3, 2)]];;
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(S) = mat;
+gap> Matrix(CanonicalReesZeroMatrixSemigroup(S)) = mat;
 true
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(T) = mat;
+gap> Matrix(CanonicalReesZeroMatrixSemigroup(T)) = mat;
 true
 gap> S := ReesZeroMatrixSemigroup(Group(
 > [(1, 2, 3), (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
@@ -1029,7 +1029,7 @@ gap> mat := [[0, (), (), ()],
 > 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40,
 > 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21,
 > 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5)]];;
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(S) = mat;
+gap> Matrix(CanonicalReesZeroMatrixSemigroup(S)) = mat;
 true
 gap> S := ReesZeroMatrixSemigroup(Group([(1, 2, 3, 4)]), [[(), (1, 2, 3, 4), 
 > (1, 2, 3, 4), (1, 3)(2, 4), 0], [0, (), (1, 2, 3, 4), (), ()], [0, (), (), (1,
@@ -1038,7 +1038,7 @@ gap> S := ReesZeroMatrixSemigroup(Group([(1, 2, 3, 4)]), [[(), (1, 2, 3, 4),
 gap> mat := [[(), 0, 0, (), ()], [0, (), (), (1, 4, 3, 2), (1, 2, 3, 4)],
 > [(), (), (1, 2, 3, 4), (), 0], [(1, 3)(2, 4), 0, (), (), ()],
 > [(), 0, (1, 3)(2, 4), (1, 2, 3, 4), (1, 4, 3, 2)]];;
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(S) = mat;
+gap> Matrix(CanonicalReesZeroMatrixSemigroup(S)) = mat;
 true
 gap> T := CanonicalReesZeroMatrixSemigroup(S);;
 gap> mat = Matrix(T);
@@ -1048,33 +1048,35 @@ true
 gap> S := ReesZeroMatrixSemigroup(AlternatingGroup([1 .. 5]),
 > [[(), 0], [(1, 3, 4), (2, 4, 5)], [(1, 5, 2), (1, 5, 2, 4, 3)]]);;
 gap> mat := [[0, ()], [(), ()], [(), (1, 5, 4)]];;
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(S) = mat;
+gap> Matrix(CanonicalReesZeroMatrixSemigroup(S)) = mat;
 true
 gap> T := CanonicalReesZeroMatrixSemigroup(S);;
 gap> mat = Matrix(T);
 true
 gap> UnderlyingSemigroup(S) = UnderlyingSemigroup(T);
 true
-gap> S := ReesZeroMatrixSemigroup(Group([(1, 2), (3, 4)]), 
+
+# CanonicalReesMatrixSemigroup
+gap> S := ReesMatrixSemigroup(Group([(1, 2), (3, 4)]), 
 > [[(), (), (3, 4), (), ()], [(), (3, 4), (), (3, 4), (1, 2)], [(), (1, 2), (3,
 > 4), (), ()], [(1, 2)(3, 4), (3, 4), (), (), ()], [(), (1, 2), (1, 2)(3, 4),
 > (), ()]]);;
 gap> mat := [[(), (), (), (), ()], [(), (), (), (), (1, 2)],
 > [(), (), (), (1, 2), ()], [(), (3, 4), (1, 2)(3, 4), (), (1, 2)],
 > [(), (), (3, 4), (1, 2)(3, 4), (3, 4)]];;
-gap> mat = Matrix(CanonicalReesZeroMatrixSemigroup(S));
+gap> mat = Matrix(CanonicalReesMatrixSemigroup(S));
 true
-gap> mat = ReesZeroMatrixSemigroupCanonicalLabelling(S);
+gap> mat = Matrix(CanonicalReesMatrixSemigroup(S));
 true
-gap> S := ReesZeroMatrixSemigroup(AlternatingGroup([1 .. 5]),
+gap> S := ReesMatrixSemigroup(AlternatingGroup([1 .. 5]),
 > [[(), (), (1, 5, 4, 2, 3)], [(1, 5, 4), (1, 3, 2, 5, 4), ()], [(), (), (1, 2,
 > 3, 4, 5)], [(), (), ()]]);;
 gap> mat :=
 > [[(), (), ()], [(), (), (1, 4)(2, 5)], [(), (), (1, 3, 5, 4, 2)],
 > [(), (1, 3, 4), (1, 3, 5)]];;
-gap> mat = Matrix(CanonicalReesZeroMatrixSemigroup(S));
+gap> mat = Matrix(CanonicalReesMatrixSemigroup(S));
 true
-gap> mat = ReesZeroMatrixSemigroupCanonicalLabelling(S);
+gap> mat = Matrix(CanonicalReesMatrixSemigroup(S));
 true
 
 # CanonicalX error messages
@@ -1083,14 +1085,15 @@ gap> mat := [[IdentityTransformation, IdentityTransformation,
 > IdentityTransformation], [IdentityTransformation, IdentityTransformation,
 > Transformation([2, 1])]];;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
-gap> ReesZeroMatrixSemigroupCanonicalLabelling(S);
-Error, Semigroups: ReesZeroMatrixSemigroupCanonicalLabelling: usage,
-the argument must be a Rees zero matrix semigroup with underlying semigroup wh\
-ich is a group,
 gap> CanonicalReesZeroMatrixSemigroup(S);
 Error, Semigroups: CanonicalReesZeroMatrixSemigroup: usage,
 the argument must be a Rees zero matrix semigroup with underlying semigroup wh\
 ich is a group,
+gap> S := ReesMatrixSemigroup(G, mat);;
+gap> CanonicalReesMatrixSemigroup(S);
+Error, Semigroups: CanonicalReesMatrixSemigroup: usage,
+the argument must be a Rees matrix semigroup with underlying semigroup which i\
+s a group,
 
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(A);

--- a/tst/standard/isorms.tst
+++ b/tst/standard/isorms.tst
@@ -966,6 +966,159 @@ true
 gap> BruteForceInverseCheck(iso);
 true
 
+# CanonicalMatrix and CanonicalReesZeroMatrixSemigroup
+gap> S := ReesZeroMatrixSemigroup(SymmetricGroup([1 .. 4]),
+> [[(), (2, 3), (2, 3, 4)], [(1, 2)(3, 4), (), (1, 2, 4, 3)],
+> [(1, 4, 2), (1, 3)(2, 4), ()]]);;
+gap> T := ReesZeroMatrixSemigroup(SymmetricGroup([1 .. 4]), 
+> [[(1, 2, 4, 3), (2, 4, 3), (1, 4)(2, 3)], [(1, 4), (), (1, 3)],
+> [(), (1, 3)(2, 4), (1, 3, 4, 2)]]);;
+gap> mat := [[(), (), ()], [(), (1, 4), (1, 2, 4)], 
+> [(), (1, 3, 4, 2), (1, 4, 3, 2)]];;
+gap> CanonicalMatrix(S) = mat;
+true
+gap> CanonicalMatrix(T) = mat;
+true
+gap> S := ReesZeroMatrixSemigroup(Group(
+> [(1, 2, 3), (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+> 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+> 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+> 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78,
+> 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
+> 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113,
+> 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128,
+> 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142)]), [[(),
+> (1, 2, 3)(4, 69, 134, 60, 125, 51, 116, 42, 107, 33, 98, 24, 89, 15, 80, 6,
+> 71, 136, 62, 127, 53, 118, 44, 109, 35, 100, 26, 91, 17, 82, 8, 73, 138, 64,
+> 129, 55, 120, 46, 111, 37, 102, 28, 93, 19, 84, 10, 75, 140, 66, 131, 57, 122,
+> 48, 113, 39, 104, 30, 95, 21, 86, 12, 77, 142, 68, 133, 59, 124, 50, 115, 41,
+> 106, 32, 97, 23, 88, 14, 79, 5, 70, 135, 61, 126, 52, 117, 43, 108, 34, 99,
+> 25, 90, 16, 81, 7, 72, 137, 63, 128, 54, 119, 45, 110, 36, 101, 27, 92, 18,
+> 83, 9, 74, 139, 65, 130, 56, 121, 47, 112, 38, 103, 29, 94, 20, 85, 11, 76,
+> 141, 67, 132, 58, 123, 49, 114, 40, 105, 31, 96, 22, 87, 13, 78), (), ()],
+> [(1, 3, 2)(4, 106, 69, 32, 134, 97, 60, 23, 125, 88, 51, 14, 116, 79, 42, 5,
+> 107, 70, 33, 135, 98, 61, 24, 126, 89, 52, 15, 117, 80, 43, 6, 108, 71, 34,
+> 136, 99, 62, 25, 127, 90, 53, 16, 118, 81, 44, 7, 109, 72, 35, 137, 100, 63,
+> 26, 128, 91, 54, 17, 119, 82, 45, 8, 110, 73, 36, 138, 101, 64, 27, 129, 92,
+> 55, 18, 120, 83, 46, 9, 111, 74, 37, 139, 102, 65, 28, 130, 93, 56, 19, 121,
+> 84, 47, 10, 112, 75, 38, 140, 103, 66, 29, 131, 94, 57, 20, 122, 85, 48, 11,
+> 113, 76, 39, 141, 104, 67, 30, 132, 95, 58, 21, 123, 86, 49, 12, 114, 77, 40,
+> 142, 105, 68, 31, 133, 96, 59, 22, 124, 87, 50, 13, 115, 78, 41), (), (4, 64,
+> 124, 45, 105, 26, 86, 7, 67, 127, 48, 108, 29, 89, 10, 70, 130, 51, 111, 32,
+> 92, 13, 73, 133, 54, 114, 35, 95, 16, 76, 136, 57, 117, 38, 98, 19, 79, 139,
+> 60, 120, 41, 101, 22, 82, 142, 63, 123, 44, 104, 25, 85, 6, 66, 126, 47, 107,
+> 28, 88, 9, 69, 129, 50, 110, 31, 91, 12, 72, 132, 53, 113, 34, 94, 15, 75,
+> 135, 56, 116, 37, 97, 18, 78, 138, 59, 119, 40, 100, 21, 81, 141, 62, 122, 43,
+> 103, 24, 84, 5, 65, 125, 46, 106, 27, 87, 8, 68, 128, 49, 109, 30, 90, 11, 71,
+> 131, 52, 112, 33, 93, 14, 74, 134, 55, 115, 36, 96, 17, 77, 137, 58, 118, 39,
+> 99, 20, 80, 140, 61, 121, 42, 102, 23, 83), 0]]);;
+gap> mat := [[0, (), (), ()], 
+> [(), (), (4, 142, 141, 140, 139, 138, 137, 136, 135, 134, 133, 132, 131, 130,
+> 129, 128, 127, 126, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116, 115,
+> 114, 113, 112, 111, 110, 109, 108, 107, 106, 105, 104, 103, 102, 101, 100, 99,
+> 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80,
+> 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61,
+> 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42,
+> 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23,
+> 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5), (1, 2,
+> 3)(4, 74, 5, 75, 6, 76, 7, 77, 8, 78, 9, 79, 10, 80, 11, 81, 12, 82, 13, 83,
+> 14, 84, 15, 85, 16, 86, 17, 87, 18, 88, 19, 89, 20, 90, 21, 91, 22, 92, 23,
+> 93, 24, 94, 25, 95, 26, 96, 27, 97, 28, 98, 29, 99, 30, 100, 31, 101, 32, 102,
+> 33, 103, 34, 104, 35, 105, 36, 106, 37, 107, 38, 108, 39, 109, 40, 110, 41,
+> 111, 42, 112, 43, 113, 44, 114, 45, 115, 46, 116, 47, 117, 48, 118, 49, 119,
+> 50, 120, 51, 121, 52, 122, 53, 123, 54, 124, 55, 125, 56, 126, 57, 127, 58,
+> 128, 59, 129, 60, 130, 61, 131, 62, 132, 63, 133, 64, 134, 65, 135, 66, 136,
+> 67, 137, 68, 138, 69, 139, 70, 140, 71, 141, 72, 142, 73)]];;
+gap> CanonicalMatrix(S) = mat;
+true
+gap> S := ReesZeroMatrixSemigroup(Group([(1, 2, 3, 4)]), [[(), (1, 2, 3, 4), 
+> (1, 2, 3, 4), (1, 3)(2, 4), 0], [0, (), (1, 2, 3, 4), (), ()], [0, (), (), (1,
+> 2, 3, 4), ()], [(1, 4, 3, 2), (1, 4, 3, 2), 0, (), (1, 3)(2, 4)], [0, 0, (1,
+> 4, 3, 2), (1, 3)(2, 4), ()]]);;
+gap> mat := [[0, 0, (), (), ()], [0, (), (), (), (1, 3)(2, 4)], 
+> [0, (), (1, 4, 3, 2), (1, 2, 3, 4), (1, 3)(2, 4)], [(), (), 0, (1, 2, 3, 4),
+> (1, 2, 3, 4)], [(), (1, 2, 3, 4), (), (1, 3)(2, 4), 0]];;
+gap> CanonicalMatrix(S) = mat;
+true
+gap> mat = CanonicalMatrix(mat, Group((1, 2, 3, 4)));
+true
+gap> T := CanonicalReesZeroMatrixSemigroup(S);;
+gap> mat = Matrix(T);
+true
+gap> UnderlyingSemigroup(S) = UnderlyingSemigroup(T);
+true
+gap> S := ReesZeroMatrixSemigroup(AlternatingGroup([1 .. 5]),
+> [[(), 0], [(1, 3, 4), (2, 4, 5)], [(1, 5, 2), (1, 5, 2, 4, 3)]]);;
+gap> mat := [[0, ()], [(), ()], [(), (1, 5, 4)]];;
+gap> CanonicalMatrix(S) = mat;
+true
+gap> T := CanonicalReesZeroMatrixSemigroup(S);;
+gap> mat = Matrix(T);
+true
+gap> UnderlyingSemigroup(S) = UnderlyingSemigroup(T);
+true
+
+# CanonicalMatrix and CanonicalReesMatrixSemigroup
+gap> S := ReesMatrixSemigroup(Group([(1, 2), (3, 4)]), 
+> [[(), (), (3, 4), (), ()], [(), (3, 4), (), (3, 4), (1, 2)], [(), (1, 2), (3,
+> 4), (), ()], [(1, 2)(3, 4), (3, 4), (), (), ()], [(), (1, 2), (1, 2)(3, 4),
+> (), ()]]);;
+gap> mat := [[(), (), (), (), ()], [(), (), (), (), (1, 2)], 
+> [(), (), (), (1, 2), ()], [(), (), (3, 4), (3, 4), (1, 2)(3, 4)], [(), (3, 4),
+> (1, 2), (1, 2)(3, 4), (3, 4)]];;
+gap> mat = Matrix(CanonicalReesMatrixSemigroup(S));
+true
+gap> mat = CanonicalMatrix(S);
+true
+gap> mat = CanonicalMatrix(mat, Group((1, 2), (3, 4)));
+true
+gap> S := ReesMatrixSemigroup(AlternatingGroup([1 .. 5]),
+> [[(), (), (1, 5, 4, 2, 3)], [(1, 5, 4), (1, 3, 2, 5, 4), ()], [(), (), (1, 2,
+> 3, 4, 5)], [(), (), ()]]);;
+gap> mat :=
+> [[(), (), ()], [(), (), (1, 5)(2, 4)], [(), (), (1, 4, 5, 2, 3)], [(), 
+> (2, 4, 3), (1, 5, 4)]];;
+gap> mat = Matrix(CanonicalReesMatrixSemigroup(S));
+true
+gap> mat = CanonicalMatrix(S);
+true
+gap> mat = CanonicalMatrix(mat, AlternatingGroup(5));
+true
+
+# CanonicalX error messages
+gap> G := Semigroup([Transformation([2, 1])]);;
+gap> mat := [[IdentityTransformation, IdentityTransformation,
+> IdentityTransformation], [IdentityTransformation, IdentityTransformation,
+> Transformation([2, 1])]];;
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> CanonicalMatrix(mat, G);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CanonicalMatrix' on 2 arguments
+gap> CanonicalMatrix(S);
+Error, Semigroups: CanonicalMatrix: usage,
+the argument must be a Rees zero matrix semigroup with underlying semigroup wh\
+ich is a group,
+gap> CanonicalReesZeroMatrixSemigroup(S);
+Error, Semigroups: CanonicalMatrix: usage,
+the argument must be a Rees zero matrix semigroup with underlying semigroup wh\
+ich is a group,
+gap> S := ReesMatrixSemigroup(G, mat);;
+gap> CanonicalMatrix(S);
+Error, Semigroups: CanonicalMatrix: usage,
+the argument must be a Rees matrix semigroup with underlying semigroup which i\
+s a group,
+gap> CanonicalReesMatrixSemigroup(S);
+Error, Semigroups: CanonicalMatrix: usage,
+the argument must be a Rees matrix semigroup with underlying semigroup which i\
+s a group,
+gap> CanonicalMatrix([[(1, 2, 3)]], Group(()));
+Error, Semigroups: CanonicalMatrix: usage,
+the first argument must be a list of lists containing only elements of the gro\
+up (which is the second argument) or zero,
+gap> CanonicalMatrix([[(), ()], [(1, 2)]], Group((1, 2)));
+Error, Semigroups: CanonicalMatrix: usage,
+the first argument must be a list of lists of identical length,
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(A);
 gap> Unbind(BruteForceInverseCheck);

--- a/tst/standard/isorms.tst
+++ b/tst/standard/isorms.tst
@@ -966,18 +966,18 @@ true
 gap> BruteForceInverseCheck(iso);
 true
 
-# CanonicalMatrix and CanonicalReesZeroMatrixSemigroup
+# ReesZeroMatrixSemigroupCanonicalLabelling and CanonicalReesZeroMatrixSemigroup
 gap> S := ReesZeroMatrixSemigroup(SymmetricGroup([1 .. 4]),
 > [[(), (2, 3), (2, 3, 4)], [(1, 2)(3, 4), (), (1, 2, 4, 3)],
 > [(1, 4, 2), (1, 3)(2, 4), ()]]);;
 gap> T := ReesZeroMatrixSemigroup(SymmetricGroup([1 .. 4]), 
 > [[(1, 2, 4, 3), (2, 4, 3), (1, 4)(2, 3)], [(1, 4), (), (1, 3)],
 > [(), (1, 3)(2, 4), (1, 3, 4, 2)]]);;
-gap> mat := [[(), (), ()], [(), (1, 4), (1, 2, 4)], 
-> [(), (1, 3, 4, 2), (1, 4, 3, 2)]];;
-gap> CanonicalMatrix(S) = mat;
+gap> mat := [[(), (), ()], [(1, 4), (), (2, 4)],
+> [(), (1, 3), (1, 4, 3, 2)]];;
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(S) = mat;
 true
-gap> CanonicalMatrix(T) = mat;
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(T) = mat;
 true
 gap> S := ReesZeroMatrixSemigroup(Group(
 > [(1, 2, 3), (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
@@ -1012,35 +1012,33 @@ gap> S := ReesZeroMatrixSemigroup(Group(
 > 103, 24, 84, 5, 65, 125, 46, 106, 27, 87, 8, 68, 128, 49, 109, 30, 90, 11, 71,
 > 131, 52, 112, 33, 93, 14, 74, 134, 55, 115, 36, 96, 17, 77, 137, 58, 118, 39,
 > 99, 20, 80, 140, 61, 121, 42, 102, 23, 83), 0]]);;
-gap> mat := [[0, (), (), ()], 
-> [(), (), (4, 142, 141, 140, 139, 138, 137, 136, 135, 134, 133, 132, 131, 130,
-> 129, 128, 127, 126, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116, 115,
-> 114, 113, 112, 111, 110, 109, 108, 107, 106, 105, 104, 103, 102, 101, 100, 99,
-> 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80,
-> 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61,
-> 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42,
-> 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23,
-> 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5), (1, 2,
-> 3)(4, 74, 5, 75, 6, 76, 7, 77, 8, 78, 9, 79, 10, 80, 11, 81, 12, 82, 13, 83,
-> 14, 84, 15, 85, 16, 86, 17, 87, 18, 88, 19, 89, 20, 90, 21, 91, 22, 92, 23,
-> 93, 24, 94, 25, 95, 26, 96, 27, 97, 28, 98, 29, 99, 30, 100, 31, 101, 32, 102,
-> 33, 103, 34, 104, 35, 105, 36, 106, 37, 107, 38, 108, 39, 109, 40, 110, 41,
-> 111, 42, 112, 43, 113, 44, 114, 45, 115, 46, 116, 47, 117, 48, 118, 49, 119,
-> 50, 120, 51, 121, 52, 122, 53, 123, 54, 124, 55, 125, 56, 126, 57, 127, 58,
-> 128, 59, 129, 60, 130, 61, 131, 62, 132, 63, 133, 64, 134, 65, 135, 66, 136,
-> 67, 137, 68, 138, 69, 139, 70, 140, 71, 141, 72, 142, 73)]];;
-gap> CanonicalMatrix(S) = mat;
+gap> mat := [[0, (), (), ()],
+> [(),  (),  (4, 96, 49, 141, 94, 47, 139, 92, 45, 137, 90, 43, 135, 88, 41,
+> 133, 86, 39, 131, 84, 37, 129, 82, 35, 127, 80, 33, 125, 78, 31, 123, 76, 29,
+> 121, 74, 27, 119, 72, 25, 117, 70, 23, 115, 68, 21, 113, 66, 19, 111, 64, 17,
+> 109, 62, 15, 107, 60, 13, 105, 58, 11, 103, 56, 9, 101, 54, 7, 99, 52, 5, 97,
+> 50, 142, 95, 48, 140, 93, 46, 138, 91, 44, 136, 89, 42, 134, 87, 40, 132, 85,
+> 38, 130, 83, 36, 128, 81, 34, 126, 79, 32, 124, 77, 30, 122, 75, 28, 120, 73,
+> 26, 118, 71, 24, 116, 69, 22, 114, 67, 20, 112, 65, 18, 110, 63, 16, 108, 61,
+> 14, 106, 59, 12, 104, 57, 10, 102, 55, 8, 100, 53, 6, 98, 51), (1, 2, 3)(4,
+> 142, 141, 140, 139, 138, 137, 136, 135, 134, 133, 132, 131, 130, 129, 128,
+> 127, 126, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116, 115, 114, 113,
+> 112, 111, 110, 109, 108, 107, 106, 105, 104, 103, 102, 101, 100, 99, 98, 97,
+> 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80, 79, 78,
+> 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60, 59,
+> 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40,
+> 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21,
+> 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5)]];;
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(S) = mat;
 true
 gap> S := ReesZeroMatrixSemigroup(Group([(1, 2, 3, 4)]), [[(), (1, 2, 3, 4), 
 > (1, 2, 3, 4), (1, 3)(2, 4), 0], [0, (), (1, 2, 3, 4), (), ()], [0, (), (), (1,
 > 2, 3, 4), ()], [(1, 4, 3, 2), (1, 4, 3, 2), 0, (), (1, 3)(2, 4)], [0, 0, (1,
 > 4, 3, 2), (1, 3)(2, 4), ()]]);;
-gap> mat := [[0, 0, (), (), ()], [0, (), (), (), (1, 3)(2, 4)], 
-> [0, (), (1, 4, 3, 2), (1, 2, 3, 4), (1, 3)(2, 4)], [(), (), 0, (1, 2, 3, 4),
-> (1, 2, 3, 4)], [(), (1, 2, 3, 4), (), (1, 3)(2, 4), 0]];;
-gap> CanonicalMatrix(S) = mat;
-true
-gap> mat = CanonicalMatrix(mat, Group((1, 2, 3, 4)));
+gap> mat := [[(), 0, 0, (), ()], [0, (), (), (1, 4, 3, 2), (1, 2, 3, 4)],
+> [(), (), (1, 2, 3, 4), (), 0], [(1, 3)(2, 4), 0, (), (), ()],
+> [(), 0, (1, 3)(2, 4), (1, 2, 3, 4), (1, 4, 3, 2)]];;
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(S) = mat;
 true
 gap> T := CanonicalReesZeroMatrixSemigroup(S);;
 gap> mat = Matrix(T);
@@ -1050,39 +1048,33 @@ true
 gap> S := ReesZeroMatrixSemigroup(AlternatingGroup([1 .. 5]),
 > [[(), 0], [(1, 3, 4), (2, 4, 5)], [(1, 5, 2), (1, 5, 2, 4, 3)]]);;
 gap> mat := [[0, ()], [(), ()], [(), (1, 5, 4)]];;
-gap> CanonicalMatrix(S) = mat;
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(S) = mat;
 true
 gap> T := CanonicalReesZeroMatrixSemigroup(S);;
 gap> mat = Matrix(T);
 true
 gap> UnderlyingSemigroup(S) = UnderlyingSemigroup(T);
 true
-
-# CanonicalMatrix and CanonicalReesMatrixSemigroup
-gap> S := ReesMatrixSemigroup(Group([(1, 2), (3, 4)]), 
+gap> S := ReesZeroMatrixSemigroup(Group([(1, 2), (3, 4)]), 
 > [[(), (), (3, 4), (), ()], [(), (3, 4), (), (3, 4), (1, 2)], [(), (1, 2), (3,
 > 4), (), ()], [(1, 2)(3, 4), (3, 4), (), (), ()], [(), (1, 2), (1, 2)(3, 4),
 > (), ()]]);;
-gap> mat := [[(), (), (), (), ()], [(), (), (), (), (1, 2)], 
-> [(), (), (), (1, 2), ()], [(), (), (3, 4), (3, 4), (1, 2)(3, 4)], [(), (3, 4),
-> (1, 2), (1, 2)(3, 4), (3, 4)]];;
-gap> mat = Matrix(CanonicalReesMatrixSemigroup(S));
+gap> mat := [[(), (), (), (), ()], [(), (), (), (), (1, 2)],
+> [(), (), (), (1, 2), ()], [(), (3, 4), (1, 2)(3, 4), (), (1, 2)],
+> [(), (), (3, 4), (1, 2)(3, 4), (3, 4)]];;
+gap> mat = Matrix(CanonicalReesZeroMatrixSemigroup(S));
 true
-gap> mat = CanonicalMatrix(S);
+gap> mat = ReesZeroMatrixSemigroupCanonicalLabelling(S);
 true
-gap> mat = CanonicalMatrix(mat, Group((1, 2), (3, 4)));
-true
-gap> S := ReesMatrixSemigroup(AlternatingGroup([1 .. 5]),
+gap> S := ReesZeroMatrixSemigroup(AlternatingGroup([1 .. 5]),
 > [[(), (), (1, 5, 4, 2, 3)], [(1, 5, 4), (1, 3, 2, 5, 4), ()], [(), (), (1, 2,
 > 3, 4, 5)], [(), (), ()]]);;
 gap> mat :=
-> [[(), (), ()], [(), (), (1, 5)(2, 4)], [(), (), (1, 4, 5, 2, 3)], [(), 
-> (2, 4, 3), (1, 5, 4)]];;
-gap> mat = Matrix(CanonicalReesMatrixSemigroup(S));
+> [[(), (), ()], [(), (), (1, 4)(2, 5)], [(), (), (1, 3, 5, 4, 2)],
+> [(), (1, 3, 4), (1, 3, 5)]];;
+gap> mat = Matrix(CanonicalReesZeroMatrixSemigroup(S));
 true
-gap> mat = CanonicalMatrix(S);
-true
-gap> mat = CanonicalMatrix(mat, AlternatingGroup(5));
+gap> mat = ReesZeroMatrixSemigroupCanonicalLabelling(S);
 true
 
 # CanonicalX error messages
@@ -1091,33 +1083,14 @@ gap> mat := [[IdentityTransformation, IdentityTransformation,
 > IdentityTransformation], [IdentityTransformation, IdentityTransformation,
 > Transformation([2, 1])]];;
 gap> S := ReesZeroMatrixSemigroup(G, mat);;
-gap> CanonicalMatrix(mat, G);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CanonicalMatrix' on 2 arguments
-gap> CanonicalMatrix(S);
-Error, Semigroups: CanonicalMatrix: usage,
+gap> ReesZeroMatrixSemigroupCanonicalLabelling(S);
+Error, Semigroups: ReesZeroMatrixSemigroupCanonicalLabelling: usage,
 the argument must be a Rees zero matrix semigroup with underlying semigroup wh\
 ich is a group,
 gap> CanonicalReesZeroMatrixSemigroup(S);
-Error, Semigroups: CanonicalMatrix: usage,
+Error, Semigroups: CanonicalReesZeroMatrixSemigroup: usage,
 the argument must be a Rees zero matrix semigroup with underlying semigroup wh\
 ich is a group,
-gap> S := ReesMatrixSemigroup(G, mat);;
-gap> CanonicalMatrix(S);
-Error, Semigroups: CanonicalMatrix: usage,
-the argument must be a Rees matrix semigroup with underlying semigroup which i\
-s a group,
-gap> CanonicalReesMatrixSemigroup(S);
-Error, Semigroups: CanonicalMatrix: usage,
-the argument must be a Rees matrix semigroup with underlying semigroup which i\
-s a group,
-gap> CanonicalMatrix([[(1, 2, 3)]], Group(()));
-Error, Semigroups: CanonicalMatrix: usage,
-the first argument must be a list of lists containing only elements of the gro\
-up (which is the second argument) or zero,
-gap> CanonicalMatrix([[(), ()], [(1, 2)]], Group((1, 2)));
-Error, Semigroups: CanonicalMatrix: usage,
-the first argument must be a list of lists of identical length,
 
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(A);


### PR DESCRIPTION
This adds a few attributes for Rees (zero) matrix semigroups. Given a Rees (zero) matrix semigroup `S` the function `CanonicalMatrix` returns a matrix over `UnderlyingSemigroup(S)` which defines a Rees (zero) matrix semigroup isomorphic to `S`. This matrix is canonical in the sense that given any two isomorphic Rees (zero) matrix semigroups the function `CanonicalMatrix` will return the same matrix. `CanonicalRees(Zero)MatrixSemigroup(S)` simply returns `Rees(Zero)MatrixSemigroup(CanonicalMatrix(S), UnderlyingSemigroup(S))`.

The idea behind the method is that two Rees zero matrix semigroups M_0[G;{1 .. m}, {1 .. n};P] and M_0[G;{1 .. m}, {1 .. n};Q] are isomorphic if and only if they lie in the same orbit of the set of all m x n matrices over G_0 with respect to the group action of permuting rows and columns, multiplying rows and columns by group elements and applying automorphisms of G_0 to all entries simultaneously. By constructing this action we can take a matrix and use `SmallestImageSet` to find a canonical representative of its orbit in the space of all these matrices.