### PR TITLE
Fix header includes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_CANONICAL_HOST
 dnl ##
 dnl ## Setup automake
 dnl ##
-AM_INIT_AUTOMAKE([1.11 -Wall foreign subdir-objects])
+AM_INIT_AUTOMAKE([1.11 -Wall foreign subdir-objects nostdinc])
 AM_SILENT_RULES([yes])
 AM_PROG_AR
 

--- a/src/congpairs.cc
+++ b/src/congpairs.cc
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include "src/congpairs.h"
+#include "congpairs.h"
 
 #include <string>
 #include <unordered_map>

--- a/src/fropin.cc
+++ b/src/fropin.cc
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <fropin.h>
+#include "fropin.h"
 
 #include <algorithm>
 #include <iostream>


### PR DESCRIPTION
This PR fixes the root directory of semigroups getting included in the include path.

The first commit fixes two included headers -- technically these were always wrong, but worked because lots of extra things were in the include path. The second commit stops extra include paths appearing.

Now you have renamed VERSION anyway, this might not make things any better, but it is (I hope) "neater" in the long term. it would also be nice to see if it breaks any semigroups tests, to see if this is the right idea for a fix.