### PR TITLE
README.md: fix Travis link and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 #### Copyright (C) 2011-20 James D. Mitchell et al.<br />Licensing information is available in the LICENSE file.
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.592893.svg)](https://doi.org/10.5281/zenodo.592893)
-[![Build Status](https://travis-ci.org/gap-packages/Semigroups.svg?branch=stable-3.1)](https://travis-ci.org/gap-packages/Semigroups)
+[![Build Status](https://travis-ci.com/gap-packages/Semigroups.svg?branch=stable-3.4)](https://travis-ci.com/gap-packages/Semigroups)
 
 ## Getting Semigroups
 


### PR DESCRIPTION
- point to travis-ci.com instead of .org (which will be turned off on December 31, 2020)
- adjust the badge to point to the stable-3.4 branch

If you have other active branches (`master`?) you may want to apply similar changes there?