### PR TITLE
 Fix issue 556

### DIFF
--- a/gap/main/fropin.gi
+++ b/gap/main/fropin.gi
@@ -22,7 +22,7 @@ IsSemigroup and IsGeneratorsOfEnumerableSemigroup);
 
 # This is optional, but it is useful in several places, for example, to be able
 # to use MinimalFactorization with a perm group.
-InstallTrueMethod(IsEnumerableSemigroupRep, IsGroup and IsFinite);
+# InstallTrueMethod(IsEnumerableSemigroupRep, IsGroup and IsFinite);
 
 # This should be removed ultimately, but is included now because there are too
 # few methods for fp semigroup and monoids at present.

--- a/gap/main/orbits.gi
+++ b/gap/main/orbits.gi
@@ -162,30 +162,30 @@ InstallMethod(EvaluateWord,
 "for multiplicative element with one coll and list of integers",
 [IsMultiplicativeElementWithOneCollection, IsList],
 function(gens, w)
-    local i, res;
-    if Length(w) = 0  then
-      return One(gens);
-    fi;
-    res := gens[AbsInt(w[1])] ^ SignInt(w[1]);
-    for i in [2 .. Length(w)]  do
-      res := res * gens[AbsInt(w[i])] ^ SignInt(w[i]);
-    od;
-    return res;
+  local i, res;
+  if Length(w) = 0  then
+    return One(gens);
+  fi;
+  res := gens[AbsInt(w[1])] ^ SignInt(w[1]);
+  for i in [2 .. Length(w)]  do
+    res := res * gens[AbsInt(w[i])] ^ SignInt(w[i]);
+  od;
+  return res;
 end);
 
 InstallMethod(EvaluateWord,
 "for multiplicative element coll and list of integers",
 [IsMultiplicativeElementCollection, IsList],
 function(gens, w)
-    local i, res;
-    if Length(w) = 0  then
-      return SEMIGROUPS.UniversalFakeOne;
-    fi;
-    res := gens[AbsInt(w[1])] ^ SignInt(w[1]);
-    for i in [2 .. Length(w)]  do
-      res := res * gens[AbsInt(w[i])] ^ SignInt(w[i]);
-    od;
-    return res;
+  local i, res;
+  if Length(w) = 0 then
+    return SEMIGROUPS.UniversalFakeOne;
+  fi;
+  res := gens[AbsInt(w[1])] ^ SignInt(w[1]);
+  for i in [2 .. Length(w)]  do
+    res := res * gens[AbsInt(w[i])] ^ SignInt(w[i]);
+  od;
+  return res;
 end);
 
 InstallMethod(EvaluateExtRepObjWord,
@@ -193,18 +193,18 @@ InstallMethod(EvaluateExtRepObjWord,
 [IsMultiplicativeElementCollection, IsList],
 function(gens, w)
   local res, i;
-    if Length(w) = 0 then
-      ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
-                    "must be a non-empty list");
-    elif Length(w) mod 2 = 1 then
-      ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
-                    "must be a list of even length");
-    fi;
-    res := gens[AbsInt(w[1])] ^ w[2];
-    for i in [3, 5 .. Length(w) - 1] do
-      res := res * gens[AbsInt(w[i])] ^ w[i + 1];
-    od;
-    return res;
+  if Length(w) = 0 then
+    ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
+    "must be a non-empty list");
+  elif Length(w) mod 2 = 1 then
+    ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
+    "must be a list of even length");
+  fi;
+  res := gens[AbsInt(w[1])] ^ w[2];
+  for i in [3, 5 .. Length(w) - 1] do
+    res := res * gens[AbsInt(w[i])] ^ w[i + 1];
+  od;
+  return res;
 end);
 
 InstallMethod(EvaluateExtRepObjWord,
@@ -212,17 +212,17 @@ InstallMethod(EvaluateExtRepObjWord,
 [IsMultiplicativeElementWithOneCollection, IsList],
 function(gens, w)
   local res, i;
-    if Length(w) = 0 then
-      return One(gens);
-    elif Length(w) mod 2 = 1 then
-      ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
-                    "must be a list of even length");
-    fi;
-    res := gens[AbsInt(w[1])] ^ w[2];
-    for i in [3, 5 .. Length(w) - 1] do
-      res := res * gens[AbsInt(w[i])] ^ w[i + 1];
-    od;
-    return res;
+  if Length(w) = 0 then
+    return One(gens);
+  elif Length(w) mod 2 = 1 then
+    ErrorNoReturn("Semigroups: EvaluateExtRepObjWord, the second argument ",
+    "must be a list of even length");
+  fi;
+  res := gens[AbsInt(w[1])] ^ w[2];
+  for i in [3, 5 .. Length(w) - 1] do
+    res := res * gens[AbsInt(w[i])] ^ w[i + 1];
+  od;
+  return res;
 end);
 
 InstallGlobalFunction(EnumeratePosition,

--- a/gap/semigroups/grpperm.gi
+++ b/gap/semigroups/grpperm.gi
@@ -177,8 +177,19 @@ function(S)
   end;
 
   inv := function(x)
+    local w, i;
+    w := ExtRepOfObj(Factorization(G, x));
+    if Length(w) = 0 then
+      return MultiplicativeNeutralElement(S);
+    fi;
+    for i in [2, 4 .. Length(w)] do
+      if w[i] < 0 then
+        w[i] := Order(GeneratorsOfGroup(G)[w[i - 1]]) + w[i];
+      fi;
+    od;
+    w := SEMIGROUPS.ExtRepObjToWord(w);
     return EvaluateWord(GeneratorsOfSemigroup(S),
-                        List(MinimalFactorization(G, x), x -> gen2[x]));
+                        List(w, x -> gen2[x]));
   end;
 
   # TODO replace this with SemigroupIsomorphismByImagesOfGenerators

