### PR TITLE
Accommodate future changed ViewStrings in GAP, in isorms.tst

### DIFF
--- a/tst/standard/isorms.tst
+++ b/tst/standard/isorms.tst
@@ -642,13 +642,7 @@ gap> BruteForceIsoCheck(map);
 true
 gap> BruteForceInverseCheck(map);
 true
-gap> map := InverseGeneralMapping(map);
-InverseGeneralMapping( CompositionMapping( MappingByFunction( 
-<Rees matrix semigroup 1x1 over Group([ (1,2) ])>, 
-<Rees matrix semigroup 1x1 over <pc group of size 2 with 1 generators>>
- , function( x ) ... end, function( x ) ... end ),
- ((), GroupHomomorphismByImages( SymmetricGroup( [ 1 .. 2 ] ), Group( 
-[ (1,2) ] ), [ (1,2) ], [ (1,2) ] ), [ (), () ]) ) )
+gap> map := InverseGeneralMapping(map);;
 gap> BruteForceIsoCheck(map);
 true
 gap> BruteForceInverseCheck(map);
@@ -875,12 +869,9 @@ gap> BruteForceIsoCheck(map);
 true
 gap> BruteForceInverseCheck(map);
 true
-gap> G := CyclicGroup(IsPcGroup, 5);
-<pc group of size 5 with 1 generators>
-gap> R := ReesZeroMatrixSemigroup(G, [[One(G), 0], [One(G), One(G)]]);
-<Rees 0-matrix semigroup 2x2 over <pc group of size 5 with 1 generators>>
-gap> S := ReesZeroMatrixSemigroup(G, [[One(G), One(G)], [0, One(G)]]);
-<Rees 0-matrix semigroup 2x2 over <pc group of size 5 with 1 generators>>
+gap> G := CyclicGroup(IsPcGroup, 5);;
+gap> R := ReesZeroMatrixSemigroup(G, [[One(G), 0], [One(G), One(G)]]);;
+gap> S := ReesZeroMatrixSemigroup(G, [[One(G), One(G)], [0, One(G)]]);;
 gap> map := IsomorphismSemigroups(R, S);;
 gap> BruteForceIsoCheck(map);
 true


### PR DESCRIPTION
Due to https://github.com/gap-system/gap/pull/3992, things like "1 generators" should instead be shown as "1 generator". This affects a couple of tests in the Semigroups package.

To main compatibility with older versions of GAP, we have to suppress the output, rather than just adopt the new output.