### PR TITLE
Copy all versions of cygsemigroups for cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,7 +61,7 @@ if SYS_IS_CYGWIN
 	cp .libs/semigroups.dll $(GAPINSTALLLIB)
 if WITH_INCLUDED_LIBSEMIGROUPS
 # Cygwin will only look in this directory for dlls
-	cp libsemigroups/.libs/cygsemigroups-0.dll $(GAPROOT)/.libs
+	cp libsemigroups/.libs/cygsemigroups-*.dll $(GAPROOT)/.libs
 endif
 else
 	cp .libs/semigroups.so $(GAPINSTALLLIB)


### PR DESCRIPTION
The version number for libsemigroups was updated (to 1), which broken cygwin as it was hard-wired to 0.

This just copies any version number.