--- a/tst/standard/fropin.tst
+++ b/tst/standard/fropin.tst
@@ -517,9 +517,7 @@ gap> MultiplicationTable(S);
 # PositionCanonical (for a group)
 gap> G := Group((1, 2, 3), (1, 2));;
 gap> IsEnumerableSemigroupRep(G);
-true
-gap> PositionCanonical(G, (1, 3, 2));
-3
+false
 
 #
 gap> SEMIGROUPS.StopTest();

--- a/tst/standard/isorms.tst
+++ b/tst/standard/isorms.tst
@@ -940,12 +940,12 @@ gap> BruteForceInverseCheck(iso);
 true
 gap> G := AllSmallGroups(8)[3];;
 gap> G := AsSemigroup(IsTransformationSemigroup, G);
-<transformation semigroup of size 8, degree 8 with 3 generators>
+<transformation monoid of size 8, degree 8 with 7 generators>
 gap> x := IdentityTransformation;;
-gap> y := Transformation([4, 7, 6, 1, 8, 3, 2, 5]);;
+gap> y := Transformation([4, 6, 7, 1, 8, 2, 3, 5]);;
 gap> R := ReesZeroMatrixSemigroup(G, [[x, 0, 0], [0, x, 0], [0, 0, x]]);
-<Rees 0-matrix semigroup 3x3 over <transformation semigroup of size 8, 
-  degree 8 with 3 generators>>
+<Rees 0-matrix semigroup 3x3 over <transformation monoid of size 8, degree 8 
+  with 7 generators>>
 gap> iso := IsomorphismReesZeroMatrixSemigroupOverPermGroup(R);;
 gap> BruteForceIsoCheck(iso);
 true
@@ -959,7 +959,7 @@ gap> BruteForceInverseCheck(iso);
 true
 gap> R := ReesZeroMatrixSemigroup(G, [[y, 0, 0], [0, y, 0], [0, 0, y]]);
 <Rees 0-matrix semigroup 3x3 over <transformation group of size 8, 
-  degree 8 with 3 generators>>
+  degree 8 with 7 generators>>
 gap> S := Semigroup(RMSElement(R, 1, x, 2), RMSElement(R, 2, x, 1));;
 gap> iso := IsomorphismReesZeroMatrixSemigroupOverPermGroup(S);;
 gap> BruteForceIsoCheck(iso);

