### PR TITLE
Fix GeneratorsOfSemigroup immediate method for partial perm groups

### DIFF
--- a/gap/semigroups/semipperm.gi
+++ b/gap/semigroups/semipperm.gi
@@ -94,7 +94,15 @@ end);
 
 InstallImmediateMethod(GeneratorsOfSemigroup,
 IsPartialPermSemigroup and IsGroup and HasGeneratorsOfGroup,
-0, GeneratorsOfGroup);
+0,
+function(G)
+  if IsEmpty(GeneratorsOfGroup(G)) then
+    # WW: really this should be `return [One(G)];`, but this fails when running
+    #     GAP's `tst/testinstall.g` for some reason that I can't figure out.
+    TryNextMethod();
+  fi;
+  return GeneratorsOfGroup(G);
+end);
 
 InstallMethod(RankOfPartialPermSemigroup,
 "for a partial perm semigroup",

--- a/tst/standard/semipperm.tst
+++ b/tst/standard/semipperm.tst
@@ -2143,6 +2143,13 @@ gap> y := Iterator(S);
 <iterator>
 gap> for x in y do od;
 
+#T# GeneratorsOfGroup
+gap> S := Group([], PartialPerm([1, 2]));;
+gap> GeneratorsOfGroup(S);
+[  ]
+gap> GeneratorsOfSemigroup(S);
+[ <identity partial perm on [ 1, 2 ]> ]
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(F);
 gap> Unbind(H1);


### PR DESCRIPTION
If a group of partial permutations was created without any `GeneratorsOfGroup`, eg by `S := Group([], PartialPerm([1, 2]));;`, then the `GeneratorsOfSemigroup` immediate method would return `[]`, which is incorrect.

This is what is currently causing the Travis tests to fail on `stable-3.1` and `master`.