### PR TITLE
Avoid using attributes Matrix, Rows, Columns

### DIFF
--- a/gap/main/fropin.gi
+++ b/gap/main/fropin.gi
@@ -68,7 +68,8 @@ IsGeneratorsOfSemigroup);
 # Rees(Zero)MatrixSemigroup code.
 
 InstallImmediateMethod(IsGeneratorsOfEnumerableSemigroup,
-IsReesZeroMatrixSubsemigroup and HasRows and HasColumns, 0,
+IsReesZeroMatrixSubsemigroup and HasRowsOfReesZeroMatrixSemigroup
+    and HasColumnsOfReesZeroMatrixSemigroup, 0,
 function(R)
   return IsGeneratorsOfEnumerableSemigroup([Representative(R)]);
 end);
@@ -87,7 +88,8 @@ end);
 # Rees(Zero)MatrixSemigroup code.
 
 InstallImmediateMethod(IsGeneratorsOfEnumerableSemigroup,
-IsReesMatrixSubsemigroup and HasRows and HasColumns, 0,
+IsReesMatrixSubsemigroup and HasRowsOfReesMatrixSemigroup
+    and HasColumnsOfReesMatrixSemigroup, 0,
 function(R)
   return IsGeneratorsOfEnumerableSemigroup([Representative(R)]);
 end);

--- a/gap/semigroups/semirms.gi
+++ b/gap/semigroups/semirms.gi
@@ -301,13 +301,16 @@ end);
 
 InstallMethod(Representative,
 "for a Rees 0-matrix subsemigroup with rows, columns and matrix",
-[IsReesZeroMatrixSubsemigroup and HasRows and HasColumns and HasMatrix],
+[IsReesZeroMatrixSubsemigroup
+    and HasRowsOfReesZeroMatrixSemigroup
+    and HasColumnsOfReesZeroMatrixSemigroup
+    and HasMatrixOfReesZeroMatrixSemigroup],
 function(R)
   return Objectify(TypeReesMatrixSemigroupElements(R),
-                   [Rows(R)[1],
+                   [RowsOfReesZeroMatrixSemigroup(R)[1],
                     Representative(UnderlyingSemigroup(R)),
-                    Columns(R)[1],
-                    Matrix(R)]);
+                    ColumnsOfReesZeroMatrixSemigroup(R)[1],
+                    MatrixOfReesZeroMatrixSemigroup(R)]);
 end);
 
 # This method is only required because of some problems in the library code for
@@ -315,13 +318,16 @@ end);
 
 InstallMethod(Representative,
 "for a Rees matrix subsemigroup with rows, columns, and matrix",
-[IsReesMatrixSubsemigroup and HasRows and HasColumns and HasMatrix],
+[IsReesMatrixSubsemigroup
+    and HasRowsOfReesMatrixSemigroup
+    and HasColumnsOfReesMatrixSemigroup
+    and HasMatrixOfReesMatrixSemigroup],
 function(R)
   return Objectify(TypeReesMatrixSemigroupElements(R),
-                   [Rows(R)[1],
+                   [RowsOfReesMatrixSemigroup(R)[1],
                     Representative(UnderlyingSemigroup(R)),
-                    Columns(R)[1],
-                    Matrix(R)]);
+                    ColumnsOfReesMatrixSemigroup(R)[1],
+                    MatrixOfReesMatrixSemigroup(R)]);
 end);
 
 # same method for ideals


### PR DESCRIPTION
and also their testers and setters. Instead use one of these:
- RowsOfReesZeroMatrixSemigroup
- RowsOfReesMatrixSemigroup
- ColumnsOfReesZeroMatrixSemigroup
- ColumnsOfReesMatrixSemigroup
- MatrixOfReesZeroMatrixSemigroup
- MatrixOfReesMatrixSemigroup

Right now, in GAP 4.11 and master branch, there are just synonyms for
the attributes they replace, but this may change in the future (namely
in order to ensure that Matrix on a single argument is a plain operation,
not an attribute, as for use as a matrix *constructor* function, it is not
desirable to have it an attribute).


My hope is that this can be merged soon. Then once a release of Semigroups with this change was made, we can change Matrix to not be an attribute anymore in the GAP master branch, for GAP 4.12 down the road; see https://github.com/gap-system/gap/pull/3664 for that.

CC @ThomasBreuer