### PR TITLE
resolve issue #581: changes made to ActionRank

### DIFF
--- a/gap/main/setup.gi
+++ b/gap/main/setup.gi
@@ -247,11 +247,7 @@ end);
 InstallMethod(ActionRank, "for a McAlister triple semigroup element and int",
 [IsMcAlisterTripleSemigroupElement, IsInt],
 function(f, n)
-  local digraph, id;
-  digraph := McAlisterTripleSemigroupQuotientDigraph(MTSEParent(f));
-  digraph := DigraphReverse(digraph);
-  id      := McAlisterTripleSemigroupComponents(MTSEParent(f)).id;
-  return Position(DigraphTopologicalSort(digraph), id[f[1]]);
+  return f[1];
 end);
 
 InstallMethod(ActionRank, "for a McAlister triple subsemigroup",
@@ -781,7 +777,7 @@ InstallMethod(LambdaBound, "for a McAlister subsemigroup",
 function(r)
   local G;
   G := McAlisterTripleSemigroupGroup(MTSEParent(Representative(S)));
-  return Size(Stabilizer(G, r));
+  return Size(Stabilizer(G, r, McAlisterTripleSemigroupAction(S)));
 end);
 
 InstallMethod(RhoBound, "for a McAlister subsemigroup",

--- a/tst/standard/setup.tst
+++ b/tst/standard/setup.tst
@@ -549,16 +549,16 @@ gap> x(1);
 gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
 gap> x := LambdaRank(M);;
 gap> x(1);
-2
-gap> x(2);
 1
+gap> x(2);
+2
 gap> x(0);
 0
 gap> x := RhoRank(M);;
 gap> x(1);
-2
-gap> x(2);
 1
+gap> x(2);
+2
 gap> x(0);
 0
 
@@ -1074,7 +1074,7 @@ true
 
 # SchutzGpMembership, for an MTS
 gap> M := McAlisterTripleSemigroup(SymmetricGroup([2, 3, 4]), Digraph([[1], [1, 2], [1, 3], [1, 4]]), [1, 2, 3]);;
-gap> M := Semigroup(Elements(M));;
+gap> M := Semigroup(MTSE(M, 2, (2, 3)), MTSE(M, 3, (2, 3)));;
 gap> o := LambdaOrb(M);; Enumerate(o);;
 gap> schutz := LambdaOrbStabChain(o, 3);;
 gap> SchutzGpMembership(M)(schutz, ());


### PR DESCRIPTION
Fix to issue #581. `LambdaOrbSchutzGp` was giving the incorrect answer sometimes. The issue lay with the `LambdaBound` being smaller than the size of the schutz group. `LambdaBound` uses the method `ActionRank` (via `LambdaRank`) and the issue was there.