### PR TITLE
Avoid redundant Matrix declaration in newer GAP versions

### DIFF
--- a/gap/elements/semiringmat.gd
+++ b/gap/elements/semiringmat.gd
@@ -36,11 +36,11 @@ DeclareOperation("MatrixNC", [IsMatrixOverSemiring,
                               IsList]);
 
 DeclareOperation("Matrix", [IsOperation, IsHomogeneousList]);
-DeclareOperation("Matrix", [IsOperation, IsHomogeneousList,
-                            IsPosInt]);
-DeclareOperation("Matrix", [IsOperation, IsHomogeneousList,
-                            IsInt, IsInt]);
-DeclareOperation("Matrix", [IsSemiring, IsHomogeneousList]);
+DeclareOperation("Matrix", [IsOperation, IsHomogeneousList, IsPosInt]);
+DeclareOperation("Matrix", [IsOperation, IsHomogeneousList, IsInt, IsInt]);
+if not CompareVersionNumbers(GAPInfo.BuildVersion, "4.10") then
+  DeclareOperation("Matrix", [IsSemiring, IsHomogeneousList]);
+fi;
 DeclareOperation("Matrix", [IsSemiring, IsMatrixOverSemiring]);
 
 DeclareConstructor("AsMatrix", [IsMatrixOverSemiring,


### PR DESCRIPTION
This removes the warning
```
#I  method installed for Matrix matches more than one declaration
```
that we currently get at startup.

Since GAP 4.10, `lib/matobj2.gd` has had the declaration `DeclareOperation("Matrix", [IsSemiring, IsList]);`. However, in Semigroups we've got the declaration `DeclareOperation("Matrix", [IsSemiring, IsHomogeneousList]);`, and we install a method for this (and hence GAP's) declaration, which is what prompts the warning.

This PR only makes the new declaration in the Semigroups package in versions of GAP before 4.10.

Fixes #615.