### PR TITLE
Remove special case for GAP < 4.9, which is no longer supported

### DIFF
--- a/src/converter.cc
+++ b/src/converter.cc
@@ -68,11 +68,7 @@ Obj BoolMatConverter::unconvert(Element const* x) const {
     SET_LEN_BLIST(blist, n);
     for (size_t j = 0; j < n; j++) {
       if ((*xx)[i * n + j]) {
-#ifdef SET_ELM_BLIST
-        SET_ELM_BLIST(blist, j + 1, True);  // for GAP < 4.9
-#else
-        SET_BIT_BLIST(blist, j + 1);  // for GAP >= 4.9
-#endif
+        SET_BIT_BLIST(blist, j + 1);
       }
     }
     SET_ELM_PLIST(o, i + 1, blist);


### PR DESCRIPTION
I noticed while reviewing #708 that we can get ride of the special case here. The minimum version of GAP required by Semigroups is currently 4.9.0.