### PR TITLE
kernel: fix bmat converter

### DIFF
--- a/src/converter.cc
+++ b/src/converter.cc
@@ -34,14 +34,19 @@ using libsemigroups::SemiringWithThreshold;
 
 BooleanMat* BoolMatConverter::convert(Obj o, size_t n) const {
   SEMIGROUPS_ASSERT(CALL_1ARGS(IsBooleanMat, o));
-  SEMIGROUPS_ASSERT(IS_BLIST_REP(ELM_PLIST(o, 1)));
+  SEMIGROUPS_ASSERT(IS_PLIST(o));
+  SEMIGROUPS_ASSERT(LEN_PLIST(o) > 0);
 
-  size_t            m = LEN_BLIST(ELM_PLIST(o, 1));
+  Obj               row = ELM_PLIST(o, 1);
+  SEMIGROUPS_ASSERT(IS_PLIST(row) || IS_BLIST_REP(row));
+  size_t            m   = (IS_BLIST_REP(row) ? LEN_BLIST(row) : LEN_PLIST(row));
   std::vector<bool> x(m * m, false);
 
   for (size_t i = 0; i < m; i++) {
-    Obj row = ELM_PLIST(o, i + 1);
-    SEMIGROUPS_ASSERT(IS_BLIST_REP(row));
+    row = ELM_PLIST(o, i + 1);
+    if (!IS_BLIST_REP(row)) {
+      ConvBlist(row);
+    }
     for (size_t j = 0; j < m; j++) {
       if (ELM_BLIST(row, j + 1) == True) {
         x.at(i * m + j) = true;

--- a/tst/standard/boolmat.tst
+++ b/tst/standard/boolmat.tst
@@ -549,6 +549,18 @@ gap> x := Matrix(IsBooleanMat, [[1, 0, 0, 1, 0],
 gap> AsBooleanMat(AsDigraph(mat)) = mat;
 true
 
+# Fix converter for BMats in the kernel, prior to PR #647 the size of returned
+# below was 4, which is nonsense.
+gap> S := Semigroup([
+> Matrix(IsBooleanMat,
+>        [[false, true], [false, true]]),
+> Matrix(IsBooleanMat,
+>        [[true, false], [true, false]])]);
+<semigroup of 2x2 boolean matrices with 2 generators>
+gap> Union2(AsList(S.2)[1], AsList(S.2)[2]);;
+gap> Size(S);
+2
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(S);
 gap> Unbind(blist);


### PR DESCRIPTION
Prior to this PR, the following happened:

~~~~
gap> S := Semigroup([
> Matrix(IsBooleanMat,
>        [[false, true], [false, true]]),
> Matrix(IsBooleanMat,
>        [[true, false], [true, false]])]);
gap> Union2(AsList(S.2)[1], AsList(S.2)[2]);
gap> Size(S);
4
~~~~

The reason being that `Union2` converts `S.2[2]` to plist rep (from blist rep), but the converter code in the kernel assumed that it will be in blist rep. This PR removes this assumption and fixes the example above. 