### PR TITLE
Better boolmat

### DIFF
--- a/doc/boolmat.xml
+++ b/doc/boolmat.xml
@@ -674,4 +674,19 @@ gap> Bell(3);
   </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="IsTransformationBooleanMat">
+  <ManSection>
+    <Prop Name = "IsTransformationBooleanMat" Arg = "mat"/>
+    <Returns><K>true</K> or <K>false</K>.</Returns>
+    <Description>
+      A boolean matrix is a <B>transformation</B> if every row contains 
+      precisely one <K>true</K> value.
+
+      <Example><![CDATA[
+gap> Number(FullBooleanMatMonoid(3), IsTransformationBooleanMat);
+27]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
 

--- a/doc/z-chap05.xml
+++ b/doc/z-chap05.xml
@@ -214,6 +214,7 @@
     <#Include Label = "IsTotalBooleanMat">
     <#Include Label = "IsPartialOrderBooleanMat">
     <#Include Label = "IsEquivalenceBooleanMat">
+    <#Include Label = "IsTransformationBooleanMat">
   </Section>
 
   <!--**********************************************************************-->

--- a/gap/elements/boolmat.gd
+++ b/gap/elements/boolmat.gd
@@ -71,3 +71,5 @@ DeclareSynonymAttr("IsPartialOrderBooleanMat", IsReflexiveBooleanMat and
                    IsAntiSymmetricBooleanMat and IsTransitiveBooleanMat);
 DeclareSynonymAttr("IsEquivalenceBooleanMat", IsReflexiveBooleanMat and
                    IsSymmetricBooleanMat and IsTransitiveBooleanMat);
+
+DeclareProperty("IsTransformationBooleanMat", IsBooleanMat);

--- a/gap/elements/boolmat.gi
+++ b/gap/elements/boolmat.gi
@@ -727,3 +727,16 @@ InstallMethod(IsOntoBooleanMat, "for a boolean matrix",
 function(x)
   return IsTotalBooleanMat(TransposedMat(x));
 end);
+
+InstallMethod(IsTransformationBooleanMat, "for a boolean matrix",
+[IsBooleanMat],
+function(x)
+  local n, i;
+  n := Length(x[1]);
+  for i in [1 .. n] do
+    if SizeBlist(x[i]) <> 1 then
+      return false;
+    fi;
+  od;
+  return true;
+end);

--- a/gap/semigroups/semitrans.gi
+++ b/gap/semigroups/semitrans.gi
@@ -792,26 +792,27 @@ InstallMethod(IsomorphismTransformationSemigroup,
 "for a boolean matrix semigroup with generators",
 [IsBooleanMatSemigroup and HasGeneratorsOfSemigroup],
 function(S)
-  local n, pts, o, pos, T, i;
-
+  local T, map, inv, n, pts, o, pos, i;
   n := Length(Representative(S)![1]);
-  pts := [];
-  for i in [1 .. n] do
-    o := Enumerate(Orb(S, BlistList([1 .. n], [i]), OnBlist));
-    pts := Union(pts, AsList(o));
-  od;
-  pos := List([1 .. n], x -> Position(pts, BlistList([1 .. n], [x])));
-  T := Semigroup(List(GeneratorsOfSemigroup(S),
-                      x -> TransformationOpNC(x, pts, OnBlist)));
+  if ForAll(GeneratorsOfSemigroup(S), IsTransformationBooleanMat) then
+    T := Semigroup(List(GeneratorsOfSemigroup(S), AsTransformation));
+    map := AsTransformation;
+    inv := x -> AsBooleanMat(x, n);
+  else
+    pts := [];
+    for i in [1 .. n] do
+      o := Enumerate(Orb(S, BlistList([1 .. n], [i]), OnBlist));
+      pts := Union(pts, AsList(o));
+    od;
+    pos := List([1 .. n], x -> Position(pts, BlistList([1 .. n], [x])));
+    T := Semigroup(List(GeneratorsOfSemigroup(S),
+                        x -> TransformationOpNC(x, pts, OnBlist)));
+    map := x -> TransformationOpNC(x, pts, OnBlist);
+    inv := x -> BooleanMat(List([1 .. n], i -> pts[pos[i] ^ x]));
+  fi;
   UseIsomorphismRelation(S, T);
 
-  return MagmaIsomorphismByFunctionsNC(S,
-                                       T,
-                                       x -> TransformationOpNC(x,
-                                                               pts,
-                                                               OnBlist),
-                                       x -> BooleanMat(List([1 .. n],
-                                                       i -> pts[pos[i] ^ x])));
+  return MagmaIsomorphismByFunctionsNC(S, T, map, inv);
 end);
 
 InstallMethod(IsomorphismTransformationSemigroup,

--- a/tst/standard/boolmat.tst
+++ b/tst/standard/boolmat.tst
@@ -561,6 +561,26 @@ gap> Union2(AsList(S.2)[1], AsList(S.2)[2]);;
 gap> Size(S);
 2
 
+# IsTransformationBooleanMat
+gap> x := Transformation([10, 8, 4, 6, 4, 5, 3, 8, 8, 2]);
+Transformation( [ 10, 8, 4, 6, 4, 5, 3, 8, 8, 2 ] )
+gap> y := AsBooleanMat(x);
+<10x10 boolean matrix>
+gap> IsTransformationBooleanMat(y);
+true
+gap> AsTransformation(y) = x;
+true
+gap> z := Matrix(IsBooleanMat,
+>           [[1, 1, 1, 1], 
+>            [1, 1, 1, 1], 
+>            [0, 1, 0, 1], 
+>            [1, 1, 0, 1]]);
+Matrix(IsBooleanMat, [[1, 1, 1, 1], [1, 1, 1, 1], [0, 1, 0, 1], [1, 1, 0, 1]])
+gap> IsTransformationBooleanMat(z);
+false
+gap> AsTransformation(z);
+fail
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(S);
 gap> Unbind(blist);


### PR DESCRIPTION
Adds `IsTransformationBooleanMat` and improves the method for `IsomorphismTransformationSemigroup` for boolean matrix semigroups whose generators are really transformations.