### PR TITLE
The empty semigroup is not monogenic

### DIFF
--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -777,7 +777,7 @@ function(S)
   gens := GeneratorsOfSemigroup(S);
   if Length(gens) <= 1 then
     SetMinimalSemigroupGeneratingSet(S, gens);
-    return true;
+    return Length(gens) = 1;
   elif CanEasilyCompareElements(gens)
       and ForAll([2 .. Length(gens)], i -> gens[1] = gens[i]) then
     SetMinimalSemigroupGeneratingSet(S, [gens[1]]);

--- a/tst/standard/properties.tst
+++ b/tst/standard/properties.tst
@@ -945,6 +945,11 @@ gap> x := MinimalSemigroupGeneratingSet(S)[1];;
 gap> S := Semigroup(x, x, x);;
 gap> IsMonogenicSemigroup(S);
 true
+gap> S := Subsemigroup(FullTransformationMonoid(2), []);;
+gap> IsEmpty(S);
+true
+gap> IsMonogenicSemigroup(S);
+false
 
 # properties: IsMonogenicInverseSemigroup, 1
 gap> IsMonogenicInverseSemigroup(AsSemigroup(IsBooleanMatSemigroup,


### PR DESCRIPTION
Currently, an empty semigroup is set to be monogenic by an immediate method. But I don't think that it should count as monogenic: its rank isn't 1, and there exists no element inside the empty semigroup that generates the empty semigroup.

I know that we normally avoid empty semigroups, and for certain properties it's probably not very clear whether the empty semigroup has that property. But here I think it's clear so we may as well fix it.