### PR TITLE
travis: configure with --with-external-libsemigroups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,25 @@ matrix:
       - PACKAGES=required
       - THRESHOLD=95
 
+    - env:
+      - SUITE=external-libsemigroups
+      - ABI=64
+      - GAP=stable-4.10
+      - PACKAGES=required
+      - SEMIGROUPS_PKG_EXTRA_FLAGS=--with-external-libsemigroups
+      - PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$HOME/miniconda2/lib/pkgconfig
+
+before_install:
+  - if [ "$SUITE" == "external-libsemigroups" ]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      chmod +x miniconda.sh;
+      ./miniconda.sh -b;
+      export PATH=/home/travis/miniconda2/bin:$PATH;
+      conda update --yes conda;
+      conda config --add channels conda-forge;
+      conda install --yes libsemigroups;
+    fi;
+
 install:
   # GAP and some packages require special flags for compilation in 32-bit mode
   - if [ "$ABI" == "32" ]; then

--- a/scripts/travis-build-semigroups.sh
+++ b/scripts/travis-build-semigroups.sh
@@ -7,6 +7,6 @@ if [ "$SUITE" != "lint" ]; then
   echo -e "\nCompiling the Semigroups package..."
   cd $GAPROOT/pkg/semigroups
   ./autogen.sh
-  ./configure $PKG_FLAGS
-  make
+  ./configure $PKG_FLAGS $SEMIGROUPS_PKG_EXTRA_FLAGS
+  make -j2
 fi

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -26,7 +26,7 @@ elif [ "$SUITE" == "coverage" ]; then
     fi
   done
 
-elif [ "$SUITE" == "test" ]; then
+else
 
   cd $SEMI_DIR/tst/workspaces
   echo -e "\nRunning SaveWorkspace tests..."


### PR DESCRIPTION
In this PR I add a travis test for when Semigroups is configured with the flag `--with-external-libsemigroups`. 