### PR TITLE
Revise C level access to GAP lists in fropin.cc

### DIFF
--- a/src/congpairs.cc
+++ b/src/congpairs.cc
@@ -319,7 +319,6 @@ Obj CONG_PAIRS_LOOKUP_PART(Obj self, gap_cong_t o) {
 
   for (size_t i = 0; i < cong->nr_classes(); i++) {
     Obj next = NEW_PLIST_IMM(T_PLIST_CYC, 0);
-    SET_LEN_PLIST(next, 0);  // should never be 0 later on, so this should be ok
     SET_ELM_PLIST(partition, i + 1, next);
     CHANGED_BAG(partition);
   }

--- a/src/fropin.h
+++ b/src/fropin.h
@@ -22,8 +22,6 @@
 #include "pkg.h"
 #include "compiled.h"
 
-#define ELM_PLIST2(plist, i, j) ELM_PLIST(ELM_PLIST(plist, i), j)
-
 // TODO(JDM) write doc
 size_t fropin_prod_by_reduction(gap_rec_t fp, size_t i, size_t j);
 

--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -1103,7 +1103,6 @@ gap_list_t EN_SEMI_IDEMPOTENTS(Obj self, gap_semigroup_t so) {
     size_t     nr   = 0;
     gap_list_t out  = NEW_PLIST_IMM(T_PLIST_CYC, 0);
     // IMMUTABLE since it should not be altered on the GAP level
-    SET_LEN_PLIST(out, 0);
     for (size_t pos = 1; pos <= size; pos++) {
       size_t i = pos, j = pos;
       while (i != 0) {
@@ -1128,7 +1127,6 @@ gap_int_t EN_SEMI_IDEMS_SUBSET(Obj self, gap_semigroup_t so, gap_list_t list) {
 
   gap_list_t out = NEW_PLIST_IMM(T_PLIST_CYC, 0);
   // IMMUTABLE since it should not be altered on the GAP level
-  SET_LEN_PLIST(out, 0);
   size_t len = 0;
 
   if (en_semi_get_type(es) != UNKNOWN) {

--- a/src/uf.cc
+++ b/src/uf.cc
@@ -85,7 +85,6 @@ Obj UF_BLOCKS(Obj self, Obj uf) {
 
   // Rewrite each block as a PLIST object, and put it into a PLIST.
   Obj gap_blocks = NEW_PLIST(T_PLIST, 0);
-  SET_LEN_PLIST(gap_blocks, 0);
   for (i = 0; i < size; i++) {
     if ((*blocks)[i] != nullptr) {  // nullptr represents a hole in the list
       Obj block = NEW_PLIST(T_PLIST_CYC, (*blocks)[i]->size());
@@ -116,7 +115,6 @@ gap_list_t UF_BLOCK_REPS(Obj self, Obj uf) {
   size_t next_rep = uf_cpp->next_rep();
 
   gap_list_t out = NEW_PLIST(T_PLIST_CYC, 0);
-  SET_LEN_PLIST(out, 0);
   size_t nr = 0;
 
   while (next_rep < uf_cpp->get_size()) {


### PR DESCRIPTION
- move `ELM_PLIST2` from fropin.h to fropin.cc
- `SET_ELM_PLIST2` called CHANGED_BAG on the wrong list (resulting in a
  potential GC crash); change it to use `ASS_LIST` which avoids this and in
  general will take care of everything for us at a minuscule performance cost
- in particular, this renders several calls to `RetypeBag` unnecessary
- a call to `RetypeBag(rules, T_PLIST_CYC)` was incorrect (because the
  elements of `rules` actually seem to be plists, not cyclotomics); instead
  use `ASS_LIST` to let the GAP kernel worry about setting suitable TNUMs
- use `ASS_LIST` and `AssPlist` in a few more places
- tiny optimization: instead of `INT_INTOBJ(expr) == 0` it is better to do
  `expr = INTOBJ_INT(0)` as the compiler can precompute the right side
- drop some redundant calls to `SET_LEN_PLIST`: new plists always have
  length 0, no need to set that; and `AssPlist` / `ASS_LIST` automatically
  set the correct list length for us