### PR TITLE
Add IsSemigroupWithClosedIdempotents

### DIFF
--- a/doc/properties.xml
+++ b/doc/properties.xml
@@ -844,12 +844,37 @@ true]]></Example>
   </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="IsSemigroupWithClosedIdempotents">
+  <ManSection>
+    <Prop Name = "IsSemigroupWithClosedIdempotents" Arg = "S"/>
+    <Returns><K>true</K> or <K>false</K>.</Returns>
+    <Description>
+      <C>IsSemigroupWithClosedIdempotents</C> returns <K>true</K> if the
+      idempotents of the semigroup <A>S</A> form a subsemigroup of <A>S</S>,
+      and <K>false</K> if they do not.
+
+      <Example><![CDATA[
+gap> x := Transformation([2, 2]);;
+gap> y := Transformation([1, 3, 3]);;
+gap> S := Semigroup(x, y);
+<transformation semigroup of degree 3 with 2 generators>
+gap> IsSemigroupWithClosedIdempotents(S);
+true
+gap> S := FullTransformationMonoid(4);
+<full transformation monoid of degree 4>
+gap> IsSemigroupWithClosedIdempotents(S);
+false]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="IsSemigroupWithCommutingIdempotents">
   <ManSection>
     <Prop Name = "IsSemigroupWithCommutingIdempotents" Arg = "S"/>
     <Returns><K>true</K> or <K>false</K>.</Returns>
     <Description>
-      <C>IsSemigroupWithIdempotents</C> returns <K>true</K> if the idempotents
+      <C>IsSemigroupWithCommutingIdempotents</C> returns <K>true</K> if the
+      idempotents
       of the semigroup <A>S</A> commute, and <K>false</K> if they do not. Note
       that such an semigroup is also a block group; see <Ref
         Prop="IsBlockGroup"/>. <P/>

--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -31,6 +31,9 @@ DeclareProperty("IsMonogenicInverseMonoid", IsMonoid);
 DeclareOperation("IsRegularSemigroupElementNC",
                  [IsSemigroup, IsMultiplicativeElement]);
 DeclareProperty("IsRightSimple", IsSemigroup);
+if not IsBoundGlobal("IsSemigroupWithClosedIdempotents") then
+  DeclareProperty("IsSemigroupWithClosedIdempotents", IsSemigroup);
+fi;
 DeclareProperty("IsSemigroupWithCommutingIdempotents", IsSemigroup);
 DeclareProperty("IsUnitRegularMonoid", IsSemigroup);
 DeclareProperty("IsZeroRectangularBand", IsSemigroup);

--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -1068,8 +1068,6 @@ end);
 InstallMethod(IsOrthodoxSemigroup, "for a semigroup",
 [IsSemigroup], SUM_FLAGS,  # to beat the Smallsemi method
 function(S)
-  local e, m, i, j;
-
   if not IsFinite(S) then
     # WW we can not test the following line, since the error message we
     # eventually get depends on whether or not Smallsemi is loaded
@@ -1078,22 +1076,36 @@ function(S)
     Info(InfoSemigroups, 2, "the semigroup is not regular");
     return false;
   fi;
+  Info(InfoSemigroups, 2, "the idempotents do not form a subsemigroup");
+  return IsSemigroupWithClosedIdempotents(S);
+end);
+
+InstallMethod(IsSemigroupWithClosedIdempotents, "for a semigroup",
+[IsSemigroup],
+function(S)
+  local e, m, i, j;
+
+  if not IsFinite(S) then
+    TryNextMethod();
+  fi;
 
   e := Idempotents(S);
-  m := Length(e);
+  m := NrIdempotents(S);
 
   for i in [1 .. m] do
-    for j in [1 .. m] do
-      if not IsIdempotent(e[i] * e[j]) then
+    for j in [i + 1 .. m] do
+      if not IsIdempotent(e[i] * e[j]) or not IsIdempotent(e[j] * e[i]) then
         Info(InfoSemigroups, 2, "the product of idempotents ", i, " and ", j,
-             " is not an idempotent");
+             " (in some order) is not idempotent");
         return false;
       fi;
     od;
   od;
-
   return true;
 end);
+
+InstallTrueMethod(IsSemigroupWithClosedIdempotents,
+                  IsSemigroupWithCommutingIdempotents);
 
 # same method for ideals, works for finite and infinite
 

--- a/gap/ideals/ideals.gi
+++ b/gap/ideals/ideals.gi
@@ -82,7 +82,7 @@ end);
 InstallMethod(ViewString,
 "for a semigroup ideal with ideal generators",
 [IsSemigroupIdeal and HasGeneratorsOfSemigroupIdeal],
-6,  # to beat the library method
+8,  # to beat the library method
 _ViewStringForSemigroupsIdeals);
 
 InstallMethod(ViewString,

--- a/gap/semigroups/semigraph.gi
+++ b/gap/semigroups/semigraph.gi
@@ -45,7 +45,7 @@ function(S)
 end);
 
 InstallMethod(AssignGeneratorVariables, "for an inverse semigroup",
-[IsInverseSemigroup],
+[IsGraphInverseSemigroup],
 function(S)
   DoAssignGenVars(GeneratorsOfInverseSemigroup(S));
 end);

--- a/gap/semigroups/semirms.gi
+++ b/gap/semigroups/semirms.gi
@@ -365,7 +365,7 @@ InstallMethod(ViewString,
 "for a Rees 0-matrix subsemigroup ideal with ideal generators",
 [IsReesZeroMatrixSubsemigroup and IsSemigroupIdeal and
  HasGeneratorsOfSemigroupIdeal],
-5,  # to beat ViewString for a semigroup ideal with ideal generators
+7,  # to beat ViewString for a semigroup ideal with ideal generators
 function(I)
   local str, nrgens;
 


### PR DESCRIPTION
This is a sensible feature to have, in my opinion, especially since the code for it already exists pretty much as part of `IsOrthodoxSemigroup`. There is a problem: this already exists in `smallsemi`, and `IsSemigroupWithClosedIdempotents` is also declared there, so loading both packages gives the warning:
```
#I  method installed for `IsSemigroupWithClosedIdempotents` matches more than one declaration
```
What should we do about this?
1. Ignore it.
2. Move the declaration of `IsSemigroupWithClosedIdempotents` to the GAP library.
3. Not have this feature in Semigroups.