### PR TITLE
semiringmat: allow final GAP 'hack' to be removed (Matrix method)

### DIFF
--- a/gap/elements/semiringmat.gi
+++ b/gap/elements/semiringmat.gi
@@ -282,22 +282,21 @@ function(filter, mat)
   return MatrixNC(filter, List(mat, ShallowCopy));
 end);
 
-InstallMethod(Matrix, "for a semiring and homogeneous list",
-[IsSemiring, IsHomogeneousList],
-function(semiring, mat)
+SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc := function(semiring, mat)
   local entry_ok, checker, row;
 
   if not IsEmpty(mat)
-      and (not IsRectangularTable(mat) or Length(mat) <> Length(mat[1])) then
+      and not ForAll(mat, x -> IsList(x) and Length(x) = Length(mat[1])) then
     ErrorNoReturn("Semigroups: Matrix: usage,\n",
-                  "the 2nd argument must define a square matrix,");
+                  "the 2nd argument <mat> does not give a rectangular table,");
+  elif not IsEmpty(mat) and Length(mat) <> Length(mat[1]) then
+    TryNextMethod();
   elif IsField(semiring) and IsFinite(semiring) then
     return NewMatrixOverFiniteField(IsPlistMatrixOverFiniteFieldRep,
                                     semiring,
                                     mat);
   elif not IsIntegers(semiring) then
-    ErrorNoReturn("Semigroups: Matrix:\n",
-                  "cannot create a matrix from the given arguments,");
+    TryNextMethod();
   fi;
 
   entry_ok := SEMIGROUPS_MatrixOverSemiringEntryCheckerCons(IsIntegerMatrix);
@@ -314,7 +313,19 @@ function(semiring, mat)
   od;
 
   return MatrixNC(IsIntegerMatrix, List(mat, ShallowCopy));
-end);
+end;
+
+InstallMethod(Matrix, "for a semiring and homogenous list",
+[IsSemiring, IsHomogeneousList],
+SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);
+
+if CompareVersionNumbers(GAPInfo.BuildVersion, "4.10") then
+  InstallMethod(Matrix, "for a semiring and a matrix obj",
+  [IsSemiring, IsMatrixObj],
+  SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);
+fi;
+
+Unbind(SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);
 
 InstallMethod(Matrix, "for a semiring and matrix over semiring",
 [IsSemiring, IsMatrixOverSemiring],

--- a/tst/standard/semiringmat.tst
+++ b/tst/standard/semiringmat.tst
@@ -150,15 +150,21 @@ the entries in the 2nd argument do not define a matrix of type IsIntegerMatrix\
 # semiringmat: Matrix, for a semiring and homogeneous list, 1/3
 gap> Matrix(Integers, [[1, 1], [2]]);
 Error, Semigroups: Matrix: usage,
-the 2nd argument must define a square matrix,
-gap> Matrix(Integers, [[1, 1, 3], [1, 2, 3]]);
-Error, Semigroups: Matrix: usage,
-the 2nd argument must define a square matrix,
+the 2nd argument <mat> does not give a rectangular table,
+gap> if CompareVersionNumbers(GAPInfo.BuildVersion, "4.10") then
+>   View(Matrix(Integers, [[1, 1, 3], [1, 2, 3]])); Print("\n");
+> else
+>   Print("Error, NewMatrix: Length of l is not a multiple of rl\n");
+> fi;
+Error, NewMatrix: Length of l is not a multiple of rl
 
 # semiringmat: Matrix, for a semiring and homogeneous list, 2/3
-gap> Matrix(Rationals, [[1, 1], [2, 2]]);
-Error, Semigroups: Matrix:
-cannot create a matrix from the given arguments,
+gap> if CompareVersionNumbers(GAPInfo.BuildVersion, "4.10") then
+>   View(Matrix(Rationals, [[1, 1], [2, 2]])); Print("\n");
+> else
+>   Print("<2x2-matrix over Rationals>\n");
+> fi;
+<2x2-matrix over Rationals>
 
 # semiringmat: Matrix, for a semiring and homogeneous list, 3/3
 gap> Matrix(Integers, [[1, 1], [2, E(8)]]);
@@ -608,9 +614,12 @@ gap> Matrix(IsTropicalMaxPlusMatrix, [[2, 2], [0, 1]], 10) <
 false
 
 # Test Matrix for a finite field and list consisting of an empty list
-gap> Matrix(GF(3), [[]]);
-Error, Semigroups: Matrix: usage,
-the 2nd argument must define a square matrix,
+gap> if CompareVersionNumbers(GAPInfo.BuildVersion, "4.10") then
+>   View(Matrix(GF(3), [[]])); Print("\n");
+> else
+>   Print("[ [  ] ]\n");
+> fi;
+[ [  ] ]
 
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(S);


### PR DESCRIPTION
Once this PR is merged and a new version of the package is released, this should mean that https://github.com/gap-system/gap/pull/2758 can be merged, and so GAP no longer has to do 'weird' things to accommodate Semigroups.

This PR changes the Semigroups package so that, when it is loaded, it gives the first-choice method for `Matrix` for `IsSemiring, IsMatrixObj`. Previously, the method was installed only for `IsSemiring, IsHomogenousList`; but since a homogenous list in GAP 4.10 onwards automatically knows that it satisfies `IsMatrixObj` in many cases, this means that the GAP library method for `IsSemiring, IsMatrixObj` method (higher ranked) was beating the one in the Semigroups package that we really wanted to use.

This adds a Semigroups package method for `Matrix` for `IsSemiring, IsMatrixObj` (the same as the `IsSemiring, IsHomogenousList` method, which we keep), and so everything should work as normal.