### PR TITLE
semigroups: operator \<

### DIFF
--- a/gap/semigroups/semibipart.gi
+++ b/gap/semigroups/semibipart.gi
@@ -614,3 +614,12 @@ end);
 
 InstallMethod(DegreeOfBipartitionSemigroup, "for a bipartition semigroup",
 [IsBipartitionSemigroup], S -> DegreeOfBipartition(Representative(S)));
+
+InstallMethod(\<, "for bipartition semigroups",
+[IsBipartitionSemigroup, IsBipartitionSemigroup],
+function(S, T)
+  if DegreeOfBipartitionSemigroup(S) <> DegreeOfBipartitionSemigroup(T) then
+    return DegreeOfBipartitionSemigroup(S) < DegreeOfBipartitionSemigroup(T);
+  fi;
+  TryNextMethod();
+end);

--- a/gap/semigroups/semigrp.gi
+++ b/gap/semigroups/semigrp.gi
@@ -13,23 +13,25 @@
 ## whether they are acting or not, i.e. they should work for all semigroups.
 ## It is organized as follows:
 ##
-##   1. Helper functions
+##   1.  Helper functions
 ##
-##   2. Generators
+##   2.  Generators
 ##
-##   3. Semigroup/Monoid/InverseSemigroup/InverseMonoidByGenerators
+##   3.  Semigroup/Monoid/InverseSemigroup/InverseMonoidByGenerators
 ##
-##   4. RegularSemigroup
+##   4.  RegularSemigroup
 ##
-##   5. ClosureSemigroup/Monoid
+##   5.  ClosureSemigroup/Monoid
 ##
-##   6. ClosureInverseSemigroup/Monoid
+##   6.  ClosureInverseSemigroup/Monoid
 ##
-##   7. Subsemigroups
+##   7.  Subsemigroups
 ##
-##   8. Random semigroups and elements
+##   8.  Random semigroups and elements
 ##
-##   9. Changing representation: AsSemigroup, AsMonoid
+##   9.  Changing representation: AsSemigroup, AsMonoid
+##
+##   10. Operators
 ##
 #############################################################################
 
@@ -1354,4 +1356,36 @@ InstallMethod(AsMonoid, "for a filter, ring, and semigroup",
 [IsFunction and IsOperation, IsRing, IsSemigroup],
 function(filt, R, S)
   return Range(IsomorphismMonoid(filt, R, S));
+end);
+
+#############################################################################
+## 10. Operators
+#############################################################################
+
+InstallMethod(\<, "for semigroups in the same family", IsIdenticalObj,
+[IsSemigroup, IsSemigroup],
+function(S, T)
+  local SS, TT, s, t;
+
+  if not IsFinite(S) or not IsFinite(T) then
+    TryNextMethod();
+  fi;
+
+  SS := IteratorSorted(S);
+  TT := IteratorSorted(T);
+
+  while not (IsDoneIterator(SS) or IsDoneIterator(TT)) do
+    s := NextIterator(SS);
+    t := NextIterator(TT);
+    if s <> t then
+      return s < t;
+    fi;
+  od;
+
+  if IsDoneIterator(SS) and IsDoneIterator(TT) then
+    # This line is executed by the tests but does not show as such in the code
+    # coverage.
+    return false;  # S = T
+  fi;
+  return IsDoneIterator(SS);
 end);

--- a/gap/semigroups/semipbr.gi
+++ b/gap/semigroups/semipbr.gi
@@ -171,3 +171,12 @@ InstallMethod(IsomorphismMonoid,
 function(filter, S)
   return MagmaIsomorphismByFunctionsNC(S, S, IdFunc, IdFunc);
 end);
+
+InstallMethod(\<, "for pbr semigroups",
+[IsPBRSemigroup, IsPBRSemigroup],
+function(S, T)
+  if DegreeOfPBRSemigroup(S) <> DegreeOfPBRSemigroup(T) then
+    return DegreeOfPBRSemigroup(S) < DegreeOfPBRSemigroup(T);
+  fi;
+  TryNextMethod();
+end);

--- a/gap/semigroups/semipperm.gi
+++ b/gap/semigroups/semipperm.gi
@@ -958,3 +958,20 @@ function(S)
 
   return t;
 end);
