### PR TITLE
Re-factor SmallestIdempotentPower

### DIFF
--- a/gap/elements/elements.gi
+++ b/gap/elements/elements.gi
@@ -96,20 +96,21 @@ end);
 InstallMethod(SmallestIdempotentPower, "for a multiplicative element",
 [IsMultiplicativeElement],
 function(x)
-  local a, ind, per, pow;
+  local a, index, period, r;
 
   if not IsGeneratorsOfSemigroup([x]) then
     ErrorNoReturn("Semigroups: SmallestIdempotentPower: usage,\n",
                   "the argument <x> must be the generator of a semigroup,");
   fi;
   a := IndexPeriodOfSemigroupElement(x);
-  ind := a[1];
-  per := a[2];
-  pow := per;
-  while pow < ind do
-    pow := pow + per;
-  od;
-  return pow;
+  index := a[1];
+  period := a[2];
+  # From Howie 1995, page 11
+  r := index mod period;
+  if r = 0 then
+    return index;
+  fi;
+  return index + period - r;
 end);
 
 InstallMethod(IsMultiplicativeZero,

--- a/tst/standard/elements.tst
+++ b/tst/standard/elements.tst
@@ -71,6 +71,18 @@ gap> x := PBR([[-3, -2, -1, 1, 2, 3], [-3, -2, -1, 1, 3], [-3, -2, -1, 1, 2]],
 > [[-3, -2, -1, 1, 2], [-3, 2, 3], [-2, -1, 2, 3]]);;
 gap> SmallestIdempotentPower(x);
 2
+gap> First([1 .. 100], i -> IsIdempotent(x ^ i)) = last;
+true
+gap> x := PBR([[-2, 2], [-1]], [[1], [1, 2]]);;
+gap> SmallestIdempotentPower(x);
+4
+gap> First([1 .. 100], i -> IsIdempotent(x ^ i)) = last;
+true
+gap> x := PBR([[-2], [-1]], [[1], [1, 2]]);;
+gap> SmallestIdempotentPower(x);
+2
+gap> First([1 .. 100], i -> IsIdempotent(x ^ i)) = last;
+true
 gap> x := Transformation(
 > [71, 14, 60, 68, 67, 74, 61, 19, 81, 10, 17, 21, 9, 49, 78,
 >  73, 81, 22, 59, 50, 29, 31, 6, 27, 40, 21, 75, 44, 71, 62, 22, 56, 90, 53,
@@ -80,9 +92,13 @@ gap> x := Transformation(
 >  93, 44, 4, 96, 11, 39, 14, 57, 34]);;
 gap> SmallestIdempotentPower(x);
 42
+gap> First([1 .. 100], i -> IsIdempotent(x ^ i)) = last;
+true
 gap> x := Transformation([2, 6, 4, 5, 3, 7, 8, 8]);;
 gap> SmallestIdempotentPower(x);
 6
+gap> First([1 .. 100], i -> IsIdempotent(x ^ i)) = last;
+true
 gap> SmallestIdempotentPower(GeneratorsOfMagma(FreeMagma(1))[1]);
 Error, Semigroups: SmallestIdempotentPower: usage,
 the argument <x> must be the generator of a semigroup,


### PR DESCRIPTION
I was looking at the generic code for `SmallestIdempotentPower` (which I wrote) and I felt that it wasn't very clear, and potentially slow (when the period was much smaller than the index). So I re-wrote it, conforming more directly to the description in Howie.