--- a/tst/standard/semibipart.tst
+++ b/tst/standard/semibipart.tst
@@ -2117,7 +2117,7 @@ true
 gap> S := DihedralGroup(6);
 <pc group of size 6 with 2 generators>
 gap> T := AsSemigroup(IsBipartitionSemigroup, S);
-<block bijection group of size 6, degree 6 with 2 generators>
+<block bijection group of size 6, degree 6 with 5 generators>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);
@@ -2139,7 +2139,7 @@ true
 gap> S := DihedralGroup(6);
 <pc group of size 6 with 2 generators>
 gap> T := AsMonoid(IsBipartitionMonoid, S);
-<block bijection group of size 6, degree 6 with 2 generators>
+<block bijection group of size 6, degree 6 with 5 generators>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);

--- a/tst/standard/semiboolmat.tst
+++ b/tst/standard/semiboolmat.tst
@@ -1644,7 +1644,7 @@ true
 gap> S := DihedralGroup(6);
 <pc group of size 6 with 2 generators>
 gap> T := AsSemigroup(IsBooleanMatSemigroup, S);
-<semigroup of size 6, 6x6 boolean matrices with 2 generators>
+<monoid of size 6, 6x6 boolean matrices with 5 generators>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);
@@ -1666,7 +1666,7 @@ true
 gap> S := DihedralGroup(6);
 <pc group of size 6 with 2 generators>
 gap> T := AsMonoid(IsBooleanMatMonoid, S);
-<semigroup of size 6, 6x6 boolean matrices with 2 generators>
+<monoid of size 6, 6x6 boolean matrices with 5 generators>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);

--- a/tst/standard/semipbr.tst
+++ b/tst/standard/semipbr.tst
@@ -1887,7 +1887,7 @@ true
 gap> S := DihedralGroup(6);
 <pc group of size 6 with 2 generators>
 gap> T := AsSemigroup(IsPBRSemigroup, S);
-<pbr semigroup of size 6, degree 6 with 2 generators>
+<pbr monoid of size 6, degree 6 with 5 generators>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);
@@ -1909,7 +1909,7 @@ true
 gap> S := DihedralGroup(6);
 <pc group of size 6 with 2 generators>
 gap> T := AsMonoid(IsPBRMonoid, S);
-<pbr monoid of size 6, degree 6 with 2 generators>
+<pbr monoid of size 6, degree 6 with 5 generators>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);

--- a/tst/standard/semipperm.tst
+++ b/tst/standard/semipperm.tst
@@ -1839,7 +1839,7 @@ true
 gap> S := DihedralGroup(6);
 <pc group of size 6 with 2 generators>
 gap> T := AsMonoid(IsPartialPermMonoid, S);
-<inverse partial perm monoid of size 6, rank 6 with 2 generators>
+<inverse partial perm monoid of size 6, rank 6 with 5 generators>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);

--- a/tst/standard/semirms.tst
+++ b/tst/standard/semirms.tst
@@ -1823,7 +1823,7 @@ true
 gap> S := DihedralGroup(IsPermGroup, 4);
 Group([ (1,2), (3,4) ])
 gap> T := AsSemigroup(IsReesMatrixSemigroup, S);
-<Rees matrix semigroup 1x1 over Group([ (1,3)(2,4), (1,2)(3,4) ])>
+<Rees matrix semigroup 1x1 over Group([ (1,2)(3,4), (1,3)(2,4) ])>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);

--- a/tst/standard/semitrans.tst
+++ b/tst/standard/semitrans.tst
@@ -2179,7 +2179,7 @@ true
 #   convert from non-perm group  to IsTransformationSemigroup
 gap> S := DihedralGroup(6);;
 gap> T := AsSemigroup(IsTransformationSemigroup, S);
-<transformation semigroup of size 6, degree 6 with 2 generators>
+<transformation monoid of size 6, degree 6 with 5 generators>
 gap> Size(S) = Size(T);
 true
 gap> NrDClasses(S) = NrDClasses(T);


### PR DESCRIPTION
This PR partially fixes Issue #556, by removing the implication `IsFinite and IsGroup` => `IsEnumerableSemigroupRep`.  Other such implications remain, and should be removed. The remaining implications will be removed in a more major clean up (hopefully) in the coming months.