### PR TITLE
Make sure to include GAP headers before libsemigroups

### DIFF
--- a/src/bipart.cc
+++ b/src/bipart.cc
@@ -28,10 +28,10 @@
 #include <utility>
 #include <vector>
 
+#include "src/compiled.h"
+
 #include "libsemigroups/blocks.hpp"
 #include "libsemigroups/froidure-pin.hpp"
-
-#include "src/compiled.h"
 
 using libsemigroups::Blocks;
 using libsemigroups::Element;

--- a/src/bipart.h
+++ b/src/bipart.h
@@ -19,14 +19,14 @@
 #ifndef SEMIGROUPS_SRC_BIPART_H_
 #define SEMIGROUPS_SRC_BIPART_H_
 
-#include "libsemigroups/element.hpp"
-
 // GAP headers
 #include "src/compiled.h"
 
 // Semigroups pkg headers
 #include "pkg.h"
 #include "semigroups-debug.h"
+
+#include "libsemigroups/element.hpp"
 
 using libsemigroups::Bipartition;
 using libsemigroups::Blocks;

--- a/src/pkg.h
+++ b/src/pkg.h
@@ -43,10 +43,11 @@
 #include <iostream>
 #include <vector>
 
+#include "src/compiled.h"
+
 #include "rnams.h"
 #include "semigroups-debug.h"
 
-#include "src/compiled.h"
 
 #if !defined(GAP_KERNEL_MAJOR_VERSION) || GAP_KERNEL_MAJOR_VERSION < 3
 // compatibility with GAP <= 4.9

--- a/src/semigrp.h
+++ b/src/semigrp.h
@@ -21,9 +21,9 @@
 #ifndef SEMIGROUPS_SRC_SEMIGRP_H_
 #define SEMIGROUPS_SRC_SEMIGRP_H_
 
-#include "libsemigroups/froidure-pin.hpp"
-
 #include "src/compiled.h"  // GAP headers
+
+#include "libsemigroups/froidure-pin.hpp"
 
 #include "converter.h"
 #include "pkg.h"


### PR DESCRIPTION
This way, #defines in libsemigroups don't affect GAP headers. For example, GAP may typedef BOOL in the future, and right now that would break Semigroups because libsemigroups #defines BOOL to something. With this patch, that problem goes away.

It also seems in general useful to have a fixed order; this way, *if* things break in either GAP or libsemigroups due to a change in the respective other, at least they will break consistently.
Motivated by https://github.com/gap-system/gap/pull/3814