### PR TITLE
Conditionally install libsemigroups, and drop src/ prefix for its headers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libsemigroups"]
-	path = libsemigroups
-	url = https://github.com/james-d-mitchell/libsemigroups.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libsemigroups"]
+	path = libsemigroups
+	url = https://github.com/james-d-mitchell/libsemigroups.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,8 @@ ACLOCAL_AMFLAGS = -I m4
 
 if WITH_INCLUDED_LIBSEMIGROUPS
   SUBDIRS = libsemigroups
+  # the following triggers "make install" on libsemigroups
+  BUILT_SOURCES = bin/include/libsemigroups/blocks.h
 endif
 
 AM_CPPFLAGS = @LIBSEMIGROUPS_CFLAGS@
@@ -21,8 +23,8 @@ semigroups_la_SOURCES =  src/pkg.cc src/converter.cc src/bipart.cc
 semigroups_la_SOURCES += src/uf.cc src/fropin.cc src/congpairs.cc
 semigroups_la_SOURCES += src/semigrp.cc
 
-semigroups_la_CXXFLAGS = $(GAP_CFLAGS) -std=gnu++11 -O3 -g -march=native
-semigroups_la_CPPFLAGS = $(GAP_CPPFLAGS)
+semigroups_la_CXXFLAGS = $(GAP_CFLAGS) @LIBSEMIGROUPS_CFLAGS@ -std=gnu++11 -O3 -g -march=native
+semigroups_la_CPPFLAGS = $(GAP_CPPFLAGS)  @LIBSEMIGROUPS_CFLAGS@
 semigroups_la_CFLAGS = $(GAP_CFLAGS)
 semigroups_la_LDFLAGS = $(GAP_LDFLAGS) -module -avoid-version
 
@@ -31,6 +33,10 @@ semigroups_la_LIBADD = @LIBSEMIGROUPS_LIBS@
 if SYS_IS_CYGWIN
 semigroups_la_LDFLAGS += -no-undefined -version-info 0:0:0 -Wl,$(GAPROOT)/bin/$(GAPARCH)/gap.dll
 endif
+
+# the following is only run if BUILT_SOURCES is wound up
+bin/include/libsemigroups/blocks.h:
+	$(MAKE) -C libsemigroups install
 
 all-local: semigroups.la
 	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR) $(top_srcdir)/bin/lib

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,8 +6,11 @@
 #
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = libsemigroups
-AM_CPPFLAGS = -I$(srcdir)/libsemigroups
+if WITH_INCLUDED_LIBSEMIGROUPS
+  SUBDIRS = libsemigroups
+endif
+
+AM_CPPFLAGS = @LIBSEMIGROUPS_CFLAGS@
 
 BINARCHDIR = bin/$(GAPARCH)
 GAPINSTALLLIB = $(abs_top_srcdir)/$(BINARCHDIR)/semigroups.so
@@ -23,7 +26,7 @@ semigroups_la_CPPFLAGS = $(GAP_CPPFLAGS)
 semigroups_la_CFLAGS = $(GAP_CFLAGS)
 semigroups_la_LDFLAGS = $(GAP_LDFLAGS) -module -avoid-version
 
-semigroups_la_LIBADD = libsemigroups/libsemigroups.la
+semigroups_la_LIBADD = @LIBSEMIGROUPS_LIBS@
 
 if SYS_IS_CYGWIN
 semigroups_la_LDFLAGS += -no-undefined -version-info 0:0:0 -Wl,$(GAPROOT)/bin/$(GAPARCH)/gap.dll
@@ -31,7 +34,9 @@ endif
 
 all-local: semigroups.la
 	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR) $(top_srcdir)/bin/lib