+
+InstallMethod(\<, "for partial perm semigroups",
+[IsPartialPermSemigroup, IsPartialPermSemigroup],
+function(S, T)
+  if DegreeOfPartialPermSemigroup(S)
+      <> DegreeOfPartialPermSemigroup(T)
+      or CodegreeOfPartialPermSemigroup(S)
+      <> CodegreeOfPartialPermSemigroup(T) then
+    return DegreeOfPartialPermSemigroup(S)
+      < DegreeOfPartialPermSemigroup(T) or
+      (DegreeOfPartialPermSemigroup(S)
+       = DegreeOfPartialPermSemigroup(T)
+       and CodegreeOfPartialPermSemigroup(S)
+       < CodegreeOfPartialPermSemigroup(T));
+  fi;
+  TryNextMethod();
+end);

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -318,32 +318,12 @@ end);
 InstallMethod(\<, "for transformation semigroups",
 [IsTransformationSemigroup, IsTransformationSemigroup],
 function(S, T)
-  local des, det, SS, TT, s, t;
-
-  des := DegreeOfTransformationSemigroup(S);
-  det := DegreeOfTransformationSemigroup(T);
-
-  if des <> det then
-    return des < det;
+  if DegreeOfTransformationSemigroup(S)
+      <> DegreeOfTransformationSemigroup(T) then
+    return DegreeOfTransformationSemigroup(S)
+      < DegreeOfTransformationSemigroup(T);
   fi;
-
-  SS := IteratorSorted(S);
-  TT := IteratorSorted(T);
-
-  while not (IsDoneIterator(SS) or IsDoneIterator(TT)) do
-    s := NextIterator(SS);
-    t := NextIterator(TT);
-    if s <> t then
-      return s < t;
-    fi;
-  od;
-
-  if IsDoneIterator(SS) and IsDoneIterator(TT) then
-    # This line is executed by the tests but does not show as such in the code
-    # coverage.
-    return false;  # S = T
-  fi;
-  return IsDoneIterator(SS);
+  TryNextMethod();
 end);
 
 InstallMethod(SmallestElementSemigroup,

--- a/tst/standard/semibipart.tst
+++ b/tst/standard/semibipart.tst
@@ -2609,6 +2609,28 @@ gap> GeneratorsOfInverseMonoid(S);
 gap> InverseMonoid(last) = S;
 true
 
+# Operator < 
+gap> A := Semigroup(Bipartition([[1, 2], [-1], [-2]]),
+> Bipartition([[1, 2, -1, -2]]));
+<bipartition semigroup of degree 2 with 2 generators>
+gap> B := Semigroup([Bipartition([[1, 2, -2], [-1]]),
+>  Bipartition([[1, 2, -1], [-2]])]);
+<bipartition semigroup of degree 2 with 2 generators>
+gap> C := Monoid([Bipartition([[1, -1]])]);
+<trivial block bijection group of degree 1 with 1 generator>
+gap> A < B;
+true
+gap> B < A;
+false
+gap> B = A;
+false
+gap> C = A;
+false
+gap> C < A;
+true
+gap> C < B;
+true
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);

--- a/tst/standard/semipbr.tst
+++ b/tst/standard/semipbr.tst
@@ -2110,6 +2110,33 @@ gap> S := Semigroup([
 gap> AsMonoid(S);
 <pbr monoid of size 4, degree 4 with 2 generators>
 
+# Operator \<
+gap> A := Monoid([
+>   PBR([[]], [[1]]),
+>   PBR([[-1, 1]], [[1]]),
+>   PBR([[-1]], [[]]),
+>   PBR([[-1]], [[-1, 1]])]);;
+gap> B := Monoid([
+>  PBR([[]], [[]]),
+>  PBR([[1]], [[]]),
+>  PBR([[1]], [[-1]]),
+>  PBR([[-1, 1]], [[1]]),
+>  PBR([[-1]], [[]]),
+>  PBR([[-1]], [[-1, 1]]),
+>  PBR([[]], [[-1, 1]])]);;
+gap> A < B;
+true
+gap> B < A;
+false
+gap> A = B;
+false
+gap> C := Monoid([PBR([[-2, -1, 1, 2], [-1]], [[-1, 1, 2], [-1, 1]]),
+>  PBR([[-2, -1, 1, 2], [-2, -1, 1, 2]], [[-2, -1, 1, 2], [-2, 2]])]);;
+gap> C > A;
+true
+gap> C > B;
+true
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);

--- a/tst/standard/semipperm.tst
+++ b/tst/standard/semipperm.tst
@@ -2150,6 +2150,23 @@ gap> GeneratorsOfGroup(S);
 gap> GeneratorsOfSemigroup(S);
 [ <identity partial perm on [ 1, 2 ]> ]
 
+# Operator \<
+gap> S := Semigroup([
+>  PartialPerm([1, 2, 3, 5, 6, 7, 8], [9, 6, 11, 2, 3, 10, 4]),
+>  PartialPerm([1, 2, 3, 4, 5, 7, 10], [2, 6, 9, 3, 5, 10, 1]),
+>  PartialPerm([1, 3, 4, 5, 6, 8], [8, 9, 1, 10, 6, 11]),
+>  PartialPerm([1, 2, 3, 5, 6, 7, 8], [7, 3, 4, 5, 2, 11, 8]),
+>  PartialPerm([1, 2, 3, 4, 5, 6, 7], [1, 10, 8, 6, 4, 9, 5])]);;
+gap> S < S;
+false
+gap> T := SymmetricInverseMonoid(4);;
+gap> T < S;
+true
+gap> T > S;
+false
+gap> T = S;
+false
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(F);
 gap> Unbind(H1);


### PR DESCRIPTION
This commit adds a generic operator \< for semigroups, with special versions
for transformation semigroups, pbr semigroups, and bipartitions.