+if WITH_INCLUDED_LIBSEMIGROUPS
 	cp -RL libsemigroups/.libs/* $(top_srcdir)/bin/lib/
+endif
 if SYS_IS_CYGWIN
 	cp .libs/semigroups.dll $(GAPINSTALLLIB)
 # Cygwin will only look in this directory for dlls

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,8 +6,8 @@
 #
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src/libsemigroups
-AM_CPPFLAGS = -I$(srcdir)/src/libsemigroups
+SUBDIRS = libsemigroups
+AM_CPPFLAGS = -I$(srcdir)/libsemigroups
 
 BINARCHDIR = bin/$(GAPARCH)
 GAPINSTALLLIB = $(abs_top_srcdir)/$(BINARCHDIR)/semigroups.so
@@ -23,7 +23,7 @@ semigroups_la_CPPFLAGS = $(GAP_CPPFLAGS)
 semigroups_la_CFLAGS = $(GAP_CFLAGS)
 semigroups_la_LDFLAGS = $(GAP_LDFLAGS) -module -avoid-version
 
-semigroups_la_LIBADD = src/libsemigroups/libsemigroups.la
+semigroups_la_LIBADD = libsemigroups/libsemigroups.la
 
 if SYS_IS_CYGWIN
 semigroups_la_LDFLAGS += -no-undefined -version-info 0:0:0 -Wl,$(GAPROOT)/bin/$(GAPARCH)/gap.dll
@@ -31,11 +31,11 @@ endif
 
 all-local: semigroups.la
 	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR) $(top_srcdir)/bin/lib
-	cp -RL src/libsemigroups/.libs/* $(top_srcdir)/bin/lib/
+	cp -RL libsemigroups/.libs/* $(top_srcdir)/bin/lib/
 if SYS_IS_CYGWIN
 	cp .libs/semigroups.dll $(GAPINSTALLLIB)
 # Cygwin will only look in this directory for dlls
-	cp src/libsemigroups/.libs/cygsemigroups-0.dll $(GAPROOT)/.libs
+	cp libsemigroups/.libs/cygsemigroups-0.dll $(GAPROOT)/.libs
 else
 	cp .libs/semigroups.so $(GAPINSTALLLIB)
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,8 @@ ACLOCAL_AMFLAGS = -I m4
 if WITH_INCLUDED_LIBSEMIGROUPS
   SUBDIRS = libsemigroups
   # the following triggers "make install" on libsemigroups
+  # note that making it a concrete file prevents this target
+  # to be needlessly re-run if libsemigroups/ is not changed.
   BUILT_SOURCES = bin/include/libsemigroups/blocks.h
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,13 +42,12 @@ bin/include/libsemigroups/blocks.h:
 
 all-local: semigroups.la
 	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR) $(top_srcdir)/bin/lib
-if WITH_INCLUDED_LIBSEMIGROUPS
-	cp -RL libsemigroups/.libs/* $(top_srcdir)/bin/lib/
-endif
 if SYS_IS_CYGWIN
 	cp .libs/semigroups.dll $(GAPINSTALLLIB)
+if WITH_INCLUDED_LIBSEMIGROUPS
 # Cygwin will only look in this directory for dlls
 	cp libsemigroups/.libs/cygsemigroups-0.dll $(GAPROOT)/.libs
+endif
 else
 	cp .libs/semigroups.so $(GAPINSTALLLIB)
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ bin/include/libsemigroups/blocks.h:
 	$(MAKE) -C libsemigroups install
 
 all-local: semigroups.la
-	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR) $(top_srcdir)/bin/lib
+	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR)
 if SYS_IS_CYGWIN
 	cp .libs/semigroups.dll $(GAPINSTALLLIB)
 if WITH_INCLUDED_LIBSEMIGROUPS

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AC_CONFIG_SRCDIR([src/pkg.cc])
 AC_CONFIG_HEADER([src/_pkgconfig.h:cnf/pkgconfig.h.in])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([cnf])
-AC_CONFIG_SUBDIRS([src/libsemigroups])
+AC_CONFIG_SUBDIRS([libsemigroups])
 
 dnl ##
 dnl ## Get canonical host info
@@ -31,9 +31,9 @@ AM_PROG_AR
 AX_PREFIX_CONFIG_H([src/semigroups-config.h],[],[src/_pkgconfig.h])
 
 dnl ## abs_top_builddir seems to hold the top build dir for the subpackage
-dnl ## src/libsemigroups which is why this contains ../.. 
+dnl ## libsemigroups which is why this contains ../ 
 dnl ## FIXME figure out how to do this properly
-AC_PREFIX_DEFAULT('${abs_top_builddir}/../../bin/')
+AC_PREFIX_DEFAULT('${abs_top_builddir}/../bin/')
 
 dnl ##
 dnl ## Set the language
@@ -76,22 +76,22 @@ fi
 
 dnl ## Check for libsemigroups
 AC_CHECK_FILE(
-   [src/libsemigroups/src/semigroups.h],
+   [libsemigroups/src/semigroups.h],
    [],
    [AC_MSG_ERROR([libsemigroups is required, clone or download the repo from
-    https://github.com/james-d-mitchell/libsemigroups into the src directory])]
+    https://github.com/james-d-mitchell/libsemigroups into this directory])]
    )
 
 dnl ## Check for a version of libsemigroups with VERSION file
 AC_CHECK_FILE(
-   [src/libsemigroups/VERSION],
+   [libsemigroups/VERSION],
    [],
    [AC_MSG_ERROR([libsemigroups version 0.6.1 or higher is required])]
    )
 
 AC_MSG_CHECKING([libsemigroups version])
 REQUI_LIBSEMIGROUPS_VERSION="$(cat .LIBSEMIGROUPS_VERSION)"
-FOUND_LIBSEMIGROUPS_VERSION="$(cat src/libsemigroups/VERSION)"
+FOUND_LIBSEMIGROUPS_VERSION="$(cat libsemigroups/VERSION)"
 AC_MSG_RESULT([$FOUND_LIBSEMIGROUPS_VERSION])
 AX_COMPARE_VERSION($FOUND_LIBSEMIGROUPS_VERSION, 
                    [ge], 

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,6 @@ AC_CONFIG_SRCDIR([src/pkg.cc])
 AC_CONFIG_HEADER([src/_pkgconfig.h:cnf/pkgconfig.h.in])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([cnf])
-AC_CONFIG_SUBDIRS([libsemigroups])
 
 dnl ##
 dnl ## Get canonical host info
@@ -75,30 +74,7 @@ else
 fi
 
 dnl ## Check for libsemigroups
-AC_CHECK_FILE(
-   [libsemigroups/src/semigroups.h],
-   [],
-   [AC_MSG_ERROR([libsemigroups is required, clone or download the repo from
-    https://github.com/james-d-mitchell/libsemigroups into this directory])]
-   )
-
-dnl ## Check for a version of libsemigroups with VERSION file
-AC_CHECK_FILE(
-   [libsemigroups/VERSION],
-   [],
-   [AC_MSG_ERROR([libsemigroups version 0.6.1 or higher is required])]
-   )
-
-AC_MSG_CHECKING([libsemigroups version])
-REQUI_LIBSEMIGROUPS_VERSION="$(cat .LIBSEMIGROUPS_VERSION)"
-FOUND_LIBSEMIGROUPS_VERSION="$(cat libsemigroups/VERSION)"
-AC_MSG_RESULT([$FOUND_LIBSEMIGROUPS_VERSION])
-AX_COMPARE_VERSION($FOUND_LIBSEMIGROUPS_VERSION, 
-                   [ge], 
-                   $REQUI_LIBSEMIGROUPS_VERSION,
-                   [], 
-                   [AC_MSG_ERROR([libsemigroups version $REQUI_LIBSEMIGROUPS_VERSION or higher is required])]
-                  )
+AX_CHECK_LIBSEMIGROUPS
 
 dnl ## User setting: Debug mode (off by default)
 AC_ARG_ENABLE([debug],

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -1,0 +1,52 @@
+dnl handle libsemigroups checks
+dnl
+dnl if --with-included-libsemigroups is supplied, always use the included version
+dnl otherwise, use an external version if it is known to pkg-config and is new enough
+dnl failing the latter, use the included version
+dnl
+AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
+  AC_ARG_WITH([included-libsemigroups],
+	      [AC_HELP_STRING([--with-included-libsemigroups],
+			      [use the libsemigroups included here])])
+  REQUI_LIBSEMIGROUPS_VERSION="$(cat .LIBSEMIGROUPS_VERSION)"
+  need_included_libsemigroups=yes
+  PKG_CHECK_MODULES([LIBSEMIGROUPS], [libsemigroups >= $REQUI_LIBSEMIGROUPS_VERSION], 
+  	[need_included_libsemigroups=no],
+  	[need_included_libsemigroups=yes])
+
+  if test "$need_included_libsemigroups" = yes; then
+     AC_MSG_NOTICE([Using included libsemigroups.])
+     if test "$with_included_libsemigroups" = no; then
+	with_included_libsemigroups=yes
+     fi
+  fi
+
+  if test "$with_included_libsemigroups" = yes;  then
+  	AC_CHECK_FILE(
+   		[libsemigroups/src/semigroups.h],
+   		[],
+   		[AC_MSG_ERROR([libsemigroups is required, clone or download the repo from
+    			https://github.com/james-d-mitchell/libsemigroups into this directory])])
+
+	AC_CHECK_FILE(
+   		[libsemigroups/VERSION],
+   		[],
+   		[AC_MSG_ERROR([libsemigroups version 0.6.1 or higher is required])])
+
+	AC_MSG_CHECKING([libsemigroups version])
+	FOUND_LIBSEMIGROUPS_VERSION="$(cat libsemigroups/VERSION)"
+	AC_MSG_RESULT([$FOUND_LIBSEMIGROUPS_VERSION])
+	AX_COMPARE_VERSION($FOUND_LIBSEMIGROUPS_VERSION,
+                   [ge],
+                   $REQUI_LIBSEMIGROUPS_VERSION,
+                   [],
+                   [AC_MSG_ERROR([libsemigroups version $REQUI_LIBSEMIGROUPS_VERSION or higher is required])]
+                  )
+	LIBSEMIGROUPS_CFLAGS = -I$(srcdir)/libsemigroups
+	LIBSEMIGROUPS_LIBS = libsemigroups/libsemigroups.la
+
+  fi
+  AC_CONFIG_SUBDIRS([libsemigroups])
+
+  AM_CONDITIONAL([WITH_INCLUDED_LIBSEMIGROUPS], [test "$with_included_libsemigroups" = yes])
+])

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -38,7 +38,7 @@ AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
                    [AC_MSG_ERROR([libsemigroups version $REQUI_LIBSEMIGROUPS_VERSION or higher is required])]
                   )
 	AC_SUBST(LIBSEMIGROUPS_CFLAGS, ['-I./bin/include'])
-	AC_SUBST(LIBSEMIGROUPS_LIBS, ['libsemigroups/libsemigroups.la'])
+	AC_SUBST(LIBSEMIGROUPS_LIBS, ['bin/lib/libsemigroups.la'])
   fi
   AC_CONFIG_SUBDIRS([libsemigroups])
 

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -14,14 +14,8 @@ AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
   	[need_included_libsemigroups=no],
   	[need_included_libsemigroups=yes])
 
-  if test "$need_included_libsemigroups" = yes; then
-     AC_MSG_NOTICE([Using included libsemigroups.])
-     if test "$with_included_libsemigroups" = no; then
-	with_included_libsemigroups=yes
-     fi
-  fi
-
-  if test "$with_included_libsemigroups" = yes;  then
+  if test "$with_included_libsemigroups" = yes -o "$need_included_libsemigroups" = yes;  then
+	AC_MSG_NOTICE([Using included libsemigroups.])
   	AC_CHECK_FILE(
    		[libsemigroups/src/semigroups.h],
    		[],
@@ -42,11 +36,10 @@ AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
                    [],
                    [AC_MSG_ERROR([libsemigroups version $REQUI_LIBSEMIGROUPS_VERSION or higher is required])]
                   )
-	LIBSEMIGROUPS_CFLAGS = -I$(srcdir)/libsemigroups
-	LIBSEMIGROUPS_LIBS = libsemigroups/libsemigroups.la
-
+	AC_SUBST(LIBSEMIGROUPS_CFLAGS, ['-Ilibsemigroups'])
+	AC_SUBST(LIBSEMIGROUPS_LIBS, ['libsemigroups/libsemigroups.la'])
   fi
   AC_CONFIG_SUBDIRS([libsemigroups])
 
-  AM_CONDITIONAL([WITH_INCLUDED_LIBSEMIGROUPS], [test "$with_included_libsemigroups" = yes])
+  AM_CONDITIONAL([WITH_INCLUDED_LIBSEMIGROUPS], [test "$with_included_libsemigroups" = yes -o "$need_included_libsemigroups" = yes])
 ])

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -25,7 +25,7 @@ AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
 	AC_CHECK_FILE(
    		[libsemigroups/VERSION],
    		[],
-   		[AC_MSG_ERROR([libsemigroups version 0.6.1 or higher is required])])
+		[AC_MSG_ERROR([libsemigroups version $REQUI_LIBSEMIGROUPS_VERSION or higher is required])])
 
 	AC_MSG_CHECKING([libsemigroups version])
 	FOUND_LIBSEMIGROUPS_VERSION="$(cat libsemigroups/VERSION)"

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -1,20 +1,21 @@
 dnl handle libsemigroups checks
 dnl
-dnl if --with-included-libsemigroups is supplied, always use the included version
-dnl otherwise, use an external version if it is known to pkg-config and is new enough
-dnl failing the latter, use the included version
+dnl if --with-external-libsemigroups is supplied,
+dnl use it if it is known to pkg-config and is new enough;
+dnl otherwise use the included version
 dnl
 AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
-  AC_ARG_WITH([included-libsemigroups],
-	      [AC_HELP_STRING([--with-included-libsemigroups],
-			      [use the libsemigroups included here])])
+  AC_ARG_WITH([external-libsemigroups],
+	      [AC_HELP_STRING([--with-external-libsemigroups],
+			      [use the external libsemigroups])])
   REQUI_LIBSEMIGROUPS_VERSION="$(cat .LIBSEMIGROUPS_VERSION)"
   need_included_libsemigroups=yes
-  PKG_CHECK_MODULES([LIBSEMIGROUPS], [libsemigroups >= $REQUI_LIBSEMIGROUPS_VERSION], 
-  	[need_included_libsemigroups=no],
-  	[need_included_libsemigroups=yes])
-
-  if test "$with_included_libsemigroups" = yes -o "$need_included_libsemigroups" = yes;  then
+  if test "$with_external_libsemigroups" = yes;  then
+	PKG_CHECK_MODULES([LIBSEMIGROUPS], [libsemigroups >= $REQUI_LIBSEMIGROUPS_VERSION],
+	[need_included_libsemigroups=no],
+	[need_included_libsemigroups=yes])
+  fi
+  if test "$need_included_libsemigroups" = yes;  then
 	AC_MSG_NOTICE([Using included libsemigroups.])
   	AC_CHECK_FILE(
    		[libsemigroups/src/semigroups.h],
@@ -41,5 +42,5 @@ AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
   fi
   AC_CONFIG_SUBDIRS([libsemigroups])
 
-  AM_CONDITIONAL([WITH_INCLUDED_LIBSEMIGROUPS], [test "$with_included_libsemigroups" = yes -o "$need_included_libsemigroups" = yes])
+  AM_CONDITIONAL([WITH_INCLUDED_LIBSEMIGROUPS], [test "$need_included_libsemigroups" = yes])
 ])

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -36,7 +36,7 @@ AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
                    [],
                    [AC_MSG_ERROR([libsemigroups version $REQUI_LIBSEMIGROUPS_VERSION or higher is required])]
                   )
-	AC_SUBST(LIBSEMIGROUPS_CFLAGS, ['-Ilibsemigroups'])
+	AC_SUBST(LIBSEMIGROUPS_CFLAGS, ['-I./bin/include'])
 	AC_SUBST(LIBSEMIGROUPS_LIBS, ['libsemigroups/libsemigroups.la'])
   fi
   AC_CONFIG_SUBDIRS([libsemigroups])

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -1,7 +1,7 @@
 set -e
 
 SEMI_DIR=`dirname "$0"`
-LIBS_DIR="$SEMI_DIR/src/libsemigroups"
+LIBS_DIR="$SEMI_DIR/libsemigroups"
 
 # Get libsemigroups version from file
 if [ -f $SEMI_DIR/.LIBSEMIGROUPS_VERSION ]; then

--- a/src/bipart.cc
+++ b/src/bipart.cc
@@ -28,7 +28,7 @@
 #include <utility>
 #include <vector>
 
-#include "libsemigroups/src/semigroups.h"
+#include "libsemigroups/semigroups.h"
 #include "src/compiled.h"
 
 using libsemigroups::Element;

--- a/src/bipart.h
+++ b/src/bipart.h
@@ -19,7 +19,7 @@
 #ifndef SEMIGROUPS_SRC_BIPART_H_
 #define SEMIGROUPS_SRC_BIPART_H_
 
-#include "libsemigroups/src/elements.h"
+#include "libsemigroups/elements.h"
 #include "pkg.h"
 #include "semigroups-debug.h"
 #include "src/compiled.h"

--- a/src/congpairs.cc
+++ b/src/congpairs.cc
@@ -27,7 +27,7 @@
 #include "rnams.h"
 #include "semigrp.h"
 
-#include "libsemigroups/src/cong.h"
+#include "libsemigroups/cong.h"
 
 using libsemigroups::Congruence;
 using libsemigroups::Partition;

--- a/src/converter.h
+++ b/src/converter.h
@@ -40,7 +40,7 @@
 
 #include "semigroups-debug.h"
 
-#include "libsemigroups/src/elements.h"
+#include "libsemigroups/elements.h"
 
 using libsemigroups::Bipartition;
 using libsemigroups::BooleanMat;

--- a/src/fropin.cc
+++ b/src/fropin.cc
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <iostream>
 
-#include "libsemigroups/src/report.h"
+#include "libsemigroups/report.h"
 #include "rnams.h"
 #include "semigroups-debug.h"
 #include "semigrp.h"

--- a/src/pkg.cc
+++ b/src/pkg.cc
@@ -32,9 +32,9 @@
 #include "semigrp.h"
 #include "uf.h"
 
-#include "libsemigroups/src/cong.h"
-#include "libsemigroups/src/semigroups.h"
-#include "libsemigroups/src/uf.h"
+#include "libsemigroups/cong.h"
+#include "libsemigroups/semigroups.h"
+#include "libsemigroups/uf.h"
 
 using libsemigroups::Congruence;
 using libsemigroups::UF;

--- a/src/semigrp.h
+++ b/src/semigrp.h
@@ -22,7 +22,7 @@
 #define SEMIGROUPS_SRC_SEMIGRP_H_
 
 #include "converter.h"
-#include "libsemigroups/src/semigroups.h"
+#include "libsemigroups/semigroups.h"
 #include "pkg.h"
 #include "rnams.h"
 #include "src/compiled.h"  // GAP headers

--- a/src/uf.cc
+++ b/src/uf.cc
@@ -26,7 +26,7 @@
 #include "semigroups-debug.h"
 #include "src/compiled.h"
 
-#include "libsemigroups/src/uf.h"
+#include "libsemigroups/uf.h"
 
 using libsemigroups::UF;
 


### PR DESCRIPTION
conditionally install libsemigroups; nothing changes if there is no external libsemigroups
known to pkg-config and matching the version test; there is an extra option `--with-included-libsemigroups` to force the use of the included library (it is needed to `make dist`
including libsemigroups). The included libsemigroups will also be used if no external one is good enough.

Dealing with libsemigroups (version check, etc) is moved into m4/ subdir macro.

`src/` prefix is removed from for libsemigroups headers `#include`'s, and `src/libsemigroups` is moved one level up the directory tree. 